### PR TITLE
Add bind_noc_address to SysmemBuffer

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -134,6 +134,17 @@ public:
 
     std::optional<uint64_t> get_noc_addr() const { return noc_addr_; }
 
+    /**
+     * Confirms this buffer is bound to a NOC address, so that every tile on the device can reach it rather
+     * than only the PCIe tile.
+     *
+     * The driver assigns the NOC address when the pages are pinned, so binding is decided at construction
+     * by the bind_to_noc argument on the allocator, not here. This is therefore a no-op on a bound buffer
+     * and throws on an unbound one, which turns a buffer that can never be reached over the NOC into an
+     * error at the point of the mistaken assumption rather than at a much later device access.
+     */
+    void bind_noc_address();
+
     DeviceBufferAccess get_device_access() const { return device_access_; }
 
     /**

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -158,6 +158,16 @@ void SysmemBuffer::read_from_sysmem(void* dest, const size_t size, const size_t 
     memcpy(dest, static_cast<const uint8_t*>(get_buffer_va()) + offset, size);
 }
 
+void SysmemBuffer::bind_noc_address() {
+    if (noc_addr_.has_value()) {
+        return;
+    }
+    UMD_THROW(
+        error::RuntimeError,
+        "This sysmem buffer has no NOC address and cannot be given one: the driver assigns it when the pages "
+        "are pinned. Allocate or map the buffer with bind_to_noc set instead.");
+}
+
 void* SysmemBuffer::get_buffer_va() const { return static_cast<uint8_t*>(buffer_va_) + offset_from_aligned_addr_; }
 
 size_t SysmemBuffer::get_buffer_size() const { return buffer_size_; }

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -131,6 +131,37 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
     EXPECT_EQ(deleter_saw, aligned_start);
 }
 
+// The driver assigns the NOC address at pin time, so bind_noc_address() only confirms what already
+// happened. On a bound buffer it is a no-op.
+TEST(ApiSimulationSysmemManager, BindNocAddressIsNoOpWhenAlreadyBound) {
+    std::vector<uint8_t> backing(4096, 0);
+
+    SysmemBuffer buffer(
+        backing.data(),
+        backing.size(),
+        /*device_io_addr=*/0x1000,
+        /*communication_id=*/2,
+        std::optional<uint64_t>(0x1234));
+
+    EXPECT_NO_THROW(buffer.bind_noc_address());
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+
+    // Idempotent.
+    EXPECT_NO_THROW(buffer.bind_noc_address());
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+}
+
+// A buffer whose pages were not pinned with NOC access can never be given a NOC address, so asking
+// must fail loudly rather than leave the caller believing the buffer is reachable over the NOC.
+TEST(ApiSimulationSysmemManager, BindNocAddressThrowsWhenUnbound) {
+    std::vector<uint8_t> backing(4096, 0);
+    SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x1000, /*communication_id=*/2);
+
+    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+    EXPECT_THROW(buffer.bind_noc_address(), std::exception);
+    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+}
+
 // A buffer given no deleter must still destruct cleanly. unique_ptr with an empty std::function
 // deleter would otherwise throw bad_function_call.
 TEST(ApiSimulationSysmemManager, BufferWithoutDeleterDestructsCleanly) {


### PR DESCRIPTION
### Issue
#3249

### Description
Adds `SysmemBuffer::bind_noc_address()` from the Base API Specification. A NOC address lets every tile on the device reach the buffer, rather than only the PCIe tile.

The spec models binding as something that can be deferred, with a binder callable that programs the translation on demand. That does not apply here: the driver assigns the NOC address when the pages are pinned, so binding is decided by the `bind_to_noc` argument at allocate or map time. UMD used to program the iATU itself on the pre-2.0 driver, which could have bound after the fact, but that path is gone — #3170 removed `init_pcie_iatus()`, #3171 removed `is_mapping_buffer_to_noc_supported()`, and `KMD_MINIMUM_VERSION` is 2.0.0.

So this is a no-op on a bound buffer and throws on an unbound one. The throw is the point: a buffer that was not pinned with NOC access can never be given a NOC address, and failing at the mistaken assumption is much easier to diagnose than the device access that would otherwise fail later.

Stacked on #3256.

### List of the changes
- Added `SysmemBuffer::bind_noc_address()`.
- Added tests that binding an already-bound buffer is a no-op and is idempotent, and that binding an unbound buffer throws.

### API Changes
This PR has API changes.

- Added `SysmemBuffer::bind_noc_address()`.

### Testing
CI
