### PR TITLE
[base API] Move ArchitectureImplementation into TTDeviceModel

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -55,8 +55,7 @@ public:
     EthTrainingStatus read_eth_core_training_status(CoreCoord eth_core) override;
 
 protected:
-    BlackholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    explicit BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
     virtual bool is_arc_available_over_axi();
 

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -90,7 +90,6 @@ public:
 protected:
     SimulationTTDevice(
         std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
         const std::filesystem::path& simulator_directory,
         std::unique_ptr<SimulationSysmemManager> sysmem_manager);
 
@@ -99,10 +98,7 @@ protected:
     // Client-mode constructor: the device does not own a local simulator, so it has no simulator
     // directory or sysmem manager -- those live on the remote host reached over the socket. Takes
     // the client here so client_ is initialized through the base, not written by each derived ctor.
-    SimulationTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
-        std::unique_ptr<SimulationClient> client);
+    SimulationTTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<SimulationClient> client);
 
     // Attach to / detach from the remote host in client mode. Both derived devices drive their
     // client-mode lifecycle (setup_/teardown_) through these rather than touching client_ directly.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -530,13 +530,9 @@ protected:
     LockManager lock_manager;
 
     // Every TTDevice is built around a model, which supplies its identity, the protocol it talks to
-    // hardware over and -- as components are decoupled from TTDevice -- the components it runs on.
-    // The transport no longer reaches TTDevice at all; the model owns it.
+    // hardware over, its SoC architecture descriptor and -- as components are decoupled from
+    // TTDevice -- the components it runs on.
     TTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl);
-    TTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     virtual void retrain_dram_core(const uint32_t dram_channel) = 0;
 
@@ -575,14 +571,11 @@ protected:
 private:
     void log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms);
 
-    void assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-
     xy_pair resolve_coordinate(CoreCoord core, NocId noc_id) const;
 
     DmaInterface *get_dma_interface();
 
     std::unique_ptr<TTDeviceModel> model_;
-    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_ = nullptr;
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     std::unique_ptr<FirmwareTelemetryReader> telemetry = nullptr;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -526,13 +526,12 @@ public:
     const SocDescriptor &get_soc_descriptor() const;
 
 protected:
-    std::unique_ptr<ArchitectureImplementation> architecture_impl_;
     LockManager lock_manager;
 
-    // Every TTDevice is built around a model, which supplies its identity, the protocol it talks to
-    // hardware over, its SoC architecture descriptor and -- as components are decoupled from
-    // TTDevice -- the components it runs on.
-    TTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl);
+    // Every TTDevice is built around a model, which supplies its identity and the components it
+    // runs on: the protocol it talks to hardware over, its architecture implementation and its SoC
+    // architecture descriptor.
+    explicit TTDevice(std::unique_ptr<TTDeviceModel> model);
 
     virtual void retrain_dram_core(const uint32_t dram_channel) = 0;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -54,8 +54,7 @@ public:
     ~WormholeTTDevice() override = default;
 
 protected:
-    WormholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    explicit WormholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -29,6 +29,8 @@ public:
         uint8_t jlink_id,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
