### PR TITLE
Make SysmemBuffer constructible only by an allocator

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -40,54 +40,6 @@ public:
      */
     using Deleter = std::function<void(void*)>;
 
-    /**
-     * Constructor for SysmemBuffer. Start of the buffer must be aligned
-     * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
-     * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
-     * see a buffer of the original size. Same as for buffer size, user won't be able to access the memory before the
-     * start of the buffer, aligning is transparent to the user.
-     * Pages separated by | AB - Aligned buffer,
-     * UB - Unaligned buffer, UE - Unaligned end, AE - Aligned end
-     *
-     * |     Page 0     |     Page 1     |     Page 2     |     Page 3     |
-     * +----------------+----------------+----------------+----------------+
-     * ^                ^       ^                    ^    ^
-     * Page Start       AB      UB                   UE   AE
-     *                          |<--- buffer_size -->|
-     *                  |<----- mapped_buffer_size ----->|
-     *
-     * @param tt_device Pointer to the TTDevice. Used directly for DMA transfers, and to access the underlying
-     * PCIDevice for mapping/unmapping and TLB allocation.
-     * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
-     * @param buffer_size Size of the buffer requested by the user.
-     * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
-     * @param release_backing_memory Optional callable that frees the pages behind buffer_va, invoked after
-     * the buffer has been unpinned from the device. Pass it when the allocator owns the memory it is handing
-     * over; leave it empty when the caller owns the memory and only wants it unpinned on destruction.
-     */
-    SysmemBuffer(
-        TTDevice* tt_device,
-        void* buffer_va,
-        size_t buffer_size,
-        bool map_to_noc = false,
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
-        Deleter release_backing_memory = {});
-    /**
-     * Constructor for a buffer that was already made visible to the device by the caller.
-     *
-     * @param communication_id Identifier of the device this buffer's IOVA is valid for. Supplied by the
-     * allocator, which pins for exactly one device. Matches TTDevice::get_communication_device_id().
-     * @param deleter Cleanup callable invoked on destruction with the page-aligned start of the buffer.
-     * Defaults to releasing nothing, since this constructor takes a mapping the caller already owns.
-     */
-    SysmemBuffer(
-        void* buffer_va,
-        size_t buffer_size,
-        uint64_t device_io_addr,
-        int communication_id,
-        std::optional<uint64_t> noc_addr = std::nullopt,
-        Deleter deleter = {},
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
     ~SysmemBuffer();
 
     /**
@@ -177,6 +129,60 @@ public:
     void dma_read_from_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
 private:
+    // Buffers are created only by an allocator, which pins for exactly one device and stamps that
+    // device's id into every buffer it produces. SystemMemoryAllocator constructs through its
+    // protected create_buffer() helper.
+    friend class SystemMemoryAllocator;
+
+    /**
+     * Constructor for SysmemBuffer. Start of the buffer must be aligned
+     * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
+     * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
+     * see a buffer of the original size. Same as for buffer size, user won't be able to access the memory before the
+     * start of the buffer, aligning is transparent to the user.
+     * Pages separated by | AB - Aligned buffer,
+     * UB - Unaligned buffer, UE - Unaligned end, AE - Aligned end
+     *
+     * |     Page 0     |     Page 1     |     Page 2     |     Page 3     |
+     * +----------------+----------------+----------------+----------------+
+     * ^                ^       ^                    ^    ^
+     * Page Start       AB      UB                   UE   AE
+     *                          |<--- buffer_size -->|
+     *                  |<----- mapped_buffer_size ----->|
+     *
+     * @param tt_device Pointer to the TTDevice. Used directly for DMA transfers, and to access the underlying
+     * PCIDevice for mapping/unmapping and TLB allocation.
+     * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
+     * @param buffer_size Size of the buffer requested by the user.
+     * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
+     * @param release_backing_memory Optional callable that frees the pages behind buffer_va, invoked after
+     * the buffer has been unpinned from the device. Pass it when the allocator owns the memory it is handing
+     * over; leave it empty when the caller owns the memory and only wants it unpinned on destruction.
+     */
+    SysmemBuffer(
+        TTDevice* tt_device,
+        void* buffer_va,
+        size_t buffer_size,
+        bool map_to_noc = false,
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
+        Deleter release_backing_memory = {});
+    /**
+     * Constructor for a buffer that was already made visible to the device by the caller.
+     *
+     * @param communication_id Identifier of the device this buffer's IOVA is valid for. Supplied by the
+     * allocator, which pins for exactly one device. Matches TTDevice::get_communication_device_id().
+     * @param deleter Cleanup callable invoked on destruction with the page-aligned start of the buffer.
+     * Defaults to releasing nothing, since this constructor takes a mapping the caller already owns.
+     */
+    SysmemBuffer(
+        void* buffer_va,
+        size_t buffer_size,
+        uint64_t device_io_addr,
+        int communication_id,
+        std::optional<uint64_t> noc_addr = std::nullopt,
+        Deleter deleter = {},
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
+
     /**
      * Aligns the address and size of the buffer to the page size. If the buffer is not aligned to the page size,
      * it will be aligned and the size will be adjusted accordingly. The original buffer size will not be changed.

--- a/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
@@ -6,11 +6,12 @@
 
 #include <cstddef>
 #include <memory>
+#include <utility>
 
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/types/host_memory.hpp"
 
 namespace tt::umd {
-class SysmemBuffer;
 
 /**
  * Creates or maps device-visible host memory buffers for a single device.
@@ -65,6 +66,20 @@ public:
      * and stamps this value into every buffer it produces.
      */
     virtual int get_communication_id() const = 0;
+
+protected:
+    /**
+     * Creates a buffer. SysmemBuffer's constructors are private with this class as their only
+     * friend, so that buffers cannot be built outside an allocator — every buffer has to carry the
+     * device id and the cleanup behaviour of the allocator that pinned it.
+     *
+     * Friendship is not inherited, so derived allocators construct through this rather than calling the
+     * constructors themselves. Arguments are forwarded to the matching SysmemBuffer constructor.
+     */
+    template <typename... Args>
+    static std::unique_ptr<SysmemBuffer> create_buffer(Args&&... args) {
+        return std::unique_ptr<SysmemBuffer>(new SysmemBuffer(std::forward<Args>(args)...));
+    }
 };
 
 }  // namespace tt::umd

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -450,7 +450,7 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
     // This mapping belongs to the buffer, so hand it a deleter that frees it. mmap returns a page-aligned
     // address, so the pointer the deleter receives is the one to munmap.
     const size_t mapping_size = sysmem_buffer_size;
