### PR TITLE
Make SysmemBuffer constructible only by an allocator

### DIFF
--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -41,6 +41,19 @@ protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 
 private:
+    /**
+     * Pins buffer_va for the device and wraps it in a SysmemBuffer.
+     *
+     * release_backing_memory is what distinguishes the two allocation paths: it frees the pages for a buffer
+     * this manager allocated, and is empty for one mapped from a caller's pointer.
+     */
+    std::unique_ptr<SysmemBuffer> pin_and_wrap(
+        void* buffer_va,
+        size_t buffer_size,
+        const bool map_to_noc,
+        DeviceBufferAccess device_access,
+        SysmemBuffer::Deleter release_backing_memory);
+
     bool init_hugepages(uint32_t num_host_mem_channels);
 
     bool init_iommu(uint32_t num_fake_mem_channels);

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <utility>
 #include <vector>
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
@@ -101,10 +100,19 @@ private:
     // Caller must hold registry_->mutex.
     std::optional<MappedBuffer> find_mapped_buffer_locked(uint64_t device_io_addr, uint32_t size);
 
+    // Assigns an arena address, registers the buffer and wraps it. Shared by the allocate and map
+    // paths, which differ only in who owns the memory: allocate passes a release callable that frees
+    // the mapping, map passes none because the caller owns it. Mirrors SiliconSysmemManager::pin_and_wrap().
+    std::unique_ptr<SysmemBuffer> register_and_wrap(
+        void* buffer,
+        size_t sysmem_buffer_size,
+        const bool map_to_noc,
+        DeviceBufferAccess device_access,
+        SysmemBuffer::Deleter release_backing_memory);
+
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
     uint64_t host_base_ = 0;  // this chip's distinct host-physical base (= chip_id * PER_CHIP_HOST_STRIDE)
-    std::vector<std::pair<void*, size_t>> owned_allocations_;
     std::shared_ptr<MappedBufferRegistry> registry_;
 };
 

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -14,7 +14,6 @@
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
-class PCIDevice;
 class TTDevice;
 
 /**
@@ -34,18 +33,28 @@ public:
     /**
      * Cleanup callable invoked on destruction, receiving the page-aligned start of the buffer.
      *
-     * It encodes the difference between the two ownership models: for a buffer the allocator itself
-     * allocated, it unpins the pages and frees the backing memory; for a buffer mapped from a caller's
-     * pointer, it only unpins, leaving the memory to its owner.
-     *
-     * NOTE: the Base API Specification keeps this alias, and the constructors below, private, with the
-     * allocator a friend of this class. There the allocator is the sole author of the deleter and states
-     * the ownership model outright: it composes unpin-and-free for memory UMD owns, and unpin-only for
-     * memory the client owns. Here both are public and the model is instead implied by whether a
-     * release callable was passed, which is not what we want to keep. Moving to the spec's shape is a
-     * follow-up, together with making the constructors private.
+     * The allocator is its sole author and states the ownership model outright: unpin-and-free for
+     * memory UMD owns, unpin-only for memory the client owns.
      */
     using Deleter = std::function<void(void*)>;
+
+    /**
+     * A buffer's page-aligned extent. The pages an allocator pins must cover the whole user range, so an
+     * unaligned start is rounded down and the size grown to match.
+     */
+    struct AlignedRange {
+        void* base = nullptr;           // Page-aligned start. This is what gets pinned and released.
+        size_t mapped_size = 0;         // Page-rounded size covering the user's whole range.
+        uint64_t offset_from_base = 0;  // Distance from base to the user's virtual address.
+    };
+
+    /**
+     * Computes the page-aligned extent covering [buffer_va, buffer_va + buffer_size).
+     *
+     * Allocators use this to pin exactly the range the buffer will report offsets against. It is a pure
+     * function of its arguments, so the allocator and the buffer independently agree on the extent.
+     */
+    static AlignedRange page_align(void* buffer_va, size_t buffer_size);
 
     /**
      * Callable that programs the hardware address translation binding this buffer to the NOC, returning
@@ -57,57 +66,6 @@ public:
      */
     using NocBinder = std::function<uint64_t()>;
 
