### PR TITLE
Give SysmemBuffer ownership of its memory via a Deleter

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 
 #include "umd/device/types/host_memory.hpp"
@@ -31,6 +32,15 @@ class TTDevice;
 class SysmemBuffer {
 public:
     /**
+     * Cleanup callable invoked on destruction, receiving the page-aligned start of the buffer.
+     *
+     * It encodes the difference between the two ownership models: for a buffer the allocator itself
+     * allocated, it unpins the pages and frees the backing memory; for a buffer mapped from a caller's
+     * pointer, it only unpins, leaving the memory to its owner.
+     */
+    using Deleter = std::function<void(void*)>;
+
+    /**
      * Constructor for SysmemBuffer. Start of the buffer must be aligned
      * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
      * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
@@ -51,18 +61,24 @@ public:
      * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
      * @param buffer_size Size of the buffer requested by the user.
      * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
+     * @param release_backing_memory Optional callable that frees the pages behind buffer_va, invoked after
+     * the buffer has been unpinned from the device. Pass it when the allocator owns the memory it is handing
+     * over; leave it empty when the caller owns the memory and only wants it unpinned on destruction.
      */
     SysmemBuffer(
         TTDevice* tt_device,
         void* buffer_va,
         size_t buffer_size,
         bool map_to_noc = false,
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
+        Deleter release_backing_memory = {});
     /**
      * Constructor for a buffer that was already made visible to the device by the caller.
      *
      * @param communication_id Identifier of the device this buffer's IOVA is valid for. Supplied by the
      * allocator, which pins for exactly one device. Matches TTDevice::get_communication_device_id().
+     * @param deleter Cleanup callable invoked on destruction with the page-aligned start of the buffer.
+     * Defaults to releasing nothing, since this constructor takes a mapping the caller already owns.
      */
     SysmemBuffer(
         void* buffer_va,
@@ -70,7 +86,7 @@ public:
         uint64_t device_io_addr,
         int communication_id,
         std::optional<uint64_t> noc_addr = std::nullopt,
-        std::function<void()> unmap_callback = {},
+        Deleter deleter = {},
         DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
     ~SysmemBuffer();
 
@@ -190,7 +206,10 @@ private:
     // the PCIE core that is connected to the host and this address.
     std::optional<uint64_t> noc_addr_;
 
-    std::function<void()> unmap_callback_;
+    // Owns the buffer's page-aligned start. Releasing it runs the deleter composed at construction,
+    // which unpins the pages from the device and, for buffers this class allocated, frees them.
+    std::unique_ptr<void, Deleter> system_memory_ptr_;
+
     DeviceBufferAccess device_access_ = DeviceBufferAccess::READ_WRITE;
 
     // Device this buffer's IOVA is valid for. -1 when unknown.

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -447,7 +447,25 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
             error::RuntimeError,
             fmt::format("Failed to allocate sysmem buffer of size {:#x} bytes with mmap.", sysmem_buffer_size));
     }
-    return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
+    // This mapping belongs to the buffer, so hand it a deleter that frees it. mmap returns a page-aligned
+    // address, so the pointer the deleter receives is the one to munmap.
+    const size_t mapping_size = sysmem_buffer_size;
+    return std::make_unique<SysmemBuffer>(
+        tt_device_,
+        mapping,
+        sysmem_buffer_size,
+        map_to_noc,
+        DeviceBufferAccess::READ_WRITE,
+        [mapping_size](void *aligned_va) {
+            if (munmap(aligned_va, mapping_size) != 0) {
+                log_warning(
+                    LogUMD,
+                    "Failed to munmap sysmem buffer of size {:#x} at {:p}: {}.",
+                    mapping_size,
+                    aligned_va,
+                    strerror(errno));
+            }
+        });
 }
 
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -189,7 +189,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
         device_io_addr,
         communication_id_,
         noc_addr,