+    ~BlackholeTTDeviceModel() override;
+
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -10,6 +10,7 @@
 
 namespace tt::umd {
 
+class ArchitectureImplementation;
 class JtagDevice;
 class SocArchDescriptor;
 class RemoteCommunication;
@@ -34,6 +35,8 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    ArchitectureImplementation *get_architecture_impl() override;
+
     SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
@@ -51,6 +54,7 @@ public:
 private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
+    std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class JtagDevice;
+class SocArchDescriptor;
 class RemoteCommunication;
 
 // Model for a Blackhole device, over any transport that reaches one. Each constructor builds the
@@ -18,14 +19,22 @@ class RemoteCommunication;
 // protocol provides -- the rest stay null.
 class BlackholeTTDeviceModel : public TTDeviceModel {
 public:
-    BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
-    BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
+    BlackholeTTDeviceModel(
+        std::unique_ptr<PCIDevice> pci_device,
+        bool use_safe_api,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    BlackholeTTDeviceModel(
+        std::unique_ptr<JtagDevice> jtag_device,
+        uint8_t jlink_id,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
 
@@ -35,10 +44,13 @@ public:
 
     RemoteInterface *get_remote_interface() override;
 
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
     PCIDevice *get_pci_device() override;
 
 private:
     int communication_device_id_;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
@@ -23,12 +25,15 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    ArchitectureImplementation *get_architecture_impl() override;
+
     SocArchDescriptor *get_soc_arch_descriptor() override;
 
     std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
 
 private:
     tt::ARCH arch_;
+    std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -19,6 +19,8 @@ class SimulationTTDeviceModel : public TTDeviceModel {
 public:
     explicit SimulationTTDeviceModel(tt::ARCH arch);
 
+    ~SimulationTTDeviceModel() override;
+
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -23,6 +23,10 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    SocArchDescriptor *get_soc_arch_descriptor() override;
+
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
 private:
     tt::ARCH arch_;
 };

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -11,6 +11,7 @@
 
 namespace tt::umd {
 
+class ArchitectureImplementation;
 class DmaInterface;
 class FirmwareTelemetryReader;
 class HangDetector;
@@ -53,6 +54,8 @@ public:
 
     // Required components.
     virtual DeviceProtocol *get_device_protocol() = 0;
+
+    virtual ArchitectureImplementation *get_architecture_impl() = 0;
 
     // The model resolves this from what the caller supplied, or from its architecture's constants.
     virtual SocArchDescriptor *get_soc_arch_descriptor() = 0;

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/arch.hpp"
 
@@ -16,6 +18,7 @@ class JtagInterface;
 class PCIDevice;
 class PcieInterface;
 class RemoteInterface;
+class SocArchDescriptor;
 
 /**
  * Composition root for a single device's hardware-facing components.
@@ -51,6 +54,9 @@ public:
     // Required components.
     virtual DeviceProtocol *get_device_protocol() = 0;
 
+    // The model resolves this from what the caller supplied, or from its architecture's constants.
+    virtual SocArchDescriptor *get_soc_arch_descriptor() = 0;
+
     // Optional components.
     virtual HangDetector *get_hang_detector() { return nullptr; }
 
@@ -64,6 +70,11 @@ public:
     virtual JtagInterface *get_jtag_interface() { return nullptr; }
 
     virtual RemoteInterface *get_remote_interface() { return nullptr; }
+
+    // TODO: temporary - SocDescriptor shares ownership of the architecture descriptor, so TTDevice
+    // needs the shared_ptr rather than the raw pointer the Base API exposes above. Delete once
+    // SocDescriptor's ownership model is revisited.
+    virtual std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() = 0;
 
     // TODO: temporary - delete along with TTDevice::get_pci_device() once callers go through
     // PcieInterface only.

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -32,6 +32,8 @@ public:
         std::unique_ptr<RemoteCommunication> remote_communication,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
+    ~WormholeTTDeviceModel() override;
+
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -10,6 +10,7 @@
 
 namespace tt::umd {
 
+class ArchitectureImplementation;
 class JtagDevice;
 class SocArchDescriptor;
 class RemoteCommunication;
@@ -37,6 +38,8 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    ArchitectureImplementation *get_architecture_impl() override;
+
     SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
@@ -54,6 +57,7 @@ public:
 private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
+    std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class JtagDevice;
+class SocArchDescriptor;
 class RemoteCommunication;
 
 // Model for a Wormhole device, over any transport that reaches one. Each constructor builds the
@@ -18,15 +19,25 @@ class RemoteCommunication;
 // protocol provides -- the rest stay null.
 class WormholeTTDeviceModel : public TTDeviceModel {
 public:
-    WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
-    WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
-    explicit WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication);
+    WormholeTTDeviceModel(
+        std::unique_ptr<PCIDevice> pci_device,
+        bool use_safe_api,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    WormholeTTDeviceModel(
+        std::unique_ptr<JtagDevice> jtag_device,
+        uint8_t jlink_id,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    WormholeTTDeviceModel(
+        std::unique_ptr<RemoteCommunication> remote_communication,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
 
@@ -36,10 +47,13 @@ public:
 
     RemoteInterface *get_remote_interface() override;
 
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
     PCIDevice *get_pci_device() override;
 
 private:
     int communication_device_id_;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -41,9 +41,8 @@
 
 namespace tt::umd {
 
-BlackholeTTDevice::BlackholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
+BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
+    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>()) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -41,8 +41,7 @@
 
 namespace tt::umd {
 
-BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
-    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>()) {
+BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -93,7 +93,6 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     int num_host_mem_channels) :
     SimulationTTDevice(
         std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
-        ArchitectureImplementation::create(soc_descriptor.arch),
         simulator_directory,
         std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)),
     communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)) {
@@ -108,10 +107,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
 RtlSimulationTTDevice::RtlSimulationTTDevice(
     const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
-    SimulationTTDevice(
-        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
-        ArchitectureImplementation::create(soc_descriptor.arch),
-        std::move(client)) {
+    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch), std::move(client)) {
     set_soc_descriptor(soc_descriptor);
 
     // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -32,18 +32,12 @@ namespace tt::umd {
 // public header only forward-declares SimulationServerSocket.
 SimulationTTDevice::SimulationTTDevice(
     std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
     const std::filesystem::path& simulator_directory,
     std::unique_ptr<SimulationSysmemManager> sysmem_manager) :
-    TTDevice(std::move(model), std::move(architecture_impl)),
-    simulator_directory_(simulator_directory),
-    sysmem_manager_(std::move(sysmem_manager)) {}
+    TTDevice(std::move(model)), simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {}
 
-SimulationTTDevice::SimulationTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    std::unique_ptr<SimulationClient> client) :
-    TTDevice(std::move(model), std::move(architecture_impl)), client_(std::move(client)) {}
+SimulationTTDevice::SimulationTTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<SimulationClient> client) :
+    TTDevice(std::move(model)), client_(std::move(client)) {}
 
 SimulationTTDevice::~SimulationTTDevice() = default;
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -69,35 +69,12 @@ constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
 
 TTDevice::TTDevice(
     std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl) :
-    architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {}
-
-TTDevice::TTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
-    assign_soc_arch_descriptor(soc_arch_descriptor);
-
     if (model_->get_pcie_interface() != nullptr) {
         // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
         lock_manager.initialize_mutex(
             MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
     }
-}
-
-void TTDevice::assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        soc_arch_descriptor_ = std::make_shared<SocArchDescriptor>(architecture_impl_->get_architecture());
-        return;
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == get_arch(),
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(get_arch())));
-    soc_arch_descriptor_ = soc_arch_descriptor;
 }
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
@@ -121,7 +98,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         get_arc_core(NocId::NOC0),
         get_arc_core(NocId::NOC1),
         get_firmware_telemetry_reader());
-    construct_soc_descriptor(soc_arch_descriptor_);
+    construct_soc_descriptor(model_->get_shared_soc_arch_descriptor());
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
@@ -140,13 +117,12 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         arch = jtag_device->get_jtag_arch(device_number);
         switch (arch) {
             case ARCH::WORMHOLE_B0:
-                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                    std::make_unique<WormholeTTDeviceModel>(std::move(jtag_device), device_number),
-                    soc_arch_descriptor));
+                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
+                    std::move(jtag_device), device_number, soc_arch_descriptor)));
             case ARCH::BLACKHOLE:
-                return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                    std::make_unique<BlackholeTTDeviceModel>(std::move(jtag_device), device_number),
-                    soc_arch_descriptor));
+                return std::unique_ptr<BlackholeTTDevice>(
+                    new BlackholeTTDevice(std::make_unique<BlackholeTTDeviceModel>(
+                        std::move(jtag_device), device_number, soc_arch_descriptor)));
             default:
                 UMD_THROW(
                     error::RuntimeError,
@@ -160,10 +136,10 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     switch (arch) {
         case ARCH::WORMHOLE_B0:
             return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
+                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
         case ARCH::BLACKHOLE:
             return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
+                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -180,7 +156,7 @@ std::unique_ptr<TTDevice> TTDevice::create(
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)), soc_arch_descriptor));
+                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication), soc_arch_descriptor)));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -203,9 +179,9 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
             arch_to_str(arch)));
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            auto device = std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)),
-                /*soc_arch_descriptor=*/nullptr));
+            auto device =
+                std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
+                    std::move(remote_communication), /*soc_arch_descriptor=*/nullptr)));
             // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
             // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
             device->set_soc_descriptor(soc_descriptor);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -67,9 +67,7 @@ constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
     SiliconTlbWindow::set_sigbus_safe_handler(set_safe_handler);
 }
 