-    /**
-     * Constructor for SysmemBuffer. Start of the buffer must be aligned
-     * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
-     * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
-     * see a buffer of the original size. Same as for buffer size, user won't be able to access the memory before the
-     * start of the buffer, aligning is transparent to the user.
-     * Pages separated by | AB - Aligned buffer,
-     * UB - Unaligned buffer, UE - Unaligned end, AE - Aligned end
-     *
-     * |     Page 0     |     Page 1     |     Page 2     |     Page 3     |
-     * +----------------+----------------+----------------+----------------+
-     * ^                ^       ^                    ^    ^
-     * Page Start       AB      UB                   UE   AE
-     *                          |<--- buffer_size -->|
-     *                  |<----- mapped_buffer_size ----->|
-     *
-     * @param tt_device Pointer to the TTDevice. Used directly for DMA transfers, and to access the underlying
-     * PCIDevice for mapping/unmapping and TLB allocation.
-     * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
-     * @param buffer_size Size of the buffer requested by the user.
-     * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
-     * @param release_backing_memory Optional callable that frees the pages behind buffer_va, invoked after
-     * the buffer has been unpinned from the device. Pass it when the allocator owns the memory it is handing
-     * over; leave it empty when the caller owns the memory and only wants it unpinned on destruction.
-     * Signalling ownership through the presence of this parameter is the interim shape described in the
-     * note on Deleter, not the one the specification settles on.
-     */
-    SysmemBuffer(
-        TTDevice* tt_device,
-        void* buffer_va,
-        size_t buffer_size,
-        bool map_to_noc = false,
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
-        Deleter release_backing_memory = {});
-    /**
-     * Constructor for a buffer that was already made visible to the device by the caller.
-     *
-     * @param communication_id Identifier of the device this buffer's IOVA is valid for. Supplied by the
-     * allocator, which pins for exactly one device. Matches TTDevice::get_communication_device_id().
-     * @param deleter Cleanup callable invoked on destruction with the page-aligned start of the buffer.
-     * Defaults to releasing nothing, since this constructor takes a mapping the caller already owns.
-     */
-    SysmemBuffer(
-        void* buffer_va,
-        size_t buffer_size,
-        uint64_t device_io_addr,
-        int communication_id,
-        std::optional<uint64_t> noc_addr = std::nullopt,
-        Deleter deleter = {},
-        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
-        NocBinder noc_binder = {});
     ~SysmemBuffer();
 
     /**
@@ -196,13 +154,38 @@ public:
     void dma_read_from_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
 private:
+    // Buffers are created only by an allocator, which pins the pages and therefore knows the IOVA, the NOC
+    // address and how the memory has to be released.
+    friend class SystemMemoryAllocator;
+
     /**
-     * Aligns the address and size of the buffer to the page size. If the buffer is not aligned to the page size,
-     * it will be aligned and the size will be adjusted accordingly. The original buffer size will not be changed.
-     * However, behaviour (calculation of offset) of the SysmemBuffer is always going to be based on the original VA and
-     * size.
+     * Constructs a buffer over host memory the allocator has already pinned for the device.
+     *
+     * Alignment stays invisible to the user: get_buffer_va() and get_buffer_size() report what was
+     * passed in, and offsets are bounded by that size. The allocator must pin the same aligned range,
+     * which it computes with page_align().
+     *
+     * @param tt_device Device this buffer belongs to, used for the zero-copy DMA helpers. May be null for
+     * buffers never used for DMA, such as the simulator's.
+     * @param buffer_va Virtual address of the buffer as the user sees it.
+     * @param buffer_size Size of the buffer requested by the user.
+     * @param device_io_addr IOVA of the page-aligned start, as returned by the allocator's pinning call.
+     * @param communication_id Identifier of the device this buffer's IOVA is valid for.
+     * @param deleter Cleanup callable invoked on destruction with the page-aligned start.
+     * @param noc_addr NOC address, if the pages were pinned with NOC access.
+     * @param device_access Whether the device may write the mapping or only read it.
+     * @param noc_binder Optional callable for deferred NOC binding.
      */
-    void align_address_and_size();
+    SysmemBuffer(
+        TTDevice* tt_device,
+        void* buffer_va,
+        size_t buffer_size,
+        uint64_t device_io_addr,
+        int communication_id,
+        Deleter deleter,
+        std::optional<uint64_t> noc_addr = std::nullopt,
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE,
+        NocBinder noc_binder = {});
 
     /**
      * Validates that the [offset, offset + size) range is within the bounds of the buffer.
@@ -213,7 +196,6 @@ private:
      */
     void validate(const size_t offset, const size_t size = 0) const;
 
-    PCIDevice* pci_device_;
     TTDevice* tt_device_;
 
     // Virtual address in process addr space.

--- a/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/system_memory_allocator.hpp
@@ -6,11 +6,12 @@
 
 #include <cstddef>
 #include <memory>