-        [weak_reg, device_io_addr]() {
+        [weak_reg, device_io_addr](void*) {
             if (auto reg = weak_reg.lock()) {
                 std::lock_guard<std::mutex> lock(reg->mutex);
                 reg->buffers.erase(

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -23,8 +23,26 @@
 
 namespace tt::umd {
 
+namespace {
+
+// A unique_ptr with a std::function deleter throws bad_function_call if the function is empty and the
+// pointer is non-null, so every buffer gets a callable deleter even when there is nothing to release.
+SysmemBuffer::Deleter or_no_op(SysmemBuffer::Deleter deleter) {
+    if (deleter) {
+        return deleter;
+    }
+    return [](void*) {};
+}
+
+}  // namespace
+
 SysmemBuffer::SysmemBuffer(
-    TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc, DeviceBufferAccess device_access) :
+    TTDevice* tt_device,
+    void* buffer_va,
+    size_t buffer_size,
+    bool map_to_noc,
+    DeviceBufferAccess device_access,
+    Deleter release_backing_memory) :
     pci_device_(tt_device->get_pci_device()),
     tt_device_(tt_device),
     buffer_va_(buffer_va),
@@ -41,6 +59,23 @@ SysmemBuffer::SysmemBuffer(
         device_io_addr_ = pci_device_->map_for_dma(buffer_va_, mapped_buffer_size_, device_access_);
         noc_addr_ = std::nullopt;
     }
+    // Compose the full deleter now that the buffer is aligned and pinned: always unpin, then release the
+    // backing memory if this buffer owns it.
+    system_memory_ptr_ = std::unique_ptr<void, Deleter>(
+        buffer_va_,
+        [pci_device = pci_device_,
+         mapped_size = mapped_buffer_size_,
+         iova = device_io_addr_,
+         release = std::move(release_backing_memory)](void* aligned_va) {
+            try {
+                pci_device->unmap_for_dma(aligned_va, mapped_size);
+            } catch (...) {
+                log_warning(LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_size, iova);
+            }
+            if (release) {
+                release(aligned_va);
+            }
+        });
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
 }
 
@@ -50,7 +85,7 @@ SysmemBuffer::SysmemBuffer(
     uint64_t device_io_addr,
     int communication_id,
     std::optional<uint64_t> noc_addr,
-    std::function<void()> unmap_callback,
+    Deleter deleter,
     DeviceBufferAccess device_access) :
     pci_device_(nullptr),
     tt_device_(nullptr),
@@ -59,10 +94,10 @@ SysmemBuffer::SysmemBuffer(
     buffer_size_(buffer_size),
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
-    unmap_callback_(std::move(unmap_callback)),
     device_access_(device_access),
     communication_id_(communication_id) {
     align_address_and_size();
+    system_memory_ptr_ = std::unique_ptr<void, Deleter>(buffer_va_, or_no_op(std::move(deleter)));
     // Pair with TracyFreeN in the destructor so Tracy sees balanced alloc/free.
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
 }
@@ -99,19 +134,8 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 
 SysmemBuffer::~SysmemBuffer() {
     TracyFreeN(buffer_va_, "SysmemBuffer");
-    if (unmap_callback_) {
-        unmap_callback_();
-        return;
-    }
-    if (pci_device_ == nullptr) {
-        return;
-    }
-    try {
-        pci_device_->unmap_for_dma(buffer_va_, mapped_buffer_size_);
-    } catch (...) {
-        log_warning(
-            LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_buffer_size_, device_io_addr_);
-    }
+    // Runs the deleter composed at construction: unpin, and free the backing memory if this buffer owns it.
+    system_memory_ptr_.reset();
 }
 
 void SysmemBuffer::align_address_and_size() {

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -100,6 +100,45 @@ TEST(ApiSimulationSysmemManager, TestFourChannels) {
     }
 }
 
+// A buffer owns its memory through a deleter composed at construction. The deleter must run exactly
+// once, and it must receive the page-aligned start of the mapping rather than the caller's VA — that
+// is the address the pages were pinned at and the one that has to be released.
+TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+
+    std::vector<uint8_t> backing(3 * page_size, 0);
+    const uintptr_t raw = reinterpret_cast<uintptr_t>(backing.data());
+    void* aligned_start = reinterpret_cast<void*>((raw + page_size - 1) & ~(page_size - 1));
+    // Deliberately offset into the page so the buffer has to align downwards.
+    void* user_va = static_cast<uint8_t*>(aligned_start) + 64;
+
+    int deleter_calls = 0;
+    void* deleter_saw = nullptr;
+    {
+        SysmemBuffer buffer(
+            user_va, 128, /*device_io_addr=*/0x1000, /*communication_id=*/7, std::nullopt, [&](void* released) {
+                ++deleter_calls;
+                deleter_saw = released;
+            });
+
+        EXPECT_EQ(buffer.get_buffer_va(), user_va);
+        EXPECT_EQ(buffer.get_buffer_size(), 128u);
+        EXPECT_EQ(deleter_calls, 0);
+    }
+
+    EXPECT_EQ(deleter_calls, 1);
+    EXPECT_EQ(deleter_saw, aligned_start);
+}
+
+// A buffer given no deleter must still destruct cleanly. unique_ptr with an empty std::function
+// deleter would otherwise throw bad_function_call.
+TEST(ApiSimulationSysmemManager, BufferWithoutDeleterDestructsCleanly) {
+    std::vector<uint8_t> backing(4096, 0);
+    EXPECT_NO_THROW({
+        SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x2000, /*communication_id=*/1);
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Mapped buffer tests — parametrized over ARCH (WH and BH).
 //

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <set>
@@ -225,6 +226,62 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
 
     EXPECT_EQ(sysmem_buffer->get_buffer_size(), buf_size);
     EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapped_buffer);
+}
+
+namespace {
+
+// Resident set size in KiB, or 0 if it could not be read.
+size_t read_rss_kib() {
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            return std::stoull(line.substr(line.find_first_of("0123456789")));
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+// allocate_sysmem_buffer() mmaps the backing memory, so the buffer has to free it on destruction.
+// Before the buffer owned its memory, every allocation leaked the whole mapping.
+TEST(ApiSysmemManager, AllocatedBufferFreesBackingMemory) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
+    }
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+
+    const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const size_t buf_size = 64ULL << 20;
+    const size_t buf_size_kib = buf_size >> 10;
+    const int iterations = 8;
+
+    // Warm up so one-time allocations do not land inside the measurement.
+    { std::unique_ptr<SysmemBuffer> warmup = sysmem_manager->allocate_sysmem_buffer(buf_size); }
+
+    const size_t rss_before = read_rss_kib();
+    if (rss_before == 0) {
+        GTEST_SKIP() << "Could not read VmRSS from /proc/self/status.";
+    }
+
+    for (int i = 0; i < iterations; i++) {
+        std::unique_ptr<SysmemBuffer> buffer = sysmem_manager->allocate_sysmem_buffer(buf_size);
+        ASSERT_NE(buffer, nullptr);
+        // Touch the buffer so the pages are definitely resident.
+        std::memset(buffer->get_buffer_va(), i, 4096);
+    }
+
+    const size_t rss_after = read_rss_kib();
+    const size_t growth_kib = rss_after > rss_before ? rss_after - rss_before : 0;
+
+    // Leaking would retain every iteration's mapping. Allow one buffer of slack for allocator noise.
+    EXPECT_LT(growth_kib, buf_size_kib) << "RSS grew by " << growth_kib << " KiB across " << iterations
+                                        << " allocate/destroy cycles of " << buf_size_kib << " KiB each";
 }
 
 // The manager pins for exactly one device and stamps that device's id into every buffer, so the id


### PR DESCRIPTION
### Issue
#3249

### Description
Gives `SysmemBuffer` ownership of its memory through the Base API Specification's `Deleter`, replacing the argument-less `unmap_callback_`. The deleter is composed at construction and receives the page-aligned start of the mapping, so it releases the address the pages were actually pinned at rather than the caller's VA.

This closes a leak. `SiliconSysmemManager::allocate_sysmem_buffer()` mmaps the backing memory and hands the pointer to the buffer, but the buffer only ever unpinned it — the mapping was never munmapped, so every allocated buffer leaked its full size for the life of the process. The allocate path now supplies a deleter that frees it; the map path supplies none, since that memory belongs to the caller.

Stacked on #3253.

### List of the changes
- Added `SysmemBuffer::Deleter` and replaced `unmap_callback_` with a `std::unique_ptr<void, Deleter>` owning the buffer's page-aligned start.
- Composed the deleter in the device-backed constructor as unpin, then release the backing memory if the buffer owns it; `allocate_sysmem_buffer()` now passes a releasing deleter and `map_sysmem_buffer()` does not.
- Reshaped the simulation registry-erase callback to the new deleter signature.
- Added tests that the deleter runs exactly once with the page-aligned start, that a buffer without one destructs cleanly, and that repeated allocate/destroy cycles on silicon do not grow RSS.

### API Changes
This PR has API changes.

- Added the public `SysmemBuffer::Deleter` alias.
- `SysmemBuffer`'s device-backed constructor takes a new optional trailing `release_backing_memory` parameter.
- `SysmemBuffer`'s pre-mapped constructor takes a `Deleter` where it previously took a `std::function<void()>` unmap callback.
- `SysmemBuffer` is no longer copyable, since it now owns its memory. It was already only ever handled through `std::unique_ptr`.

### Testing
CI