-    return std::make_unique<SysmemBuffer>(
+    return create_buffer(
         tt_device_,
         mapping,
         sysmem_buffer_size,
@@ -471,7 +471,7 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess device_access) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc, device_access);
+    return create_buffer(tt_device_, buffer, sysmem_buffer_size, map_to_noc, device_access);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     // Capture a weak_ptr so the unmap callback is a safe no-op if the manager
     // has already been destroyed (unpin_or_unmap_sysmem clears the registry).
     std::weak_ptr<MappedBufferRegistry> weak_reg = registry_;
-    return std::make_unique<SysmemBuffer>(
+    return create_buffer(
         buffer,
         sysmem_buffer_size,
         device_io_addr,

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -101,6 +101,26 @@ TEST(ApiSimulationSysmemManager, TestFourChannels) {
     }
 }
 
+namespace {
+
+// SysmemBuffer's constructors are private to allocators. Tests that need a hand-built buffer —
+// with a specific deleter or NOC address — go through a minimal allocator of their own rather than
+// weakening the encapsulation.
+class TestBufferFactory : public SystemMemoryAllocator {
+public:
+    std::unique_ptr<SysmemBuffer> allocate_buffer(size_t, bool) override { return nullptr; }
+
+    std::unique_ptr<SysmemBuffer> map_user_buffer(void*, size_t, bool, DeviceBufferAccess) override {
+        return nullptr;
+    }
+
+    int get_communication_id() const override { return 0; }
+
+    using SystemMemoryAllocator::create_buffer;
+};
+
+}  // namespace
+
 // A buffer owns its memory through a deleter composed at construction. The deleter must run exactly
 // once, and it must receive the page-aligned start of the mapping rather than the caller's VA — that
 // is the address the pages were pinned at and the one that has to be released.
@@ -116,14 +136,14 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
     int deleter_calls = 0;
     void* deleter_saw = nullptr;
     {
-        SysmemBuffer buffer(
+        auto buffer = TestBufferFactory::create_buffer(
             user_va, 128, /*device_io_addr=*/0x1000, /*communication_id=*/7, std::nullopt, [&](void* released) {
                 ++deleter_calls;
                 deleter_saw = released;
             });
 
-        EXPECT_EQ(buffer.get_buffer_va(), user_va);
-        EXPECT_EQ(buffer.get_buffer_size(), 128u);
+        EXPECT_EQ(buffer->get_buffer_va(), user_va);
+        EXPECT_EQ(buffer->get_buffer_size(), 128u);
         EXPECT_EQ(deleter_calls, 0);
     }
 
@@ -136,30 +156,30 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
 TEST(ApiSimulationSysmemManager, BindNocAddressIsNoOpWhenAlreadyBound) {
     std::vector<uint8_t> backing(4096, 0);
 
-    SysmemBuffer buffer(
+    auto buffer = TestBufferFactory::create_buffer(
         backing.data(),
         backing.size(),
         /*device_io_addr=*/0x1000,
         /*communication_id=*/2,
         std::optional<uint64_t>(0x1234));
 
-    EXPECT_NO_THROW(buffer.bind_noc_address());
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+    EXPECT_NO_THROW(buffer->bind_noc_address());
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0x1234u);
 
     // Idempotent.
-    EXPECT_NO_THROW(buffer.bind_noc_address());
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+    EXPECT_NO_THROW(buffer->bind_noc_address());
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0x1234u);
 }
 
 // A buffer whose pages were not pinned with NOC access can never be given a NOC address, so asking
 // must fail loudly rather than leave the caller believing the buffer is reachable over the NOC.
 TEST(ApiSimulationSysmemManager, BindNocAddressThrowsWhenUnbound) {
     std::vector<uint8_t> backing(4096, 0);
-    SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x1000, /*communication_id=*/2);
+    auto buffer = TestBufferFactory::create_buffer(backing.data(), backing.size(), /*device_io_addr=*/0x1000, 2);
 
-    EXPECT_FALSE(buffer.get_noc_addr().has_value());
-    EXPECT_THROW(buffer.bind_noc_address(), std::exception);
-    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
+    EXPECT_THROW(buffer->bind_noc_address(), std::exception);
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
 }
 
 // A buffer given no deleter must still destruct cleanly. unique_ptr with an empty std::function
