### PR TITLE
Add bind_noc_address to SysmemBuffer

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -48,6 +48,16 @@ public:
     using Deleter = std::function<void(void*)>;
 
     /**
+     * Callable that programs the hardware address translation binding this buffer to the NOC, returning
+     * the resulting NOC address.
+     *
+     * Injected by the allocator, which holds the device context the translation needs. Optional: an
+     * allocator whose driver assigns the NOC address at pin time supplies none, and a buffer without one
+     * cannot be bound after construction.
+     */
+    using NocBinder = std::function<uint64_t()>;
+
+    /**
      * Constructor for SysmemBuffer. Start of the buffer must be aligned
      * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
      * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
@@ -96,7 +106,8 @@ public:
         int communication_id,
         std::optional<uint64_t> noc_addr = std::nullopt,
         Deleter deleter = {},
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
+        NocBinder noc_binder = {});
     ~SysmemBuffer();
 
     /**
@@ -142,6 +153,16 @@ public:
     uint64_t get_device_io_addr(const size_t offset = 0) const;
 
     std::optional<uint64_t> get_noc_addr() const { return noc_addr_; }
+
+    /**
+     * Binds a NOC address to this buffer, so every tile on the device can reach it rather than only the
+     * PCIe tile.
+     *
+     * Idempotent: a no-op once bound, whether that happened here or at pin time. Throws when the buffer is
+     * unbound and has no binder, which is the case for a buffer whose pages were not pinned with NOC access
+     * on a driver that only assigns NOC addresses at pin time.
+     */
+    void bind_noc_address();
 
     DeviceBufferAccess get_device_access() const { return device_access_; }
 
@@ -214,6 +235,9 @@ private:
     // Address that is used on the NOC to access the buffer.  NOC target must be
     // the PCIE core that is connected to the host and this address.
     std::optional<uint64_t> noc_addr_;
+
+    // Programs the NOC translation on demand. Empty when the buffer cannot be bound after construction.
+    NocBinder noc_binder_;
 
     // Owns the buffer's page-aligned start. Releasing it runs the deleter composed at construction,
     // which unpins the pages from the device and, for buffers this class allocated, frees them.

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -96,7 +96,8 @@ SysmemBuffer::SysmemBuffer(
     int communication_id,
     std::optional<uint64_t> noc_addr,
     Deleter deleter,
-    DeviceBufferAccess device_access) :
+    DeviceBufferAccess device_access,
+    NocBinder noc_binder) :
     pci_device_(nullptr),
     tt_device_(nullptr),
     buffer_va_(buffer_va),
@@ -104,6 +105,7 @@ SysmemBuffer::SysmemBuffer(
     buffer_size_(buffer_size),
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
+    noc_binder_(std::move(noc_binder)),
     device_access_(device_access),
     communication_id_(communication_id) {
     align_address_and_size();
@@ -166,6 +168,19 @@ void SysmemBuffer::read_from_sysmem(void* dest, const size_t size, const size_t 
     ZoneScopedC(tracy::Color::Yellow);
     validate(offset, size);
     memcpy(dest, static_cast<const uint8_t*>(get_buffer_va()) + offset, size);
+}
+
+void SysmemBuffer::bind_noc_address() {
+    if (noc_addr_.has_value()) {
+        return;
+    }
+    if (!noc_binder_) {
+        UMD_THROW(
+            error::RuntimeError,
+            "This sysmem buffer has no NOC address and no way to bind one. Its allocator binds at pin time, so "
+            "allocate or map the buffer with bind_to_noc set instead.");
+    }
+    noc_addr_ = noc_binder_();
 }
 
 void* SysmemBuffer::get_buffer_va() const { return static_cast<uint8_t*>(buffer_va_) + offset_from_aligned_addr_; }

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -23,6 +24,10 @@
 #include "umd/device/types/host_memory.hpp"
 
 using namespace tt::umd;
+
+using ::testing::InSequence;
+using ::testing::MockFunction;
+using ::testing::Return;
 
 const uint32_t HUGEPAGE_REGION_SIZE = 1ULL << 30;  // 1GB
 
@@ -116,22 +121,108 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
     // Deliberately offset into the page so the buffer has to align downwards.
     void* user_va = static_cast<uint8_t*>(aligned_start) + 64;
 
-    int deleter_calls = 0;
-    void* deleter_saw = nullptr;
+    MockFunction<void(void*)> deleter;
+    // Checkpoint reached while the buffer is still alive, sequenced before the deleter so that running
+    // it any earlier than destruction fails the expectation.
+    MockFunction<void()> buffer_still_alive;
+    {
+        InSequence sequence;
+        EXPECT_CALL(buffer_still_alive, Call());
+        EXPECT_CALL(deleter, Call(aligned_start));
+    }
+
     {
         SysmemBuffer buffer(
-            user_va, 128, /*device_io_addr=*/0x1000, /*communication_id=*/7, std::nullopt, [&](void* released) {
-                ++deleter_calls;
-                deleter_saw = released;
-            });
+            user_va, 128, /*device_io_addr=*/0x1000, /*communication_id=*/7, std::nullopt, deleter.AsStdFunction());
 
         EXPECT_EQ(buffer.get_buffer_va(), user_va);
         EXPECT_EQ(buffer.get_buffer_size(), 128u);
-        EXPECT_EQ(deleter_calls, 0);
+        buffer_still_alive.Call();
     }
+}
 
