### PR TITLE
Add get_communication_id to SysmemBuffer and SysmemManager

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -58,10 +58,17 @@ public:
         size_t buffer_size,
         bool map_to_noc = false,
         DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
+    /**
+     * Constructor for a buffer that was already made visible to the device by the caller.
+     *
+     * @param communication_id Identifier of the device this buffer's IOVA is valid for. Supplied by the
+     * allocator, which pins for exactly one device. Matches TTDevice::get_communication_device_id().
+     */
     SysmemBuffer(
         void* buffer_va,
         size_t buffer_size,
         uint64_t device_io_addr,
+        int communication_id,
         std::optional<uint64_t> noc_addr = std::nullopt,
         std::function<void()> unmap_callback = {},
         DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
@@ -112,6 +119,13 @@ public:
     std::optional<uint64_t> get_noc_addr() const { return noc_addr_; }
 
     DeviceBufferAccess get_device_access() const { return device_access_; }
+
+    /**
+     * Returns the identifier of the device context this buffer was pinned for. The IOVA is valid only
+     * for that device, so callers can compare this against TTDevice::get_communication_device_id() to
+     * confirm a buffer belongs to the device it is about to be used with.
+     */
+    int get_communication_id() const { return communication_id_; }
 
     /**
      * Does zero copy DMA transfer to the device. Since the buffer is already mapped through KMD, this function
@@ -178,6 +192,9 @@ private:
 
     std::function<void()> unmap_callback_;
     DeviceBufferAccess device_access_ = DeviceBufferAccess::READ_WRITE;
+
+    // Device this buffer's IOVA is valid for. -1 when unknown.
+    int communication_id_ = -1;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -65,6 +65,12 @@ public:
 
     uint64_t get_pcie_base() const { return pcie_base_; }
 
+    /**
+     * Returns the identifier of the device context this manager pins memory for. A manager pins for
+     * exactly one device and stamps this value into every buffer it produces.
+     */
+    int get_communication_id() const { return communication_id_; }
+
     static uint64_t get_pcie_base_for_arch(tt::ARCH arch);
 
 protected:
@@ -74,6 +80,9 @@ protected:
     TTDevice* tt_device_ = nullptr;
     // TODO: Properly initialize for SimulationSysmemManager.
     uint64_t pcie_base_ = 0;
+
+    // Device this manager pins for. Set by the concrete manager's constructor. -1 when unknown.
+    int communication_id_ = -1;
 
     std::vector<HugepageMapping> hugepage_mapping_per_channel;
     void* iommu_mapping = nullptr;

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -111,6 +111,7 @@ SiliconSysmemManager::SiliconSysmemManager(TTDevice *tt_device, uint32_t num_hos
     tt_device_ = tt_device;
     pci_device_ = tt_device->get_pci_device();
     UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
+    communication_id_ = tt_device->get_communication_device_id();
     pcie_base_ = get_pcie_base_for_arch(pci_device_->get_arch());
     UMD_ASSERT(
         num_host_mem_channels <= 4,

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -38,6 +38,7 @@ SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels,
     // region target, so each chip's DMA lands in its own host window with no per-chip tag at egress.
     pcie_base_ = get_pcie_base_for_arch(arch);
     host_base_ = static_cast<uint64_t>(chip_id) * PER_CHIP_HOST_STRIDE;
+    communication_id_ = static_cast<int>(chip_id);
     registry_ = std::make_shared<MappedBufferRegistry>();
     SimulationSysmemManager::init_sysmem(num_host_mem_channels);
 }
@@ -186,6 +187,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
         buffer,
         sysmem_buffer_size,
         device_io_addr,
+        communication_id_,
         noc_addr,
         [weak_reg, device_io_addr]() {
             if (auto reg = weak_reg.lock()) {

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -30,7 +30,8 @@ SysmemBuffer::SysmemBuffer(
     buffer_va_(buffer_va),
     mapped_buffer_size_(buffer_size),
     buffer_size_(buffer_size),
-    device_access_(device_access) {
+    device_access_(device_access),
+    communication_id_(tt_device->get_communication_device_id()) {
     UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
     align_address_and_size();
     if (map_to_noc) {
@@ -47,6 +48,7 @@ SysmemBuffer::SysmemBuffer(
     void* buffer_va,
     size_t buffer_size,
     uint64_t device_io_addr,
+    int communication_id,
     std::optional<uint64_t> noc_addr,
     std::function<void()> unmap_callback,
     DeviceBufferAccess device_access) :
@@ -58,7 +60,8 @@ SysmemBuffer::SysmemBuffer(
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
     unmap_callback_(std::move(unmap_callback)),
-    device_access_(device_access) {
+    device_access_(device_access),
+    communication_id_(communication_id) {
     align_address_and_size();
     // Pair with TracyFreeN in the destructor so Tracy sees balanced alloc/free.
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -216,6 +216,29 @@ TEST_P(ApiSimulationSysmemManagerByArch, HostCopyThroughBufferRoundTrips) {
     EXPECT_EQ(sentinel, sentinel_readback);
 }
 
+// The manager stamps its communication id into every buffer it produces, so a caller can confirm a
+// buffer belongs to the device it is about to be used with.
+TEST_P(ApiSimulationSysmemManagerByArch, BuffersCarryTheManagerCommunicationId) {
+    const uint32_t chip_id = 3;
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam(), chip_id);
+    EXPECT_EQ(sysmem->get_communication_id(), static_cast<int>(chip_id));
+
+    auto allocated = sysmem->allocate_sysmem_buffer(4096);
+    ASSERT_NE(allocated, nullptr);
+    EXPECT_EQ(allocated->get_communication_id(), sysmem->get_communication_id());
+
+    std::vector<uint8_t> external_buf(8192, 0);
+    auto mapped = sysmem->map_sysmem_buffer(external_buf.data(), external_buf.size());
+    ASSERT_NE(mapped, nullptr);
+    EXPECT_EQ(mapped->get_communication_id(), sysmem->get_communication_id());
+
+    // A manager for a different chip stamps a different id.
+    auto other_sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam(), chip_id + 1);
+    auto other_buffer = other_sysmem->allocate_sysmem_buffer(4096);
+    ASSERT_NE(other_buffer, nullptr);
+    EXPECT_NE(other_buffer->get_communication_id(), allocated->get_communication_id());
+}
+
 TEST_P(ApiSimulationSysmemManagerByArch, HostCopyOutOfBoundsThrows) {
     auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam());
 

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -227,6 +227,33 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
     EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapped_buffer);
 }
 
+// The manager pins for exactly one device and stamps that device's id into every buffer, so the id
+// on a buffer must match the TTDevice it was pinned against.
+TEST(ApiSysmemManager, SysmemBufferCommunicationId) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
+    if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
+    }
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+
+    for (const ChipId mmio_chip : cluster->get_target_mmio_device_ids()) {
+        Chip* chip = cluster->get_chip(mmio_chip);
+        SysmemManager* sysmem_manager = chip->get_sysmem_manager();
+        const int expected_id = chip->get_tt_device()->get_communication_device_id();
+
+        EXPECT_EQ(sysmem_manager->get_communication_id(), expected_id);
+
+        const size_t buf_size = 1 << 20;
+        std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->allocate_sysmem_buffer(buf_size);
+        ASSERT_NE(sysmem_buffer, nullptr);
+        EXPECT_EQ(sysmem_buffer->get_communication_id(), expected_id);
+    }
+}
+
 // Host-side copies must land at the user's VA, not at the page-aligned start the buffer
 // pins internally. This uses a deliberately unaligned mapping to exercise that.
 TEST(ApiSysmemManager, SysmemBufferHostCopyUnaligned) {


### PR DESCRIPTION
### Issue
#3249

### Description
Adds `get_communication_id()` to `SysmemBuffer` and `SysmemManager`, per the Base API Specification. A manager pins for exactly one device and stamps that device's id into every buffer it produces, so a caller holding a buffer can confirm it belongs to the device it is about to be used with — its IOVA is only valid there. The value matches `TTDevice::get_communication_device_id()`.

`SiliconSysmemManager` takes the id from its `TTDevice`; `SimulationSysmemManager` uses its chip id. The id is carried on the manager as a protected member alongside `pcie_base_`, following what that class already does.

Stacked on #3252.

### List of the changes
- Added `SysmemBuffer::get_communication_id()`, populated from the `TTDevice` in the device-backed constructor and passed explicitly in the pre-mapped one.
- Added `SysmemManager::get_communication_id()`, set by both concrete managers.
- Added tests that a manager's buffers carry its id, that managers for different chips stamp different ids, and that the id matches the `TTDevice` on silicon.

### API Changes
This PR has API changes.

- `SysmemBuffer`'s pre-mapped constructor takes a new required `communication_id` parameter after `device_io_addr`. The device-backed constructor is unchanged.

### Testing
CI

---
Replaces #3253, which GitHub auto-closed as merged when the stack was reordered (its head branch became an ancestor of its base). Same commit, new base.
