### PR TITLE
Add the SystemMemoryAllocator interface

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -217,6 +217,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/chip_helpers/sysmem_manager.hpp
                 api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
                 api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+                api/umd/device/chip_helpers/system_memory_allocator.hpp
                 api/umd/device/chip_helpers/sysmem_buffer.hpp
                 api/umd/device/chip_helpers/tlb_manager.hpp
                 api/umd/device/chip_helpers/simulation_tlb_allocator.hpp

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -9,8 +9,8 @@
 #include <memory>
 #include <vector>
 
-#include "sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/chip_helpers/system_memory_allocator.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
@@ -23,10 +23,23 @@ namespace tt::umd {
 class PCIDevice;
 class TTDevice;
 
-class SysmemManager {
+class SysmemManager : public SystemMemoryAllocator {
 public:
     SysmemManager() = default;
-    virtual ~SysmemManager() = default;
+    ~SysmemManager() override = default;
+
+    /**
+     * SystemMemoryAllocator surface. These are the Base API Specification names; they forward to the
+     * allocate_sysmem_buffer() / map_sysmem_buffer() implementations below, which the legacy
+     * channel-based paths still call directly.
+     */
+    std::unique_ptr<SysmemBuffer> allocate_buffer(size_t size, bool bind_to_noc = false) override;
+
+    std::unique_ptr<SysmemBuffer> map_user_buffer(
+        void* user_ptr,
+        size_t size,
+        bool bind_to_noc = false,
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE) override;
 
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
@@ -69,7 +82,7 @@ public:
      * Returns the identifier of the device context this manager pins memory for. A manager pins for
      * exactly one device and stamps this value into every buffer it produces.
      */
-    int get_communication_id() const { return communication_id_; }
+    int get_communication_id() const override { return communication_id_; }
 
     static uint64_t get_pcie_base_for_arch(tt::ARCH arch);
 

--- a/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "umd/device/types/host_memory.hpp"
+
+namespace tt::umd {
+class SysmemBuffer;
+
+/**
+ * Creates or maps device-visible host memory buffers for a single device.
+ *
+ * An allocator is created per device by whichever layer owns that device's transport, and is paired
+ * with its TTDevice by matching get_communication_id(). Buffers can be reached by the device in two
+ * ways: through their IOVA, which only the PCIe tile uses, or through a NOC address, which lets every
+ * tile reach the buffer once it has been bound.
+ */
+class SystemMemoryAllocator {
+public:
+    virtual ~SystemMemoryAllocator() = default;
+
+    /**
+     * Allocates a pinned, device-visible host memory buffer.
+     *
+     * The allocator creates contiguous host memory (via hugepage, IOMMU, or both), pins it, and maps it
+     * for device DMA access. The returned buffer owns that memory and frees it on destruction.
+     *
+     * @param size Requested buffer size in bytes.
+     * @param bind_to_noc If true, additionally binds the buffer to a NOC address so that all device tiles,
+     * not just the PCIe tile, can reach it.
+     * @return An exclusively owned system memory buffer.
+     */
+    virtual std::unique_ptr<SysmemBuffer> allocate_buffer(size_t size, bool bind_to_noc = false) = 0;
+
+    /**
+     * Pins and maps a caller-provided host memory buffer for device DMA access.
+     *
+     * The caller retains ownership of the underlying memory. The allocator pins the pages and creates an
+     * IOMMU mapping so the device can reach it; destroying the buffer unpins the pages but does not free
+     * the memory. Requires an IOMMU, since without one arbitrary user pointers cannot be made
+     * device-visible.
+     *
+     * @param user_ptr Pointer to the caller-allocated host memory.
+     * @param size Size of the caller's buffer in bytes.
+     * @param bind_to_noc If true, additionally binds the buffer to a NOC address.
+     * @param device_access What the device is allowed to do with the mapping. READ_ONLY pins the pages so the
+     * device cannot write through them, which needs KMD support the concrete allocator reports separately.
+     * @return An exclusively owned handle to the mapped buffer.
+     */
+    virtual std::unique_ptr<SysmemBuffer> map_user_buffer(
+        void* user_ptr,
+        size_t size,
+        bool bind_to_noc = false,
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE) = 0;
+
+    /**
+     * Returns the identifier of the device context this allocator pins memory for.
+     *
+     * An allocator pins for exactly one device — the one whose file descriptor and IOMMU context it holds —
+     * and stamps this value into every buffer it produces.
+     */
+    virtual int get_communication_id() const = 0;
+};
+
+}  // namespace tt::umd

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -77,6 +77,15 @@ void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysm
     memcpy(dest, user_scratchspace, size);
 }
 
+std::unique_ptr<SysmemBuffer> SysmemManager::allocate_buffer(size_t size, bool bind_to_noc) {
+    return allocate_sysmem_buffer(size, bind_to_noc);
+}
+
+std::unique_ptr<SysmemBuffer> SysmemManager::map_user_buffer(
+    void *user_ptr, size_t size, bool bind_to_noc, DeviceBufferAccess device_access) {
+    return map_sysmem_buffer(user_ptr, size, bind_to_noc, device_access);
+}
+
 uint64_t SysmemManager::get_pcie_base_for_arch(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -17,8 +17,10 @@
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/chip_helpers/system_memory_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/host_memory.hpp"
 
 using namespace tt::umd;
 
@@ -269,6 +271,42 @@ TEST_P(ApiSimulationSysmemManagerByArch, HostCopyThroughBufferRoundTrips) {
     uint8_t sentinel_readback = 0;
     buffer->read_from_sysmem(&sentinel_readback, sizeof(sentinel_readback), buffer_size - 1);
     EXPECT_EQ(sentinel, sentinel_readback);
+}
+
+// A manager must be usable purely through the SystemMemoryAllocator interface, since that is what the
+// Base API hands to upper layers.
+TEST_P(ApiSimulationSysmemManagerByArch, UsableThroughTheAllocatorInterface) {
+    const uint32_t chip_id = 5;
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam(), chip_id);
+    SystemMemoryAllocator* allocator = sysmem.get();
+
+    EXPECT_EQ(allocator->get_communication_id(), static_cast<int>(chip_id));
+
+    auto allocated = allocator->allocate_buffer(4096);
+    ASSERT_NE(allocated, nullptr);
+    EXPECT_NE(allocated->get_buffer_va(), nullptr);
+    EXPECT_EQ(allocated->get_communication_id(), static_cast<int>(chip_id));
+    EXPECT_FALSE(allocated->get_noc_addr().has_value());
+
+    std::vector<uint8_t> external(8192, 0);
+    auto mapped = allocator->map_user_buffer(external.data(), external.size());
+    ASSERT_NE(mapped, nullptr);
+    EXPECT_EQ(mapped->get_buffer_va(), external.data());
+    // Mappings are read-write unless the caller asks otherwise.
+    EXPECT_EQ(mapped->get_device_access(), DeviceBufferAccess::READ_WRITE);
+
+    // The interface carries device access, so a read-only mapping is reachable without dropping to the
+    // concrete manager.
+    std::vector<uint8_t> read_only(4096, 0);
+    auto pinned_read_only = allocator->map_user_buffer(
+        read_only.data(), read_only.size(), /*bind_to_noc=*/false, DeviceBufferAccess::READ_ONLY);
+    ASSERT_NE(pinned_read_only, nullptr);
+    EXPECT_EQ(pinned_read_only->get_device_access(), DeviceBufferAccess::READ_ONLY);
+
+    // bind_to_noc reaches the same path as the concrete map_to_noc flag.
+    auto bound = allocator->allocate_buffer(4096, /*bind_to_noc=*/true);
+    ASSERT_NE(bound, nullptr);
+    EXPECT_TRUE(bound->get_noc_addr().has_value());
 }
 
 // The manager stamps its communication id into every buffer it produces, so a caller can confirm a


### PR DESCRIPTION
### Issue
#3249

### Description
Adds the `SystemMemoryAllocator` interface from the Base API Specification and makes `SysmemManager` implement it. The interface is pure virtual with no `.cpp`, matching how the other base-layer interfaces in the repo are laid out.

The three methods forward to the existing `allocate_sysmem_buffer()` / `map_sysmem_buffer()` implementations, so nothing changes behaviourally — this only puts the spec's names and shape in front of what is already there. The legacy channel and hugepage surface stays on `SysmemManager`; retiring it is separate work.

`map_user_buffer()` carries device access: it takes a trailing `DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE`, so read-only page pinning (#2680) is reachable through the interface rather than only through `map_sysmem_buffer()` on the concrete manager. The default keeps every call site source-compatible.

Stacked on #3255.

### List of the changes
- Added `umd/device/chip_helpers/system_memory_allocator.hpp` declaring `allocate_buffer()`, `map_user_buffer()` and `get_communication_id()`.
- Made `SysmemManager` derive from `SystemMemoryAllocator` and implement the three by forwarding to the existing methods.
- Registered the new header in the installed header set.
- Dropped a duplicate `sysmem_buffer.hpp` include in `sysmem_manager.hpp` while adding the new one.
- Added a test driving a manager purely through a `SystemMemoryAllocator*`, including a read-only mapping made through the interface.

### API Changes
This PR has API changes.

- Added the `SystemMemoryAllocator` interface. `SysmemManager` now derives from it and gains `allocate_buffer()` and `map_user_buffer()` alongside the existing `allocate_sysmem_buffer()` and `map_sysmem_buffer()`.

### Testing
CI