+#include <utility>
 
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/types/host_memory.hpp"
 
 namespace tt::umd {
-class SysmemBuffer;
 
 /**
  * Creates or maps device-visible host memory buffers for a single device.
@@ -65,6 +66,18 @@ public:
      * and stamps this value into every buffer it produces.
      */
     virtual int get_communication_id() const = 0;
+
+protected:
+    /**
+     * Creates a buffer, forwarding its arguments to the private SysmemBuffer constructor.
+     *
+     * Friendship is not inherited, so a concrete allocator cannot reach that constructor itself and
+     * builds every buffer through this helper.
+     */
+    template <typename... Args>
+    static std::unique_ptr<SysmemBuffer> create_buffer(Args&&... args) {
+        return std::unique_ptr<SysmemBuffer>(new SysmemBuffer(std::forward<Args>(args)...));
+    }
 };
 
 }  // namespace tt::umd

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -107,6 +107,38 @@ static void *mmap_with_hugepage_fallback(size_t size) {
     return addr;
 }
 
+// Unpins the pages on destruction unless disarmed.
+//
+// It covers the whole window between pinning and a SysmemBuffer taking ownership, not just the
+// construction call: composing the deleter allocates a std::function, so it can throw before any
+// try block is entered, and an escape there would leave the pages pinned with nothing owning them.
+class UnpinGuard {
+public:
+    UnpinGuard(PCIDevice *pci_device, void *base, size_t size) : pci_device_(pci_device), base_(base), size_(size) {}
+
+    UnpinGuard(const UnpinGuard &) = delete;
+    UnpinGuard &operator=(const UnpinGuard &) = delete;
+
+    ~UnpinGuard() {
+        if (!armed_) {
+            return;
+        }
+        try {
+            pci_device_->unmap_for_dma(base_, size_);
+        } catch (...) {
+            log_warning(LogUMD, "Failed to unmap sysmem buffer after a failed construction.");
+        }
+    }
+
+    void disarm() { armed_ = false; }
+
+private:
+    PCIDevice *pci_device_;
+    void *base_;
+    size_t size_;
+    bool armed_ = true;
+};
+
 SiliconSysmemManager::SiliconSysmemManager(TTDevice *tt_device, uint32_t num_host_mem_channels) {
     tt_device_ = tt_device;
     pci_device_ = tt_device->get_pci_device();
@@ -438,6 +470,61 @@ void SiliconSysmemManager::print_file_contents(const std::string &filename, cons
     }
 }
 
+std::unique_ptr<SysmemBuffer> SiliconSysmemManager::pin_and_wrap(
+    void *buffer_va,
+    size_t buffer_size,
+    const bool map_to_noc,
+    DeviceBufferAccess device_access,
+    SysmemBuffer::Deleter release_backing_memory) {
+    // The buffer reports offsets against the user's address, but the pages that get pinned are the aligned
+    // range covering it. page_align() is what keeps the two in agreement.
+    const SysmemBuffer::AlignedRange range = SysmemBuffer::page_align(buffer_va, buffer_size);
+
+    uint64_t device_io_addr = 0;
+    std::optional<uint64_t> noc_addr = std::nullopt;
+    if (map_to_noc) {
+        std::tie(noc_addr, device_io_addr) =
+            pci_device_->map_buffer_to_noc(range.base, range.mapped_size, device_access);
+    } else {
+        device_io_addr = pci_device_->map_for_dma(range.base, range.mapped_size, device_access);
+    }
+
+    // Armed immediately after pinning: everything below here can throw, and until create_buffer()
+    // returns there is nothing that would unpin the pages.
+    UnpinGuard unpin_guard(pci_device_, range.base, range.mapped_size);
+
+    // The buffer's deleter unpins, then releases the backing memory if this manager owns it.
+    SysmemBuffer::Deleter deleter = [pci_device = pci_device_,
+                                     mapped_size = range.mapped_size,
+                                     device_io_addr,
+                                     release = std::move(release_backing_memory)](void *aligned_va) {
+        try {
+            pci_device->unmap_for_dma(aligned_va, mapped_size);
+        } catch (...) {
+            log_warning(
+                LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_size, device_io_addr);
+        }
+        if (release) {
+            release(aligned_va);
+        }
+    };
+
+    // The KMD assigns the NOC address at pin time, so this manager supplies no binder.
+    std::unique_ptr<SysmemBuffer> buffer = create_buffer(
+        tt_device_,
+        buffer_va,
+        buffer_size,
+        device_io_addr,
+        communication_id_,
+        std::move(deleter),
+        noc_addr,
+        device_access);
+
+    // The buffer owns the pin now.
+    unpin_guard.disarm();
+    return buffer;
+}
+
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
     ZoneScopedC(tracy::Color::Yellow);
@@ -447,8 +534,8 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
             error::RuntimeError,
             fmt::format("Failed to allocate sysmem buffer of size {:#x} bytes with mmap.", sysmem_buffer_size));
     }
-    // This mapping belongs to the buffer, so hand it a deleter that frees it. mmap returns a page-aligned
-    // address, so the pointer the deleter receives is the one to munmap.
+    // This mapping belongs to the buffer, so it is released along with the pinning. mmap returns a
+    // page-aligned address, so the pointer the deleter receives is the one to munmap.
     const size_t mapping_size = sysmem_buffer_size;
     const SysmemBuffer::Deleter release_mapping = [mapping_size](void *aligned_va) {
         if (munmap(aligned_va, mapping_size) != 0) {
@@ -461,12 +548,10 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
         }
     };
 
