### PR TITLE
Add host copy methods to SysmemBuffer

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -68,6 +68,27 @@ public:
     ~SysmemBuffer();
 
     /**
+     * Copies data from a caller-provided source buffer into this system memory buffer.
+     * Pure host-side operation, the device is not involved. This is allowed regardless of
+     * DeviceBufferAccess, which only constrains what the device may do to the mapping.
+     *
+     * @param src Pointer to the source host memory.
+     * @param size Number of bytes to copy.
+     * @param offset Byte offset within this buffer to write to. offset + size must fit in the buffer.
+     */
+    void write_to_sysmem(const void* src, size_t size, size_t offset);
+
+    /**
+     * Copies data from this system memory buffer into a caller-provided destination buffer.
+     * Pure host-side operation, the device is not involved.
+     *
+     * @param dest Pointer to the destination host memory.
+     * @param size Number of bytes to copy.
+     * @param offset Byte offset within this buffer to read from. offset + size must fit in the buffer.
+     */
+    void read_from_sysmem(void* dest, size_t size, size_t offset);
+
+    /**
      * Returns the virtual address of the buffer in the process address space.
      * Both in case of aligned and unaligned buffers, this will return the original buffer address.
      */

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
@@ -116,6 +117,18 @@ void SysmemBuffer::align_address_and_size() {
     offset_from_aligned_addr_ = reinterpret_cast<uint64_t>(buffer_va_) - aligned_buffer_va;
     buffer_va_ = reinterpret_cast<void*>(aligned_buffer_va);
     mapped_buffer_size_ = (mapped_buffer_size_ + offset_from_aligned_addr_ + page_size - 1) & ~(page_size - 1);
+}
+
+void SysmemBuffer::write_to_sysmem(const void* src, const size_t size, const size_t offset) {
+    ZoneScopedC(tracy::Color::Yellow);
+    validate(offset, size);
+    memcpy(static_cast<uint8_t*>(get_buffer_va()) + offset, src, size);
+}
+
+void SysmemBuffer::read_from_sysmem(void* dest, const size_t size, const size_t offset) {
+    ZoneScopedC(tracy::Color::Yellow);
+    validate(offset, size);
+    memcpy(dest, static_cast<const uint8_t*>(get_buffer_va()) + offset, size);
 }
 
 void* SysmemBuffer::get_buffer_va() const { return static_cast<uint8_t*>(buffer_va_) + offset_from_aligned_addr_; }

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -179,6 +180,63 @@ TEST_P(ApiSimulationSysmemManagerByArch, WriteReadThroughMappedBuffer) {
 
     // Confirm the data is also visible through the buffer VA.
     EXPECT_EQ(0, std::memcmp(buffer->get_buffer_va(), pattern.data(), pattern.size()));
+}
+
+// SysmemBuffer::write_to_sysmem / read_from_sysmem are pure host-side copies against the
+// buffer VA, bounded by the user-requested size.
+TEST_P(ApiSimulationSysmemManagerByArch, HostCopyThroughBufferRoundTrips) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam());
+
+    const size_t buffer_size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(buffer_size);
+    ASSERT_NE(buffer, nullptr);
+
+    const std::vector<uint8_t> pattern = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
+
+    // Round-trip at the start of the buffer.
+    buffer->write_to_sysmem(pattern.data(), pattern.size(), 0);
+    std::vector<uint8_t> readback(pattern.size(), 0);
+    buffer->read_from_sysmem(readback.data(), readback.size(), 0);
+    EXPECT_EQ(pattern, readback);
+    EXPECT_EQ(0, std::memcmp(buffer->get_buffer_va(), pattern.data(), pattern.size()));
+
+    // Round-trip at a non-zero offset, leaving the earlier bytes untouched.
+    const size_t offset = 512;
+    buffer->write_to_sysmem(pattern.data(), pattern.size(), offset);
+    std::fill(readback.begin(), readback.end(), 0);
+    buffer->read_from_sysmem(readback.data(), readback.size(), offset);
+    EXPECT_EQ(pattern, readback);
+    EXPECT_EQ(0, std::memcmp(static_cast<uint8_t*>(buffer->get_buffer_va()) + offset, pattern.data(), pattern.size()));
+
+    // The last byte of the buffer is addressable.
+    const uint8_t sentinel = 0xA5;
+    buffer->write_to_sysmem(&sentinel, sizeof(sentinel), buffer_size - 1);
+    uint8_t sentinel_readback = 0;
+    buffer->read_from_sysmem(&sentinel_readback, sizeof(sentinel_readback), buffer_size - 1);
+    EXPECT_EQ(sentinel, sentinel_readback);
+}
+
+TEST_P(ApiSimulationSysmemManagerByArch, HostCopyOutOfBoundsThrows) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam());
+
+    const size_t buffer_size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(buffer_size);
+    ASSERT_NE(buffer, nullptr);
+
+    std::vector<uint8_t> scratch(16, 0);
+
+    // Offset past the end.
+    EXPECT_THROW(buffer->write_to_sysmem(scratch.data(), 1, buffer_size), std::exception);
+    EXPECT_THROW(buffer->read_from_sysmem(scratch.data(), 1, buffer_size), std::exception);
+
+    // Offset in range, but the range runs off the end. This is the case the read path
+    // used to miss.
+    EXPECT_THROW(buffer->write_to_sysmem(scratch.data(), 2, buffer_size - 1), std::exception);
+    EXPECT_THROW(buffer->read_from_sysmem(scratch.data(), 2, buffer_size - 1), std::exception);
+
+    // Size larger than the whole buffer.
+    EXPECT_THROW(buffer->write_to_sysmem(scratch.data(), buffer_size + 1, 0), std::exception);
+    EXPECT_THROW(buffer->read_from_sysmem(scratch.data(), buffer_size + 1, 0), std::exception);
 }
 
 // get_mapped_host_ptr resolves a device_io_addr to the in-place host pointer (zero-copy),

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -7,6 +7,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -224,6 +225,58 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
 
     EXPECT_EQ(sysmem_buffer->get_buffer_size(), buf_size);
     EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapped_buffer);