@@ -167,7 +187,7 @@ TEST(ApiSimulationSysmemManager, BindNocAddressThrowsWhenUnbound) {
 TEST(ApiSimulationSysmemManager, BufferWithoutDeleterDestructsCleanly) {
     std::vector<uint8_t> backing(4096, 0);
     EXPECT_NO_THROW({
-        SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x2000, /*communication_id=*/1);
+        auto buffer = TestBufferFactory::create_buffer(backing.data(), backing.size(), /*device_io_addr=*/0x2000, 1);
     });
 }
 

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -21,6 +21,7 @@
 
 #include "common/microbenchmark_utils.hpp"
 #include "umd/device/chip/chip.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -406,7 +407,7 @@ TEST(MicrobenchmarkIOMMU, Map1GBPagesSysmemBuffers) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
-    TTDevice* tt_device = cluster->get_chip(CHIP_ID)->get_tt_device();
+    SysmemManager* sysmem_manager = cluster->get_chip(CHIP_ID)->get_sysmem_manager();
 
     std::array<void*, NUM_PAGES> mappings{};
     for (size_t page = 0; page < NUM_PAGES; page++) {
@@ -436,7 +437,7 @@ TEST(MicrobenchmarkIOMMU, Map1GBPagesSysmemBuffers) {
     for (int i = 0; i < NUM_EPOCHS; i++) {
         for (size_t page = 0; page < NUM_PAGES; page++) {
             auto now = std::chrono::high_resolution_clock::now();
-            sysmem_buffers[page] = std::make_unique<SysmemBuffer>(tt_device, mappings[page], MAPPING_SIZE, true);
+            sysmem_buffers[page] = sysmem_manager->map_user_buffer(mappings[page], MAPPING_SIZE, /*bind_to_noc=*/true);
             auto end = std::chrono::high_resolution_clock::now();
             map_result.add(end - now, 1, pc);
         }


### PR DESCRIPTION
### Issue
#3249

### Description
Makes `SysmemBuffer`'s constructors private with `SystemMemoryAllocator` as their only friend, per the Base API Specification. Buffers can now only come from an allocator, so every buffer necessarily carries the device id and the cleanup behaviour of whatever pinned it — the two things a hand-built buffer could previously get wrong.

Friendship is not inherited and `std::make_unique` is not a friend either, so `SystemMemoryAllocator` gained a protected `create_buffer()` that forwards to the constructors. Derived allocators build through it. That keeps the friend list to one entry instead of one per concrete manager.

Stacked on #3257.

### List of the changes
- Made both `SysmemBuffer` constructors private and declared `SystemMemoryAllocator` a friend.
- Added the protected `SystemMemoryAllocator::create_buffer()` forwarding helper and routed both concrete managers through it.
- Routed the IOMMU microbenchmark's buffer construction through `map_user_buffer()`, which is the path it was approximating anyway.
- Gave the tests that need a hand-built buffer a minimal test-local allocator rather than weakening the encapsulation.

### API Changes
This PR has API changes.

- `SysmemBuffer`'s constructors are now private. Buffers must be obtained from a `SystemMemoryAllocator` via `allocate_buffer()` or `map_user_buffer()`.

### Testing
CI
