### PR TITLE
Remove clear_mutex

### DIFF
--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -40,10 +40,9 @@ enum class MutexType {
 std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
-// underlying mutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
-// cleared automatically when the LockManager goes out of scope. We could implement these lock such that initialization
-// is not needed, and they are initialized every time they're locked, but since that communicates with the OS filesystem
-// it might be slower do to it each time. This way, locking/unlocking should be faster.
+// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these lock such that
+// initialization is not needed, and they are initialized every time they're locked, but since that communicates with
+// the OS filesystem it might be slower do to it each time. This way, locking/unlocking should be faster.
 class LockManager {
 public:
     // Mutex types that are initialized per chip (combined with device_id + device_type).
@@ -64,12 +63,10 @@ public:
 
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
     void initialize_mutex(MutexType mutex_type);
-    void clear_mutex(MutexType mutex_type);
     std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
     void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
-    void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
     std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
@@ -82,7 +79,6 @@ public:
 
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
-    void clear_mutex_internal(const std::string& mutex_name);
     std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -40,9 +40,9 @@ enum class MutexType {
 std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
-// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these lock such that
-// initialization is not needed, and they are initialized every time they're locked, but since that communicates with
-// the OS filesystem it might be slower do to it each time. This way, locking/unlocking should be faster.
+// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these locks such
+// that initialization is not needed, and they are initialized every time they're locked, but since that communicates
+// with the OS filesystem it might be slower to do it each time. This way, locking/unlocking should be faster.
 class LockManager {
 public:
     // Mutex types that are initialized per chip (combined with device_id + device_type).

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -45,13 +45,6 @@ void LockManager::initialize_mutex(MutexType mutex_type, int device_id, IODevice
     initialize_mutex_internal(mutex_name);
 }
 
-void LockManager::clear_mutex(MutexType mutex_type) { clear_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type)); }
-
-void LockManager::clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    clear_mutex_internal(mutex_name);
-}
-
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
     return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
@@ -81,15 +74,6 @@ void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
     std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
     mutex->initialize();
     mutexes.emplace(mutex_name, std::move(mutex));
-}
-
-void LockManager::clear_mutex_internal(const std::string& mutex_name) {
-    if (mutexes.find(mutex_name) == mutexes.end()) {
-        log_warning(LogUMD, "Mutex not initialized or already cleared: {}", mutex_name);
-        return;
-    }
-    // The destructor will automatically close the underlying mutex.
-    mutexes.erase(mutex_name);
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {


### PR DESCRIPTION
### Issue
#2745

### Description
A LockManager clears its mutexes when it goes out of scope, so clearing them by hand first only
matters if a lock has to go away while its manager stays alive. Nothing needs that. The single
caller was ~ArcMessenger, which cleared two mutexes out of a LockManager that was itself destroyed
a line later, and that destructor existed for nothing else.

Dropping it also takes away the one way an owner could pull a lock out from under another one,
which the next PR relies on.

### List of the changes
- Drop both clear_mutex overloads and clear_mutex_internal from LockManager
- Drop ~ArcMessenger, which only called them

### Testing
No behavior change. umd_misc_tests, plus a lock_virus run.

### API Changes
This PR has API changes, removes LockManager::clear_mutex.

Follow up, blocked until #3232 is deployed everywhere: #3233 Stop taking the shared memory half of chip specific PCIe locks

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/locks_11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