-    EXPECT_EQ(deleter_calls, 1);
-    EXPECT_EQ(deleter_saw, aligned_start);
+// The driver assigns the NOC address at pin time, so bind_noc_address() only confirms what already
+// happened. On a bound buffer it is a no-op.
+TEST(ApiSimulationSysmemManager, BindNocAddressIsNoOpWhenAlreadyBound) {
+    std::vector<uint8_t> backing(4096, 0);
+
+    SysmemBuffer buffer(
+        backing.data(),
+        backing.size(),
+        /*device_io_addr=*/0x1000,
+        /*communication_id=*/2,
+        std::optional<uint64_t>(0x1234));
+
+    EXPECT_NO_THROW(buffer.bind_noc_address());
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+
+    // Idempotent.
+    EXPECT_NO_THROW(buffer.bind_noc_address());
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+}
+
+// An allocator that can bind after the fact injects a binder. bind_noc_address() must run it exactly
+// once and cache the result, however often it is called.
+TEST(ApiSimulationSysmemManager, BindNocAddressRunsInjectedBinderOnce) {
+    std::vector<uint8_t> backing(4096, 0);
+
+    MockFunction<uint64_t()> binder;
+    // WillOnce fixes the cardinality at one, so both a binder that never runs and one that runs again
+    // on the second bind_noc_address() fail here.
+    EXPECT_CALL(binder, Call()).WillOnce(Return(0xDEADBEEF));
+
+    SysmemBuffer buffer(
+        backing.data(),
+        backing.size(),
+        /*device_io_addr=*/0x1000,
+        /*communication_id=*/2,
+        std::nullopt,
+        SysmemBuffer::Deleter{},
+        DeviceBufferAccess::READ_WRITE,
+        binder.AsStdFunction());
+
+    // Nothing bound yet, so construction cannot have run the binder.
+    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+
+    buffer.bind_noc_address();
+    ASSERT_TRUE(buffer.get_noc_addr().has_value());
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0xDEADBEEFu);
+
+    // Idempotent: the cached address is returned without running the binder again.
+    buffer.bind_noc_address();
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0xDEADBEEFu);
+}
+
+// A buffer that is already bound never runs its binder.
+TEST(ApiSimulationSysmemManager, BindNocAddressSkipsBinderWhenAlreadyBound) {
+    std::vector<uint8_t> backing(4096, 0);
+
+    MockFunction<uint64_t()> binder;
+    EXPECT_CALL(binder, Call()).Times(0);
+
+    SysmemBuffer buffer(
+        backing.data(),
+        backing.size(),
+        /*device_io_addr=*/0x1000,
+        /*communication_id=*/2,
+        std::optional<uint64_t>(0x1234),
+        SysmemBuffer::Deleter{},
+        DeviceBufferAccess::READ_WRITE,
+        binder.AsStdFunction());
+
+    buffer.bind_noc_address();
+    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+}
+
+// A buffer whose pages were not pinned with NOC access can never be given a NOC address, so asking
+// must fail loudly rather than leave the caller believing the buffer is reachable over the NOC.
+TEST(ApiSimulationSysmemManager, BindNocAddressThrowsWhenUnbound) {
+    std::vector<uint8_t> backing(4096, 0);
+    SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x1000, /*communication_id=*/2);
+
+    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+    EXPECT_THROW(buffer.bind_noc_address(), std::exception);
+    EXPECT_FALSE(buffer.get_noc_addr().has_value());
 }
 
 // A buffer given no deleter must still destruct cleanly. unique_ptr with an empty std::function


### PR DESCRIPTION
### Issue
#3249

### Description
Adds `bind_noc_address()` and the `NocBinder` it uses to `SysmemBuffer`, continuing the alignment of the sysmem classes with the Base API Specification.

No allocator supplies a binder today: the KMD assigns a NOC address only when pages are pinned, and the pre-2.0 iATU path that could have bound after the fact is gone (#3170, #3171). The binder is injected rather than built in, so an allocator that can bind another way is free to supply one.

### List of the changes
- Added `SysmemBuffer::bind_noc_address()`: runs the injected binder once and caches the result, a no-op once bound, and throws when the buffer is unbound and has no binder.
- Added `SysmemBuffer::NocBinder` and an optional trailing constructor parameter for it.
- Added tests for the bound, unbound, and injected-binder cases.

### API Changes
This PR has API changes.

- Added `SysmemBuffer::bind_noc_address()` and `SysmemBuffer::NocBinder`.
- `SysmemBuffer`'s pre-mapped constructor takes a new optional trailing `noc_binder` parameter.

### Testing
CI

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/sysmem-remove-deprecated-names