+}
+
+// Host-side copies must land at the user's VA, not at the page-aligned start the buffer
+// pins internally. This uses a deliberately unaligned mapping to exercise that.
+TEST(ApiSysmemManager, SysmemBufferHostCopyUnaligned) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
+    if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
+    }
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+
+    const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const size_t mmap_size = 2 * sysconf(_SC_PAGESIZE);
+    const size_t buf_offset = 10;  // Deliberately not page aligned.
+    const size_t buf_size = 128;
+
+    void* mapping = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    ASSERT_NE(mapping, MAP_FAILED);
+
+    void* mapped_buffer = static_cast<uint8_t*>(mapping) + buf_offset;
+
+    std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapped_buffer, buf_size);
+
+    const std::vector<uint8_t> pattern = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
+
+    sysmem_buffer->write_to_sysmem(pattern.data(), pattern.size(), 0);
+    // The bytes must be visible at the caller's VA, which is the unaligned one.
+    EXPECT_EQ(0, std::memcmp(mapped_buffer, pattern.data(), pattern.size()));
+
+    std::vector<uint8_t> readback(pattern.size(), 0);
+    sysmem_buffer->read_from_sysmem(readback.data(), readback.size(), 0);
+    EXPECT_EQ(pattern, readback);
+
+    const size_t offset = 64;
+    sysmem_buffer->write_to_sysmem(pattern.data(), pattern.size(), offset);
+    std::fill(readback.begin(), readback.end(), 0);
+    sysmem_buffer->read_from_sysmem(readback.data(), readback.size(), offset);
+    EXPECT_EQ(pattern, readback);
+
+    // Bounds are the user-requested size, not the larger page-aligned mapping.
+    EXPECT_THROW(sysmem_buffer->write_to_sysmem(pattern.data(), 1, buf_size), std::exception);
+    EXPECT_THROW(sysmem_buffer->read_from_sysmem(readback.data(), 2, buf_size - 1), std::exception);
+
+    sysmem_buffer.reset();
+    munmap(mapping, mmap_size);
 }
 
 TEST(ApiSysmemManager, SysmemBufferNocAddress) {


### PR DESCRIPTION
### Issue
#3249

### Description
Adds the buffer-side host copy methods the Base API Specification puts on `SysmemBuffer`. Both are pure host-side `memcpy`s against the buffer VA — the device is not involved. They are bounded by the user-requested size, so on an unaligned buffer they address the caller's VA rather than the larger page-aligned mapping pinned underneath.

Note these are deliberately not gated on `DeviceBufferAccess`: `READ_ONLY` constrains what the device may do to the mapping and explicitly does not restrict host access, so writing into a device-read-only buffer from the host is the intended pattern.

Stacked on #3250.

### List of the changes
- Added `SysmemBuffer::write_to_sysmem()` and `read_from_sysmem()`, both routed through the existing `validate(offset, size)` bounds check.
- Added simulation-side tests for the round trip at zero and non-zero offsets, the last addressable byte, and the out-of-bounds cases in both directions.
- Added a silicon-side test that a copy on a deliberately unaligned mapping lands at the caller's VA and is bounded by the requested size.

### Testing
CI

### API Changes
This PR has no API changes.

---
Replaces #3252, which GitHub auto-closed as merged when the stack was reordered (its head branch became an ancestor of its base). Same commit, new base.