-    // Nothing owns the mapping until the buffer is constructed, and constructing it pins the pages and can
-    // throw, so release the mapping ourselves on that path.
     try {
-        return std::make_unique<SysmemBuffer>(
-            tt_device_, mapping, sysmem_buffer_size, map_to_noc, DeviceBufferAccess::READ_WRITE, release_mapping);
+        return pin_and_wrap(mapping, sysmem_buffer_size, map_to_noc, DeviceBufferAccess::READ_WRITE, release_mapping);
     } catch (...) {
+        // Nothing owns the mmap yet, so free it here rather than leaking it.
         release_mapping(mapping);
         throw;
     }
@@ -475,7 +560,8 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess device_access) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc, device_access);
+    // The caller owns this memory, so the buffer only unpins it.
+    return pin_and_wrap(buffer, sysmem_buffer_size, map_to_noc, device_access, {});
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -9,10 +9,12 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <tt-logger/tt-logger.hpp>
 #include <vector>
 
 #include "hugepage.hpp"
@@ -97,10 +99,6 @@ void SimulationSysmemManager::unpin_or_unmap_sysmem() {
         std::lock_guard<std::mutex> lock(registry_->mutex);
         registry_->buffers.clear();
     }
-    for (const auto& [allocation, allocation_size] : owned_allocations_) {
-        munmap(allocation, allocation_size);
-    }
-    owned_allocations_.clear();
     hugepage_mapping_per_channel.clear();
     if (system_memory_ != nullptr) {
         munmap(system_memory_, system_memory_size_);
@@ -157,15 +155,42 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     void* mapping =
         mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
     UMD_ASSERT(mapping != MAP_FAILED, error::RuntimeError, "Simulation sysmem buffer mmap() failed");
-    {
-        std::lock_guard<std::mutex> lock(registry_->mutex);
-        owned_allocations_.push_back({mapping, sysmem_buffer_size});
+    // This mapping belongs to the buffer, so it is released along with the registry entry. mmap returns
+    // a page-aligned address, so the pointer the deleter receives is the one to munmap.
+    const size_t mapping_size = sysmem_buffer_size;
+    const SysmemBuffer::Deleter release_mapping = [mapping_size](void* aligned_va) {
+        if (munmap(aligned_va, mapping_size) != 0) {
+            log_warning(
+                LogUMD,
+                "Failed to munmap simulation sysmem buffer of size {:#x} at {:p}: {}.",
+                mapping_size,
+                aligned_va,
+                strerror(errno));
+        }
+    };
+
+    try {
+        return register_and_wrap(
+            mapping, sysmem_buffer_size, map_to_noc, DeviceBufferAccess::READ_WRITE, release_mapping);
+    } catch (...) {
+        // Nothing owns the mmap yet, so free it here rather than leaking it.
+        release_mapping(mapping);
+        throw;
     }
-    return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     void* buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess device_access) {
+    // The caller owns this memory, so the buffer only drops the registry entry.
+    return register_and_wrap(buffer, sysmem_buffer_size, map_to_noc, device_access, {});
+}
+
+std::unique_ptr<SysmemBuffer> SimulationSysmemManager::register_and_wrap(
+    void* buffer,
+    size_t sysmem_buffer_size,
+    const bool map_to_noc,
+    DeviceBufferAccess device_access,
+    SysmemBuffer::Deleter release_backing_memory) {
     static const auto page_size = sysconf(_SC_PAGESIZE);
     const uint64_t mapped_size = align_up(sysmem_buffer_size, page_size);
 
@@ -183,13 +208,10 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     // Capture a weak_ptr so the unmap callback is a safe no-op if the manager
     // has already been destroyed (unpin_or_unmap_sysmem clears the registry).
     std::weak_ptr<MappedBufferRegistry> weak_reg = registry_;
-    return std::make_unique<SysmemBuffer>(
-        buffer,
-        sysmem_buffer_size,
-        device_io_addr,
-        communication_id_,
-        noc_addr,
-        [weak_reg, device_io_addr](void*) {
+    // The buffer's deleter drops the registry entry, then releases the backing memory if this manager
+    // allocated it.
+    SysmemBuffer::Deleter deleter =
+        [weak_reg, device_io_addr, release = std::move(release_backing_memory)](void* aligned_va) {
             if (auto reg = weak_reg.lock()) {
                 std::lock_guard<std::mutex> lock(reg->mutex);
                 reg->buffers.erase(
@@ -201,7 +223,19 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
                         }),
                     reg->buffers.end());
             }
-        },
+            if (release) {
+                release(aligned_va);
+            }
+        };
+
+    return create_buffer(
+        /*tt_device=*/nullptr,
+        buffer,
+        sysmem_buffer_size,
+        device_io_addr,
+        communication_id_,
+        std::move(deleter),
+        noc_addr,
         device_access);
 }
 

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -48,69 +48,40 @@ SysmemBuffer::Deleter make_non_throwing(SysmemBuffer::Deleter deleter) {
 
 }  // namespace
 
