### PR TITLE
[base API] Move HangDetector into TTDeviceModel

### DIFF
--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -114,7 +114,7 @@ private:
     std::unique_ptr<TlbWindow> cached_dma_tlb_window_;
 
     // Hang check consulted on an IO-op timeout; empty until a HangDetector is wired in (see
-    // TTDevice::set_hang_detector).
+    // TTDevice::wire_hang_detector).
     std::function<bool(NocId)> hang_check_;
 };
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -577,8 +577,6 @@ protected:
 
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
-    void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
-
     xy_pair arc_core_noc0;
     xy_pair arc_core_noc1;
 
@@ -594,6 +592,10 @@ protected:
 private:
     void log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms);
 
+    // Wires the model's hang detector to this device: routes a timed-out MMIO op to a NOC liveness
+    // check, and gives the detector a separately-locked window to probe through.
+    void wire_hang_detector();
+
     xy_pair resolve_coordinate(CoreCoord core, NocId noc_id) const;
 
     DmaInterface *get_dma_interface();
@@ -603,7 +605,6 @@ private:
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     std::unique_ptr<FirmwareTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
-    std::unique_ptr<HangDetector> hang_detector_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -60,7 +60,6 @@ private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
-    std::unique_ptr<HangDetector> hang_detector_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;
@@ -69,6 +68,10 @@ private:
     RemoteInterface *remote_interface_ = nullptr;
     // Owned by the PCIe protocol; retained only to serve get_pci_device().
     PCIDevice *pci_device_ = nullptr;
+
+    // Must come after pci_device_: the detector holds a TLB window wired in by TTDevice, which needs
+    // the protocol's PCIDevice alive when it is released.
+    std::unique_ptr<HangDetector> hang_detector_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class ArchitectureImplementation;
+class HangDetector;
 class JtagDevice;
 class SocArchDescriptor;
 class RemoteCommunication;
@@ -39,6 +40,8 @@ public:
 
     ArchitectureImplementation *get_architecture_impl() override;
 
+    HangDetector *get_hang_detector() override;
+
     SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
@@ -57,6 +60,7 @@ private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
+    std::unique_ptr<HangDetector> hang_detector_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class ArchitectureImplementation;
+class HangDetector;
 class JtagDevice;
 class SocArchDescriptor;
 class RemoteCommunication;
@@ -42,6 +43,8 @@ public:
 
     ArchitectureImplementation *get_architecture_impl() override;
 
+    HangDetector *get_hang_detector() override;
+
     SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
@@ -60,6 +63,7 @@ private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
+    std::unique_ptr<HangDetector> hang_detector_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -63,7 +63,6 @@ private:
     int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
-    std::unique_ptr<HangDetector> hang_detector_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;
@@ -72,6 +71,10 @@ private:
     RemoteInterface *remote_interface_ = nullptr;
     // Owned by the PCIe protocol; retained only to serve get_pci_device().
     PCIDevice *pci_device_ = nullptr;