-TTDevice::TTDevice(
-    std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl) :
-    architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
+TTDevice::TTDevice(std::unique_ptr<TTDeviceModel> model) : model_(std::move(model)) {
     if (model_->get_pcie_interface() != nullptr) {
         // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
         lock_manager.initialize_mutex(
@@ -195,7 +193,7 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
 }
 #endif  // TT_UMD_BUILD_SIMULATION
 
-ArchitectureImplementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
+ArchitectureImplementation *TTDevice::get_architecture_implementation() { return model_->get_architecture_impl(); }
 
 // The nullptr check for capabilities in the APIs get_pci_device and get_remote_communication
 // exists for backward compatibility — these APIs are expected to return nullptr when a capability is unavailable.
@@ -457,20 +455,20 @@ void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t regi
 
 void TTDevice::wait_dram_channel_training(const uint32_t dram_channel, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
-    if (dram_channel >= architecture_impl_->get_dram_banks_number()) {
+    if (dram_channel >= get_architecture_implementation()->get_dram_banks_number()) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(
                 "Invalid DRAM channel index {}, maximum index for given architecture is {}.",
                 dram_channel,
-                architecture_impl_->get_dram_banks_number() - 1));
+                get_architecture_implementation()->get_dram_banks_number() - 1));
     }
     const uint32_t MAX_DRAM_RETRAIN_ATTEMPTS = get_max_dram_retrain_attempts();
     uint32_t num_retrain_dram_core = MAX_DRAM_RETRAIN_ATTEMPTS;
     auto start = std::chrono::steady_clock::now();
     while (true) {
-        std::vector<DramTrainingStatus> dram_training_status =
-            get_firmware_info_provider()->get_dram_training_status(architecture_impl_->get_dram_banks_number());
+        std::vector<DramTrainingStatus> dram_training_status = get_firmware_info_provider()->get_dram_training_status(
+            get_architecture_implementation()->get_dram_banks_number());
 
         if (dram_training_status.empty()) {
             log_warning(LogUMD, "DRAM training status is not available, breaking the wait for DRAM training.");
@@ -569,11 +567,15 @@ uint64_t TTDevice::get_refclk_counter() {
     uint32_t high1_addr = 0;
     uint32_t high2_addr = 0;
     uint32_t low_addr = 0;
-    read_from_arc_apb(&high1_addr, architecture_impl_->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
-    read_from_arc_apb(&low_addr, architecture_impl_->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
-    read_from_arc_apb(&high1_addr, architecture_impl_->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
+    read_from_arc_apb(
+        &high1_addr, get_architecture_implementation()->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
+    read_from_arc_apb(
+        &low_addr, get_architecture_implementation()->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
+    read_from_arc_apb(
+        &high1_addr, get_architecture_implementation()->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
     if (high2_addr > high1_addr) {
-        read_from_arc_apb(&low_addr, architecture_impl_->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
+        read_from_arc_apb(
+            &low_addr, get_architecture_implementation()->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
     }
     return (static_cast<uint64_t>(high2_addr) << 32) | low_addr;
 }
@@ -608,29 +610,31 @@ void TTDevice::advance_device_execution() {
 
 uint32_t TTDevice::get_risc_reset_state(CoreCoord core) {
     uint32_t tensix_risc_state;
-    read_from_device_reg(&tensix_risc_state, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
+    read_from_device_reg(
+        &tensix_risc_state, core, get_architecture_implementation()->get_tensix_soft_reset_addr(), sizeof(uint32_t));
 
     return tensix_risc_state;
 }
 
 void TTDevice::set_risc_reset_state(CoreCoord core, const uint32_t risc_flags) {
-    write_to_device_reg(&risc_flags, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
+    write_to_device_reg(
+        &risc_flags, core, get_architecture_implementation()->get_tensix_soft_reset_addr(), sizeof(uint32_t));
     tt_driver_atomics::sfence();
 }
 
 void TTDevice::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
     uint32_t soft_reset_current_state = get_risc_reset_state(core);
-    uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
+    uint32_t soft_reset_update = get_architecture_implementation()->get_soft_reset_reg_value(selected_riscs);
     uint32_t soft_reset_new = soft_reset_current_state | soft_reset_update;
     set_risc_reset_state(core, soft_reset_new);
 }
 
 void TTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
     uint32_t soft_reset_current_state = get_risc_reset_state(core);
-    uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
+    uint32_t soft_reset_update = get_architecture_implementation()->get_soft_reset_reg_value(selected_riscs);
     uint32_t soft_reset_new = soft_reset_current_state & ~soft_reset_update;
     uint32_t soft_reset_new_with_staggered_start =
-        soft_reset_new | (staggered_start ? architecture_impl_->get_soft_reset_staggered_start() : 0);
+        soft_reset_new | (staggered_start ? get_architecture_implementation()->get_soft_reset_staggered_start() : 0);
     set_risc_reset_state(core, soft_reset_new_with_staggered_start);
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -101,7 +101,6 @@ TTSimTTDevice::TTSimTTDevice(
     // own host window by address (see configure_iatu_region / SimulationSysmemManager).
     SimulationTTDevice(
         std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
-        ArchitectureImplementation::create(soc_descriptor.arch),
         simulator_directory,
         std::make_unique<SimulationSysmemManager>(
             num_host_mem_channels, soc_descriptor.arch, static_cast<uint32_t>(chip_id))),
@@ -184,10 +183,7 @@ void TTSimTTDevice::initialize_backend() {
 
 TTSimTTDevice::TTSimTTDevice(
     const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
-    SimulationTTDevice(
-        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
-        ArchitectureImplementation::create(soc_descriptor.arch),
-        std::move(client)),
+    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch), std::move(client)),
     chip_id_(chip_id) {
     set_soc_descriptor(soc_descriptor);
 
@@ -294,8 +290,8 @@ bool TTSimTTDevice::special_dram_read(void* mem_ptr, tt_xy_pair core, uint64_t a
 void TTSimTTDevice::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}", selected_riscs);
-    uint64_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
-    uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
+    uint64_t soft_reset_addr = get_architecture_implementation()->get_tensix_soft_reset_addr();
+    uint32_t soft_reset_update = get_architecture_implementation()->get_soft_reset_reg_value(selected_riscs);
     if (libttsim_pci_device_id == 0xFEED) {  // QSR
         uint64_t reset_value;
         read_from_device(&reset_value, core, soft_reset_addr, sizeof(reset_value));
@@ -313,8 +309,8 @@ void TTSimTTDevice::assert_risc_reset(CoreCoord core, const RiscType selected_ri
 void TTSimTTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
-    uint64_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
-    uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
+    uint64_t soft_reset_addr = get_architecture_implementation()->get_tensix_soft_reset_addr();
+    uint32_t soft_reset_update = get_architecture_implementation()->get_soft_reset_reg_value(selected_riscs);
 
     if (libttsim_pci_device_id == 0xFEED) {  // QSR
         uint64_t reset_value;

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -40,9 +40,8 @@
 
 namespace tt::umd {
 
-WormholeTTDevice::WormholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(model), std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
+WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
+    TTDevice(std::move(model), std::make_unique<WormholeImplementation>()) {
     WormholeTTDevice::set_arc_coordinate();
     // A remote device has no protocol of its own to probe; its liveness is that of the local device
     // it is reached through.

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -40,8 +40,7 @@
 
 namespace tt::umd {
 
-WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
-    TTDevice(std::move(model), std::make_unique<WormholeImplementation>()) {
+WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
     WormholeTTDevice::set_arc_coordinate();
     // A remote device has no protocol of its own to probe; its liveness is that of the local device
     // it is reached through.

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "tt_device_model/soc_arch_descriptor_resolver.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
@@ -21,6 +22,7 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
+    architecture_impl_(std::make_unique<BlackholeImplementation>()),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -36,7 +38,8 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
+    architecture_impl_(std::make_unique<BlackholeImplementation>()) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -49,6 +52,8 @@ int BlackholeTTDeviceModel::get_communication_device_id() const { return communi
 DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
 
 SocArchDescriptor *BlackholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+ArchitectureImplementation *BlackholeTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }
 
 std::shared_ptr<SocArchDescriptor> BlackholeTTDeviceModel::get_shared_soc_arch_descriptor() {
     return soc_arch_descriptor_;

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -4,48 +4,23 @@
 
 #include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
 
-#include <fmt/format.h>
-
 #include <utility>
 
+#include "tt_device_model/soc_arch_descriptor_resolver.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
-#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace {
-
-// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
-// Named per architecture on purpose: a unity build folds the model sources into one translation
-// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
-std::shared_ptr<SocArchDescriptor> resolve_blackhole_soc_arch_descriptor(
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        return std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE);
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == tt::ARCH::BLACKHOLE,
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(tt::ARCH::BLACKHOLE)));
-    return soc_arch_descriptor;
-}
-
-}  // namespace
 
 BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
-    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)),
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -61,7 +36,7 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -4,18 +4,49 @@
 
 #include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+namespace {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
+// Named per architecture on purpose: a unity build folds the model sources into one translation
+// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
+std::shared_ptr<SocArchDescriptor> resolve_blackhole_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == tt::ARCH::BLACKHOLE,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(tt::ARCH::BLACKHOLE)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace
+
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(
+    std::unique_ptr<PCIDevice> pci_device,
+    bool use_safe_api,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(pci_device->get_device_num()),
+    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)),
+    pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
@@ -25,8 +56,12 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_de
     }
 }
 
-BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
-    communication_device_id_(jlink_id) {
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(
+    std::unique_ptr<JtagDevice> jtag_device,
+    uint8_t jlink_id,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(jlink_id),
+    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -37,6 +72,12 @@ tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; 
 int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+SocArchDescriptor *BlackholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+std::shared_ptr<SocArchDescriptor> BlackholeTTDeviceModel::get_shared_soc_arch_descriptor() {
+    return soc_arch_descriptor_;
+}
 
 PcieInterface *BlackholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -45,6 +45,10 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     protocol_ = std::move(jtag_protocol);
 }
 
+// Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
+// complete type where the destructor is instantiated.
+BlackholeTTDeviceModel::~BlackholeTTDeviceModel() = default;
+
 tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; }
 
 int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -11,6 +11,10 @@ namespace tt::umd {
 SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
     arch_(arch), architecture_impl_(ArchitectureImplementation::create(arch)) {}
 
+// Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
+// complete type where the destructor is instantiated.
+SimulationTTDeviceModel::~SimulationTTDeviceModel() = default;
+
 tt::ARCH SimulationTTDeviceModel::get_arch() const { return arch_; }
 
 // A simulation backend has no host transport to be addressed within, so it reports no communication

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -4,9 +4,12 @@
 
 #include "umd/device/tt_device_model/simulation_tt_device_model.hpp"
 
+#include "umd/device/arch/architecture_implementation.hpp"
+
 namespace tt::umd {
 
-SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) : arch_(arch) {}
+SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
+    arch_(arch), architecture_impl_(ArchitectureImplementation::create(arch)) {}
 
 tt::ARCH SimulationTTDeviceModel::get_arch() const { return arch_; }
 
@@ -17,6 +20,8 @@ int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 // A simulation backend reaches its device directly rather than over a transport protocol; the
 // simulation TTDevice overrides the read/write paths instead of routing them through one.
 DeviceProtocol *SimulationTTDeviceModel::get_device_protocol() { return nullptr; }
+
+ArchitectureImplementation *SimulationTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }
 
 // A simulation backend supplies a full SocDescriptor of its own rather than an architecture
 // descriptor for TTDevice to build one from.

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -18,4 +18,10 @@ int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 // simulation TTDevice overrides the read/write paths instead of routing them through one.
 DeviceProtocol *SimulationTTDeviceModel::get_device_protocol() { return nullptr; }
 
+// A simulation backend supplies a full SocDescriptor of its own rather than an architecture
+// descriptor for TTDevice to build one from.
+SocArchDescriptor *SimulationTTDeviceModel::get_soc_arch_descriptor() { return nullptr; }
+
+std::shared_ptr<SocArchDescriptor> SimulationTTDeviceModel::get_shared_soc_arch_descriptor() { return nullptr; }
+
 }  // namespace tt::umd

--- a/device/tt_device_model/soc_arch_descriptor_resolver.hpp
+++ b/device/tt_device_model/soc_arch_descriptor_resolver.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <memory>
+
+#include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants. The
+// architecture is a template parameter so each model states its own, and a supplied descriptor is
+// checked against it.
+template <tt::ARCH arch>
+std::shared_ptr<SocArchDescriptor> resolve_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(arch);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == arch,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(arch)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace tt::umd

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -4,21 +4,52 @@
 
 #include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+namespace {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
+// Named per architecture on purpose: a unity build folds the model sources into one translation
+// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
+std::shared_ptr<SocArchDescriptor> resolve_wormhole_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == tt::ARCH::WORMHOLE_B0,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(tt::ARCH::WORMHOLE_B0)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace
+
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<PCIDevice> pci_device,
+    bool use_safe_api,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(pci_device->get_device_num()),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)),
+    pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
@@ -28,16 +59,23 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_devi
     }
 }
 
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
-    communication_device_id_(jlink_id) {
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<JtagDevice> jtag_device,
+    uint8_t jlink_id,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(jlink_id),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
 }
 
 // A remote device is reached through a local one, so it takes the local device's identity.
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication) :
-    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()) {
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<RemoteCommunication> remote_communication,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);
@@ -48,6 +86,12 @@ tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0;
 int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+SocArchDescriptor *WormholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+std::shared_ptr<SocArchDescriptor> WormholeTTDeviceModel::get_shared_soc_arch_descriptor() {
+    return soc_arch_descriptor_;
+}
 
 PcieInterface *WormholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "tt_device_model/soc_arch_descriptor_resolver.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
@@ -24,6 +25,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
+    architecture_impl_(std::make_unique<WormholeImplementation>()),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -39,7 +41,8 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
+    architecture_impl_(std::make_unique<WormholeImplementation>()) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -50,7 +53,8 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<RemoteCommunication> remote_communication,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
-    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
+    architecture_impl_(std::make_unique<WormholeImplementation>()) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);
@@ -63,6 +67,8 @@ int WormholeTTDeviceModel::get_communication_device_id() const { return communic
 DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
 
 SocArchDescriptor *WormholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+ArchitectureImplementation *WormholeTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }
 
 std::shared_ptr<SocArchDescriptor> WormholeTTDeviceModel::get_shared_soc_arch_descriptor() {
     return soc_arch_descriptor_;

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -4,51 +4,26 @@
 
 #include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 
-#include <fmt/format.h>
-
 #include <utility>
 
+#include "tt_device_model/soc_arch_descriptor_resolver.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
-#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace {
-
-// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
-// Named per architecture on purpose: a unity build folds the model sources into one translation
-// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
-std::shared_ptr<SocArchDescriptor> resolve_wormhole_soc_arch_descriptor(
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        return std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0);
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == tt::ARCH::WORMHOLE_B0,
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(tt::ARCH::WORMHOLE_B0)));
-    return soc_arch_descriptor;
-}
-
-}  // namespace
 
 WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)),
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -64,7 +39,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -75,7 +50,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<RemoteCommunication> remote_communication,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -60,6 +60,10 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     protocol_ = std::move(remote_protocol);
 }
 
+// Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
+// complete type where the destructor is instantiated.
+WormholeTTDeviceModel::~WormholeTTDeviceModel() = default;
+
 tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0; }
 
 int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }


### PR DESCRIPTION
### Issue
#2864

### Description
Each model now creates the architecture implementation for the architecture it
reports: the silicon models construct theirs directly, and simulation goes
through `ArchitectureImplementation::create()` since its architecture comes from
the SoC descriptor rather than a probed device. `TTDevice` reads it from the
model instead of owning it, and its own accessor just delegates.

This leaves `TTDevice` taking nothing but a model -- the signature the Base API
specifies -- and lets the simulation devices stop threading an architecture
implementation through their constructors.

### List of the changes
- `TTDeviceModel` declares `get_architecture_impl()` as a required component;
each concrete model owns and creates its own.
- Drop `TTDevice::architecture_impl_`; `get_architecture_implementation()` and its
in-class uses go through the model.
- `TTDevice`, `WormholeTTDevice` and `BlackholeTTDevice` constructors take only a
model; `SimulationTTDevice` drops the parameter it was forwarding.

### Testing
CI

### API Changes
This PR has API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/tt_device_model_hang_detector