+SysmemBuffer::AlignedRange SysmemBuffer::page_align(void* buffer_va, size_t buffer_size) {
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t va = reinterpret_cast<uint64_t>(buffer_va);
+    const uint64_t base = va & ~(page_size - 1);
+    AlignedRange range{};
+    range.base = reinterpret_cast<void*>(base);
+    range.offset_from_base = va - base;
+    range.mapped_size = (buffer_size + range.offset_from_base + page_size - 1) & ~(page_size - 1);
+    return range;
+}
+
 SysmemBuffer::SysmemBuffer(
     TTDevice* tt_device,
     void* buffer_va,
     size_t buffer_size,
-    bool map_to_noc,
-    DeviceBufferAccess device_access,
-    Deleter release_backing_memory) :
-    pci_device_(tt_device->get_pci_device()),
-    tt_device_(tt_device),
-    buffer_va_(buffer_va),
-    mapped_buffer_size_(buffer_size),
-    buffer_size_(buffer_size),
-    device_access_(device_access),
-    communication_id_(tt_device->get_communication_device_id()) {
-    UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
-    align_address_and_size();
-    if (map_to_noc) {
-        std::tie(noc_addr_, device_io_addr_) =
-            pci_device_->map_buffer_to_noc(buffer_va_, mapped_buffer_size_, device_access_);
-    } else {
-        device_io_addr_ = pci_device_->map_for_dma(buffer_va_, mapped_buffer_size_, device_access_);
-        noc_addr_ = std::nullopt;
-    }
-    // Compose the full deleter now that the buffer is aligned and pinned: always unpin, then release the
-    // backing memory if this buffer owns it.
-    system_memory_ptr_ = std::unique_ptr<void, Deleter>(
-        buffer_va_,
-        [pci_device = pci_device_,
-         mapped_size = mapped_buffer_size_,
-         iova = device_io_addr_,
-         release = make_non_throwing(std::move(release_backing_memory))](void* aligned_va) {
-            try {
-                pci_device->unmap_for_dma(aligned_va, mapped_size);
-            } catch (...) {
-                log_warning(LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_size, iova);
-            }
-            release(aligned_va);
-        });
-    TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
-}
-
-SysmemBuffer::SysmemBuffer(
-    void* buffer_va,
-    size_t buffer_size,
     uint64_t device_io_addr,
     int communication_id,
-    std::optional<uint64_t> noc_addr,
     Deleter deleter,
+    std::optional<uint64_t> noc_addr,
     DeviceBufferAccess device_access,
     NocBinder noc_binder) :
-    pci_device_(nullptr),
-    tt_device_(nullptr),
-    buffer_va_(buffer_va),
-    mapped_buffer_size_(buffer_size),
+    tt_device_(tt_device),
     buffer_size_(buffer_size),
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
     noc_binder_(std::move(noc_binder)),
     device_access_(device_access),
     communication_id_(communication_id) {
-    align_address_and_size();
+    const AlignedRange range = page_align(buffer_va, buffer_size);
+    buffer_va_ = range.base;
+    mapped_buffer_size_ = range.mapped_size;
+    offset_from_aligned_addr_ = range.offset_from_base;
+
     system_memory_ptr_ = std::unique_ptr<void, Deleter>(buffer_va_, make_non_throwing(std::move(deleter)));
-    // Pair with TracyFreeN in the destructor so Tracy sees balanced alloc/free.
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
 }
 
@@ -148,14 +119,6 @@ SysmemBuffer::~SysmemBuffer() {
     TracyFreeN(buffer_va_, "SysmemBuffer");
     // Destroying system_memory_ptr_ runs the deleter composed at construction: unpin, and free the
     // backing memory if this buffer owns it.
-}
-
-void SysmemBuffer::align_address_and_size() {
-    static const auto page_size = sysconf(_SC_PAGESIZE);
-    uint64_t aligned_buffer_va = reinterpret_cast<uint64_t>(buffer_va_) & ~(page_size - 1);
-    offset_from_aligned_addr_ = reinterpret_cast<uint64_t>(buffer_va_) - aligned_buffer_va;
-    buffer_va_ = reinterpret_cast<void*>(aligned_buffer_va);
-    mapped_buffer_size_ = (mapped_buffer_size_ + offset_from_aligned_addr_ + page_size - 1) & ~(page_size - 1);
 }
 
 void SysmemBuffer::write_to_sysmem(const void* src, const size_t size, const size_t offset) {

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -109,6 +110,24 @@ TEST(ApiSimulationSysmemManager, TestFourChannels) {
     }
 }
 