+
+    // Must come after pci_device_: the detector holds a TLB window wired in by TTDevice, which needs
+    // the protocol's PCIDevice alive when it is released.
+    std::unique_ptr<HangDetector> hang_detector_;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -43,8 +43,6 @@ namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
     BlackholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<BlackholeHangDetector>(
-        get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));
 }
 
 BlackholeTTDevice::~BlackholeTTDevice() {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -81,10 +81,11 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     if (model_->get_pcie_interface() != nullptr) {
         is_pcie_hung();
     }
-    bool noc_hang_check_result =
-        model_->get_hang_detector()->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
-    if (noc_hang_check_result) {
-        UMD_THROW(error::NocHangError, *this, is_selected_noc1() ? NocId::NOC1 : NocId::NOC0);
+    // The hang detector is an optional component, so a model that provides none simply skips the check.
+    HangDetector *hang_detector = model_->get_hang_detector();
+    const NocId hang_check_noc = is_selected_noc1() ? NocId::NOC1 : NocId::NOC0;
+    if (hang_detector != nullptr && hang_detector->is_noc_hung(hang_check_noc).value_or(false)) {
+        UMD_THROW(error::NocHangError, *this, hang_check_noc);
     }
     probe_arc();
     wait_arc_core_start(timeout_ms);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -73,6 +73,7 @@ TTDevice::TTDevice(std::unique_ptr<TTDeviceModel> model) : model_(std::move(mode
         lock_manager.initialize_mutex(
             MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
     }
+    wire_hang_detector();
 }
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
@@ -81,7 +82,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         is_pcie_hung();
     }
     bool noc_hang_check_result =
-        hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
+        model_->get_hang_detector()->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
     if (noc_hang_check_result) {
         UMD_THROW(error::NocHangError, *this, is_selected_noc1() ? NocId::NOC1 : NocId::NOC0);
     }
@@ -327,10 +328,11 @@ RemoteInterface *TTDevice::get_remote_interface() {
 tt::ARCH TTDevice::get_arch() const { return model_->get_arch(); }
 
 bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action) {
-    if (!hang_detector_) {
+    HangDetector *hang_detector = model_->get_hang_detector();
+    if (hang_detector == nullptr) {
         UMD_THROW(error::RuntimeError, "HangDetector is not available for this device.");
     }
-    auto result = hang_detector_->is_bus_hung(data_read);
+    auto result = hang_detector->is_bus_hung(data_read);
     if (!result.has_value()) {
         log_warning(LogUMD, "Bus hang detection is not supported for this device.");
         return false;
@@ -345,10 +347,11 @@ bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action
 }
 
 bool TTDevice::is_noc_hung(NocId noc, TTDevice::HangAction action) {
-    if (!hang_detector_) {
+    HangDetector *hang_detector = model_->get_hang_detector();
+    if (hang_detector == nullptr) {
         UMD_THROW(error::RuntimeError, "HangDetector is not available for this device.");
     }
-    auto result = hang_detector_->is_noc_hung(noc);
+    auto result = hang_detector->is_noc_hung(noc);
     if (!result.has_value()) {
         log_warning(LogUMD, "NOC hang detection is not supported for this device.");
         return false;
@@ -364,8 +367,8 @@ bool TTDevice::is_noc_hung(NocId noc, TTDevice::HangAction action) {
     return false;
 }
 
-void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
-    hang_detector_ = std::move(hang_detector);
+void TTDevice::wire_hang_detector() {
+    HangDetector *hang_detector = model_->get_hang_detector();
 
     // The per-op timed MMIO path is PCIe-specific, so the hang-check wiring only applies to PCIe devices.
     if (model_->get_pcie_interface() == nullptr) {
@@ -374,7 +377,7 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
 
     // A null detector disables hang detection: clear any previously wired callback and stop before
     // dereferencing it below.
-    if (hang_detector_ == nullptr) {
+    if (hang_detector == nullptr) {
         get_pcie_interface()->set_io_timeout_callback({});
         return;
     }
@@ -387,9 +390,13 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
     // The liveness check runs from inside a timed-out memcpy that holds io_lock_, so it must read through a
     // dedicated, separately-locked window rather than the protocol's cached window. The window and lock live
     // in the lambda's capture; HangDetector only sees the std::function and stays unaware of either.
+    //
+    // get_io_window() is virtual and this runs during TTDevice's own construction, so it resolves to the
+    // base implementation. That is the right one: only a PCIe device gets this far (the guard above), and
+    // the sole override belongs to the simulation backends, which have no PCIe interface.
     auto window = std::shared_ptr<TlbWindow>(get_io_window({}, TlbMapping::UC));
     auto window_lock = std::make_shared<std::mutex>();
-    HangDetectorImplementation *hang_detector_impl = dynamic_cast<HangDetectorImplementation *>(hang_detector_.get());
+    HangDetectorImplementation *hang_detector_impl = dynamic_cast<HangDetectorImplementation *>(hang_detector);
     UMD_ASSERT(
         hang_detector_impl != nullptr,
         error::RuntimeError,

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -42,13 +42,6 @@ namespace tt::umd {
 
 WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
     WormholeTTDevice::set_arc_coordinate();
-    // A remote device has no protocol of its own to probe; its liveness is that of the local device
-    // it is reached through.
-    DeviceProtocol *hang_check_protocol =
-        is_remote()
-            ? TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol()
-            : get_device_protocol();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(hang_check_protocol));
 }
 
 bool WormholeTTDevice::get_noc_translation_enabled() {

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -11,10 +11,26 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 
 namespace tt::umd {
+
+namespace {
+
+// Whether NOC address translation is on, read from the NOC0 NIU config. The Blackhole hang detector
+// needs this at construction to pick the core it probes.
+// TODO: temporary - BlackholeTTDevice reads the same register for its own callers; both collapse into
+// DeviceFirmware::get_noc_translation_enabled() once that component exists.
+bool read_noc_translation_enabled(PcieInterface *pcie_interface, JtagInterface *jtag_interface) {
+    const uint32_t niu_cfg = jtag_interface != nullptr
+                                 ? jtag_interface->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR)
+                                 : pcie_interface->bar_read32(blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + 0x100);
+    return ((niu_cfg >> 14) & 0x1) != 0;
+}
+
+}  // namespace
 
 BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
@@ -28,6 +44,8 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
     protocol_ = std::move(pcie_protocol);
+    hang_detector_ = std::make_unique<BlackholeHangDetector>(
+        protocol_.get(), read_noc_translation_enabled(pcie_interface_, /*jtag_interface=*/nullptr));
     if (use_safe_api) {
         SiliconTlbWindow::set_sigbus_safe_handler(true);
     }
@@ -43,6 +61,8 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
+    hang_detector_ = std::make_unique<BlackholeHangDetector>(
+        protocol_.get(), read_noc_translation_enabled(/*pcie_interface=*/nullptr, jtag_interface_));
 }
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
@@ -62,6 +82,8 @@ ArchitectureImplementation *BlackholeTTDeviceModel::get_architecture_impl() { re
 std::shared_ptr<SocArchDescriptor> BlackholeTTDeviceModel::get_shared_soc_arch_descriptor() {
     return soc_arch_descriptor_;
 }
+
+HangDetector *BlackholeTTDeviceModel::get_hang_detector() { return hang_detector_.get(); }
 
 PcieInterface *BlackholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -11,6 +11,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
@@ -31,6 +32,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
     protocol_ = std::move(pcie_protocol);
+    hang_detector_ = std::make_unique<WormholeHangDetector>(protocol_.get());
     if (use_safe_api) {
         SiliconTlbWindow::set_sigbus_safe_handler(true);
     }
@@ -46,6 +48,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
+    hang_detector_ = std::make_unique<WormholeHangDetector>(protocol_.get());
 }
 
 // A remote device is reached through a local one, so it takes the local device's identity.
@@ -58,6 +61,8 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);
+    hang_detector_ = std::make_unique<WormholeHangDetector>(
+        remote_interface_->get_remote_communication()->get_local_device()->get_device_protocol());
 }
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
@@ -77,6 +82,8 @@ ArchitectureImplementation *WormholeTTDeviceModel::get_architecture_impl() { ret
 std::shared_ptr<SocArchDescriptor> WormholeTTDeviceModel::get_shared_soc_arch_descriptor() {
     return soc_arch_descriptor_;
 }
+
+HangDetector *WormholeTTDeviceModel::get_hang_detector() { return hang_detector_.get(); }
 
 PcieInterface *WormholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 


### PR DESCRIPTION
### Issue
#2864

### Description
Each model creates the hang detector for its architecture, so that arch-specific
choice now sits with the rest of that architecture's components. The Wormhole
model also decides which protocol the detector probes: a remote device has none
of its own, so it probes through the local device it is reached through.

TTDevice no longer owns the detector, only wires it -- an io-timeout callback
routing to a NOC liveness check, and a separately-locked window for the detector
to probe through. It now does that itself rather than leaving each architecture
to remember: `set_hang_detector()` gives way to a private `wire_hang_detector()`
called from TTDevice's own constructor.

### List of the changes
- The Wormhole and Blackhole models create and own their hang detector, and
override `get_hang_detector()`.
- Drop `TTDevice::hang_detector_`; the hang checks read the detector from the
model, and the protected `set_hang_detector()` becomes a private
`wire_hang_detector()` that TTDevice calls for itself.
- The Blackhole model reads the NOC0 NIU config itself, since its detector needs
`noc_translation_enabled` at construction.

### Testing
CI. The remote Wormhole path has no offline coverage, so its protocol selection
was verified by inspection rather than by a test -- worth exercising on hardware.

### API Changes
This PR has API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/tt_device_model_hang_detector