+namespace {
+
+// SysmemBuffer's constructor is private to allocators. Tests that need a hand-built buffer — with a
+// specific deleter, NOC address or binder — go through a minimal allocator of their own rather than
+// weakening the encapsulation.
+class TestBufferFactory : public SystemMemoryAllocator {
+public:
+    std::unique_ptr<SysmemBuffer> allocate_buffer(size_t, bool) override { return nullptr; }
+
+    std::unique_ptr<SysmemBuffer> map_user_buffer(void*, size_t, bool, DeviceBufferAccess) override { return nullptr; }
+
+    int get_communication_id() const override { return 0; }
+
+    using SystemMemoryAllocator::create_buffer;
+};
+
+}  // namespace
+
 // A buffer owns its memory through a deleter composed at construction. The deleter must run exactly
 // once, and it must receive the page-aligned start of the mapping rather than the caller's VA — that
 // is the address the pages were pinned at and the one that has to be released.
@@ -132,11 +151,16 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
     }
 
     {
-        SysmemBuffer buffer(
-            user_va, 128, /*device_io_addr=*/0x1000, /*communication_id=*/7, std::nullopt, deleter.AsStdFunction());
+        auto buffer = TestBufferFactory::create_buffer(
+            /*tt_device=*/nullptr,
+            user_va,
+            128,
+            /*device_io_addr=*/0x1000,
+            /*communication_id=*/7,
+            deleter.AsStdFunction());
 
-        EXPECT_EQ(buffer.get_buffer_va(), user_va);
-        EXPECT_EQ(buffer.get_buffer_size(), 128u);
+        EXPECT_EQ(buffer->get_buffer_va(), user_va);
+        EXPECT_EQ(buffer->get_buffer_size(), 128u);
         buffer_still_alive.Call();
     }
 }
@@ -146,19 +170,21 @@ TEST(ApiSimulationSysmemManager, BufferDeleterRunsOnceWithAlignedStart) {
 TEST(ApiSimulationSysmemManager, BindNocAddressIsNoOpWhenAlreadyBound) {
     std::vector<uint8_t> backing(4096, 0);
 
-    SysmemBuffer buffer(
+    auto buffer = TestBufferFactory::create_buffer(
+        /*tt_device=*/nullptr,
         backing.data(),
         backing.size(),
         /*device_io_addr=*/0x1000,
         /*communication_id=*/2,
+        SysmemBuffer::Deleter{},
         std::optional<uint64_t>(0x1234));
 
-    EXPECT_NO_THROW(buffer.bind_noc_address());
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+    EXPECT_NO_THROW(buffer->bind_noc_address());
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0x1234u);
 
     // Idempotent.
-    EXPECT_NO_THROW(buffer.bind_noc_address());
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+    EXPECT_NO_THROW(buffer->bind_noc_address());
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0x1234u);
 }
 
 // An allocator that can bind after the fact injects a binder. bind_noc_address() must run it exactly
@@ -171,26 +197,27 @@ TEST(ApiSimulationSysmemManager, BindNocAddressRunsInjectedBinderOnce) {
     // on the second bind_noc_address() fail here.
     EXPECT_CALL(binder, Call()).WillOnce(Return(0xDEADBEEF));
 
-    SysmemBuffer buffer(
+    auto buffer = TestBufferFactory::create_buffer(
+        /*tt_device=*/nullptr,
         backing.data(),
         backing.size(),
         /*device_io_addr=*/0x1000,
         /*communication_id=*/2,
-        std::nullopt,
         SysmemBuffer::Deleter{},
+        std::nullopt,
         DeviceBufferAccess::READ_WRITE,
         binder.AsStdFunction());
 
     // Nothing bound yet, so construction cannot have run the binder.
-    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
 
-    buffer.bind_noc_address();
-    ASSERT_TRUE(buffer.get_noc_addr().has_value());
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0xDEADBEEFu);
+    buffer->bind_noc_address();
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0xDEADBEEFu);
 
     // Idempotent: the cached address is returned without running the binder again.
-    buffer.bind_noc_address();
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0xDEADBEEFu);
+    buffer->bind_noc_address();
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0xDEADBEEFu);
 }
 
 // A buffer that is already bound never runs its binder.
@@ -200,37 +227,51 @@ TEST(ApiSimulationSysmemManager, BindNocAddressSkipsBinderWhenAlreadyBound) {
     MockFunction<uint64_t()> binder;
     EXPECT_CALL(binder, Call()).Times(0);
 
-    SysmemBuffer buffer(
+    auto buffer = TestBufferFactory::create_buffer(
+        /*tt_device=*/nullptr,
         backing.data(),
         backing.size(),
         /*device_io_addr=*/0x1000,
         /*communication_id=*/2,
-        std::optional<uint64_t>(0x1234),
         SysmemBuffer::Deleter{},
+        std::optional<uint64_t>(0x1234),
         DeviceBufferAccess::READ_WRITE,
         binder.AsStdFunction());
 
-    buffer.bind_noc_address();
-    EXPECT_EQ(buffer.get_noc_addr().value(), 0x1234u);
+    buffer->bind_noc_address();
+    EXPECT_EQ(buffer->get_noc_addr().value(), 0x1234u);
 }
 
 // A buffer whose pages were not pinned with NOC access can never be given a NOC address, so asking
 // must fail loudly rather than leave the caller believing the buffer is reachable over the NOC.
 TEST(ApiSimulationSysmemManager, BindNocAddressThrowsWhenUnbound) {
     std::vector<uint8_t> backing(4096, 0);
-    SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x1000, /*communication_id=*/2);
+    auto buffer = TestBufferFactory::create_buffer(
+        /*tt_device=*/nullptr,
+        backing.data(),
+        backing.size(),
+        /*device_io_addr=*/0x1000,
+        /*communication_id=*/2,
+        SysmemBuffer::Deleter{});
 
-    EXPECT_FALSE(buffer.get_noc_addr().has_value());
-    EXPECT_THROW(buffer.bind_noc_address(), std::exception);
-    EXPECT_FALSE(buffer.get_noc_addr().has_value());
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
+    EXPECT_THROW(buffer->bind_noc_address(), std::exception);
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
 }
 
 // A buffer given no deleter must still destruct cleanly. unique_ptr with an empty std::function
 // deleter would otherwise throw bad_function_call.
 TEST(ApiSimulationSysmemManager, BufferWithoutDeleterDestructsCleanly) {
     std::vector<uint8_t> backing(4096, 0);
-    EXPECT_NO_THROW(
-        { SysmemBuffer buffer(backing.data(), backing.size(), /*device_io_addr=*/0x2000, /*communication_id=*/1); });
+    EXPECT_NO_THROW({
+        auto buffer = TestBufferFactory::create_buffer(
+            /*tt_device=*/nullptr,
+            backing.data(),
+            backing.size(),
+            /*device_io_addr=*/0x2000,
+            /*communication_id=*/1,
+            SysmemBuffer::Deleter{});
+    });
 }
 
 // The deleter is run while the buffer is being destroyed, so an exception out of it would leave the
@@ -238,14 +279,91 @@ TEST(ApiSimulationSysmemManager, BufferWithoutDeleterDestructsCleanly) {
 TEST(ApiSimulationSysmemManager, ThrowingBufferDeleterDoesNotEscapeDestruction) {
     std::vector<uint8_t> backing(4096, 0);
     EXPECT_NO_THROW({
-        SysmemBuffer buffer(
+        auto buffer = TestBufferFactory::create_buffer(
+            /*tt_device=*/nullptr,
             backing.data(),
             backing.size(),
             /*device_io_addr=*/0x3000,
             /*communication_id=*/1,
-            std::nullopt,
-            [](void*) { throw std::runtime_error("deleter failed"); });
+            SysmemBuffer::Deleter{[](void*) { throw std::runtime_error("deleter failed"); }});
     });
+}
+
+namespace {
+
+// Resident set size in KiB, or 0 if it could not be read.
+size_t read_rss_kib() {
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            return std::stoull(line.substr(line.find_first_of("0123456789")));
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+// allocate_sysmem_buffer() mmaps the backing memory, so the buffer has to free it on destruction.
+// While the manager held the mapping in owned_allocations_ instead, nothing was released until the
+// manager itself went away and every allocation leaked for as long as it lived.
+TEST(ApiSimulationSysmemManager, AllocatedBufferFreesBackingMemory) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, tt::ARCH::WORMHOLE_B0);
+
+    const size_t buf_size = 16ULL << 20;
+    const size_t buf_size_kib = buf_size >> 10;
+    const int iterations = 8;
+
+    // Warm up so one-time allocations do not land inside the measurement.
+    { std::unique_ptr<SysmemBuffer> warmup = sysmem->allocate_sysmem_buffer(buf_size); }
+
+    const size_t rss_before = read_rss_kib();
+    if (rss_before == 0) {
+        GTEST_SKIP() << "Could not read VmRSS from /proc/self/status.";
+    }
+
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    for (int i = 0; i < iterations; i++) {
+        std::unique_ptr<SysmemBuffer> buffer = sysmem->allocate_sysmem_buffer(buf_size);
+        ASSERT_NE(buffer, nullptr);
+        // Touch one byte per page so the whole mapping is resident. Touching only the first page would
+        // leave a leak invisible: RSS would grow by a page per iteration rather than by the buffer size.
+        uint8_t* bytes = static_cast<uint8_t*>(buffer->get_buffer_va());
+        for (size_t offset = 0; offset < buf_size; offset += page_size) {
+            bytes[offset] = static_cast<uint8_t>(i);
+        }
+    }
+
+    const size_t rss_after = read_rss_kib();
+    const size_t growth_kib = rss_after > rss_before ? rss_after - rss_before : 0;
+
+    // Leaking would retain every iteration's mapping. Allow one buffer of slack for allocator noise.
+    EXPECT_LT(growth_kib, buf_size_kib) << "RSS grew by " << growth_kib << " KiB across " << iterations
+                                        << " allocate/destroy cycles of " << buf_size_kib << " KiB each";
+}
+
+// The buffer owns its mapping outright, so it stays usable after the manager that handed it over is
+// gone. While the manager owned the mapping, its destructor munmapped memory a live buffer was still
+// pointing at.
+TEST(ApiSimulationSysmemManager, AllocatedBufferOutlivesItsManager) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, tt::ARCH::WORMHOLE_B0);
+
+    const size_t buf_size = 4096;
+    std::unique_ptr<SysmemBuffer> buffer = sysmem->allocate_sysmem_buffer(buf_size);
+    ASSERT_NE(buffer, nullptr);
+
+    uint8_t* bytes = static_cast<uint8_t*>(buffer->get_buffer_va());
+    std::memset(bytes, 0xA5, buf_size);
+
+    sysmem.reset();
+
+    // Reading and writing here would fault if the manager had unmapped the buffer's pages.
+    for (size_t offset = 0; offset < buf_size; offset++) {
+        ASSERT_EQ(bytes[offset], 0xA5) << "at offset " << offset;
+    }
+    std::memset(bytes, 0x5A, buf_size);
+    EXPECT_EQ(bytes[buf_size - 1], 0x5A);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -22,6 +22,7 @@
 #include "common/microbenchmark_utils.hpp"
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -406,7 +407,7 @@ TEST(MicrobenchmarkIOMMU, Map1GBPagesSysmemBuffers) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
-    TTDevice* tt_device = cluster->get_chip(CHIP_ID)->get_tt_device();
+    SysmemManager* sysmem_manager = cluster->get_chip(CHIP_ID)->get_sysmem_manager();
 
     std::array<void*, NUM_PAGES> mappings{};
     for (size_t page = 0; page < NUM_PAGES; page++) {
@@ -436,7 +437,7 @@ TEST(MicrobenchmarkIOMMU, Map1GBPagesSysmemBuffers) {
     for (int i = 0; i < NUM_EPOCHS; i++) {
         for (size_t page = 0; page < NUM_PAGES; page++) {
             auto now = std::chrono::high_resolution_clock::now();
-            sysmem_buffers[page] = std::make_unique<SysmemBuffer>(tt_device, mappings[page], MAPPING_SIZE, true);
+            sysmem_buffers[page] = sysmem_manager->map_user_buffer(mappings[page], MAPPING_SIZE, /*bind_to_noc=*/true);
             auto end = std::chrono::high_resolution_clock::now();
             map_result.add(end - now, 1, pc);
         }


### PR DESCRIPTION
### Issue
#3249

### Description
Makes `SysmemBuffer` constructible only by an allocator, and moves page pinning out of the buffer into the allocator, so ownership matches the Base API Specification.

Today anyone can build a buffer, and whether it owns its memory is implied by whether a release callable was passed. Under the spec the allocator pins the pages, so it is the one that knows the IOVA and how to release them, and it states the ownership model outright.

Stacked on #3269.

### List of the changes
- Made the `SysmemBuffer` constructor private; `SystemMemoryAllocator` is its friend and constructs through a new protected `create_buffer()`.
- Collapsed the two constructors into one taking an already-pinned mapping; the buffer no longer holds a `PCIDevice`.
- Moved pinning and deleter composition into `SiliconSysmemManager::pin_and_wrap()`, shared by the allocate and map paths.
- Extracted the alignment maths into `SysmemBuffer::page_align()`.
- Routed the IOMMU microbenchmark through `map_user_buffer()`; tests needing a hand-built buffer use a test-local allocator.

### API Changes
This PR has API changes.

- `SysmemBuffer`'s constructors are now private. Buffers come from `SystemMemoryAllocator::allocate_buffer()` or `map_user_buffer()`.
- Added `SysmemBuffer::AlignedRange` and `SysmemBuffer::page_align()`.

### Testing
CI

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/sysmem-remove-deprecated-names