### PR TITLE
[Base API] Implement IoWindow interface in TlbWindow

### DIFF
--- a/device/api/umd/device/io_window/io_window.hpp
+++ b/device/api/umd/device/io_window/io_window.hpp
@@ -96,7 +96,7 @@ public:
      * Updates the underlying hardware mapping so that subsequent read/write operations
      * target the new device address.
      *
-     * Applies IoOrdering::Strict. Callers that need another ordering mode must use the
+     * By default ordering is IoOrdering::Strict. Callers that need another ordering mode must use the
      * two-argument overload below.
      *
      * @param config Device-side target describing the core, address, and optional NOC.
@@ -104,7 +104,7 @@ public:
     virtual void configure(const TargetIoWindowConfig& config) = 0;
 
     /**
-     * @brief Reconfigures the window, selecting the transaction ordering mode explicitly.
+     * @brief Configures the window with the transaction ordering mode explicitly set.
      *
      * @param config Device-side target describing the core, address, and optional NOC.
      * @param ordering Transaction ordering mode to apply to the new mapping.

--- a/device/api/umd/device/io_window/io_window.hpp
+++ b/device/api/umd/device/io_window/io_window.hpp
@@ -96,15 +96,32 @@ public:
      * Updates the underlying hardware mapping so that subsequent read/write operations
      * target the new device address.
      *
+     * Applies IoOrdering::Strict. Callers that need another ordering mode must use the
+     * two-argument overload below.
+     *
      * @param config Device-side target describing the core, address, and optional NOC.
      */
     virtual void configure(const TargetIoWindowConfig& config) = 0;
+
+    /**
+     * @brief Reconfigures the window, selecting the transaction ordering mode explicitly.
+     *
+     * @param config Device-side target describing the core, address, and optional NOC.
+     * @param ordering Transaction ordering mode to apply to the new mapping.
+     */
+    virtual void configure(const TargetIoWindowConfig& config, IoOrdering ordering) = 0;
 
     /**
      * @brief Returns the current device-side target configuration of this window.
      * @return TargetIoWindowConfig The core, address, and optional NOC of the current mapping.
      */
     virtual TargetIoWindowConfig get_target_config() const = 0;
+
+    /**
+     * @brief Returns the transaction ordering mode of the current mapping.
+     * @return IoOrdering The ordering applied by the most recent configure().
+     */
+    virtual IoOrdering get_io_ordering() const = 0;
 
     /**
      * @brief Returns the actual size of this I/O window in bytes.

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -91,6 +91,12 @@ public:
     // When empty (the default), overruns are treated as false alarms and never abort on time alone.
     void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) override;
 
+    // TEMP: keeps the base's IoWindow configure() overloads visible -- the declaration below would
+    // otherwise hide them from UMD-internal callers holding a SiliconTlbWindow rather than an IoWindow.
+    // Goes away together with the configure(tlb_data) override below, once tlb_data leaves the window
+    // API and every caller configures through TargetIoWindowConfig + IoOrdering.
+    using TlbWindow::configure;
+
     // Reconfigures the window and refreshes the cached timeout callback, since the NOC may have changed.
     void configure(const tlb_data& new_config) override;
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -9,8 +9,10 @@
 #include <functional>
 #include <memory>
 
+#include "umd/device/io_window/io_window.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/io_window_config.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -22,21 +24,30 @@ namespace tt::umd {
  * The memory access methods are pure virtual to allow different implementations
  * for silicon (direct memory access) vs simulation (communicator-based access).
  */
-class TlbWindow {
+class TlbWindow : public IoWindow {
 public:
     TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
 
     virtual ~TlbWindow() = default;
 
     // Pure virtual methods for memory access - to be implemented by derived classes.
-    virtual void write16(uint64_t offset, uint16_t value) = 0;
-    virtual uint16_t read16(uint64_t offset) = 0;
-    virtual void write32(uint64_t offset, uint32_t value) = 0;
-    virtual uint32_t read32(uint64_t offset) = 0;
+    void write16(uint64_t offset, uint16_t value) override = 0;
+    uint16_t read16(uint64_t offset) override = 0;
+    void write32(uint64_t offset, uint32_t value) override = 0;
+    uint32_t read32(uint64_t offset) override = 0;
     virtual void write_register(uint64_t offset, const void* data, size_t size) = 0;
     virtual void read_register(uint64_t offset, void* data, size_t size) = 0;
-    virtual void write_block(uint64_t offset, const void* data, size_t size) = 0;
-    virtual void read_block(uint64_t offset, void* data, size_t size) = 0;
+    void write_block(uint64_t offset, const void* data, size_t size) override = 0;
+    void read_block(uint64_t offset, void* data, size_t size) override = 0;
+
+    // IoWindow spec surface.
+    void write_aligned(uint64_t offset, const void* data, size_t size) override;
+    void read_aligned(uint64_t offset, void* data, size_t size) override;
+    void configure(const TargetIoWindowConfig& config) override;
+    void configure(const TargetIoWindowConfig& config, IoOrdering ordering) override;
+    TargetIoWindowConfig get_target_config() const override;
+    IoOrdering get_io_ordering() const override;
+    HostMemoryCaching get_memory_caching_type() const override;
 
     // Shared higher-level methods that use the virtual methods above.
     virtual void read_block_reconfigure(
@@ -125,7 +136,7 @@ public:
 
     // Shared utility methods.
     TlbHandle& handle_ref() const;
-    size_t get_size() const;
+    size_t get_size() const override;
     virtual void configure(const tlb_data& new_config);
     uint64_t get_base_address() const;
 

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -24,6 +24,18 @@ enum class HostMemoryCaching {
 };
 
 /**
+ * @brief Transaction ordering mode for an IoWindow target.
+ *
+ * The enumerator values intentionally match the TLB hardware encoding in tlb_data, so that
+ * translating between the two is a cast rather than a switch.
+ */
+enum class IoOrdering : uint8_t {
+    Relaxed = 0,  ///< No ordering guarantees between transactions.
+    Strict = 1,   ///< Transactions complete in issue order.
+    Posted = 2,   ///< Writes are posted; no completion acknowledgement.
+};
+
+/**
  * @brief Type-safe transaction attributes for an IoWindow target.
  */
 enum class WindowFlags : uint32_t {

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -134,9 +134,21 @@ void TlbWindow::configure(const tlb_data& new_config) {
     offset_from_aligned_addr = new_config.local_offset - (new_config.local_offset & ~(tlb_handle->get_size() - 1));
 }
 
-void TlbWindow::write_aligned(uint64_t offset, const void* data, size_t size) { write_register(offset, data, size); }
+void TlbWindow::write_aligned(uint64_t offset, const void* data, size_t size) {
+    UMD_ASSERT(
+        offset % sizeof(uint32_t) == 0 && size % sizeof(uint32_t) == 0,
+        error::RuntimeError,
+        "write_aligned offset and size must be 4-byte aligned.");
+    write_register(offset, data, size);
+}
 
-void TlbWindow::read_aligned(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
+void TlbWindow::read_aligned(uint64_t offset, void* data, size_t size) {
+    UMD_ASSERT(
+        offset % sizeof(uint32_t) == 0 && size % sizeof(uint32_t) == 0,
+        error::RuntimeError,
+        "read_aligned offset and size must be 4-byte aligned.");
+    read_register(offset, data, size);
+}
 
 void TlbWindow::configure(const TargetIoWindowConfig& config) { configure(config, IoOrdering::Strict); }
 
@@ -147,11 +159,13 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         error::RuntimeError,
         "WindowFlags are not supported by TLB-backed IoWindows.");
 
+    UMD_ASSERT(config.noc.has_value(), error::RuntimeError, "TLB-backed IoWindows must specify a NOC.");
+
     const bool mcast = config.core_end.has_value();
     configure(make_tlb_config(
         config.addr,
         mcast ? config.core_end.value() : config.core_start,
-        config.noc.value_or(NocId::NOC0),
+        config.noc.value(),
         static_cast<uint64_t>(ordering),
         mcast,
         config.core_start));

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -7,15 +7,28 @@
 #include <algorithm>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/io_window_config.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+// IoOrdering carries the TLB hardware encoding directly, so translating between the two is a cast.
+// If these ever diverge, the casts in configure()/get_io_ordering() below become silently wrong.
+// TEMP: these live exactly as long as those casts do, i.e. until tlb_data is gone from the
+// window API and IoOrdering is what callers pass all the way down. tlb_data itself stays either way --
+// it is the hardware register descriptor (see tlb_data::apply_offset) and remains internal to the
+// handle/PCI layer.
+static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
+static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
+static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
 
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
@@ -119,6 +132,52 @@ void TlbWindow::configure(const tlb_data& new_config) {
     aligned_config.local_offset = new_config.local_offset & ~(tlb_handle->get_size() - 1);
     tlb_handle->configure(aligned_config);
     offset_from_aligned_addr = new_config.local_offset - (new_config.local_offset & ~(tlb_handle->get_size() - 1));
+}
+
+void TlbWindow::write_aligned(uint64_t offset, const void* data, size_t size) { write_register(offset, data, size); }
+
+void TlbWindow::read_aligned(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
+
+void TlbWindow::configure(const TargetIoWindowConfig& config) { configure(config, IoOrdering::Strict); }
+
+void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering ordering) {
+    // A TLB mapping has no way to express these; failing loudly beats silently dropping them.
+    UMD_ASSERT(
+        config.flags == WindowFlags::None,
+        error::RuntimeError,
+        "WindowFlags are not supported by TLB-backed IoWindows.");
+
+    const bool mcast = config.core_end.has_value();
+    configure(make_tlb_config(
+        config.addr,
+        mcast ? config.core_end.value() : config.core_start,
+        config.noc.value_or(NocId::NOC0),
+        static_cast<uint64_t>(ordering),
+        mcast,
+        config.core_start));
+}
+
+TargetIoWindowConfig TlbWindow::get_target_config() const {
+    const tlb_data& config = handle_ref().get_config();
+    const tt_xy_pair end_core(config.x_end, config.y_end);
+
+    TargetIoWindowConfig target;
+    if (config.mcast) {
+        target.core_start = tt_xy_pair(config.x_start, config.y_start);
+        target.core_end = end_core;
+    } else {
+        target.core_start = end_core;
+    }
+    // The handle holds the aligned base; the remainder lives in offset_from_aligned_addr.
+    target.addr = get_base_address();
+    target.noc = static_cast<NocId>(config.noc_sel);
+    return target;
+}
+
+IoOrdering TlbWindow::get_io_ordering() const { return static_cast<IoOrdering>(handle_ref().get_config().ordering); }
+
+HostMemoryCaching TlbWindow::get_memory_caching_type() const {
+    return handle_ref().get_tlb_mapping() == TlbMapping::WC ? HostMemoryCaching::WC : HostMemoryCaching::UC;
 }
 
 uint64_t TlbWindow::get_total_offset(uint64_t offset) const { return offset + offset_from_aligned_addr; }

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -15,6 +15,7 @@
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/io_window/io_window.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
@@ -23,6 +24,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/io_window_config.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -517,6 +519,81 @@ TEST_F(TestTlb, TestTlbAccessOutofBounds) {
             0, readback_out_of_bounds_unaligned.data(), readback_out_of_bounds_unaligned.size()))
             << "Reading out of bounds from TLB window should throw an exception";
     }
+}
+
+// Exercises a TLB window purely through the Base API IoWindow interface: every call below goes
+// through an IoWindow& rather than the concrete type, so this fails if TlbWindow ever stops
+// satisfying the spec surface.
+TEST_F(TestTlb, IoWindowInterface) {
+    if (!is_kmd_version_good()) {
+        GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
+    }
+    const ChipId chip = 0;
+    // 2MB is a valid TLB size class on both Wormhole and Blackhole.
+    const size_t window_size = 1 << 21;
+    // Unaligned within the window, so get_target_config() has to reconstruct the sub-window offset.
+    const uint64_t l1_addr = 0x100;
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    PCIDevice* pci_device = cluster->get_tt_device(chip)->get_pci_device();
+    const CoreCoord tensix_core =
+        cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+
+    SiliconTlbWindow tlb_window(pci_device->allocate_tlb(window_size, TlbMapping::WC));
+    IoWindow& window = tlb_window;
+
+    TargetIoWindowConfig target;
+    target.core_start = tt_xy_pair(tensix_core.x, tensix_core.y);
+    target.addr = l1_addr;
+    target.noc = NocId::NOC0;
+    window.configure(target);
+
+    // Host-side properties come from the allocation, not from the target.
+    EXPECT_EQ(window.get_memory_caching_type(), HostMemoryCaching::WC);
+    EXPECT_EQ(window.get_size(), window_size - l1_addr);
+
+    const TargetIoWindowConfig readback_target = window.get_target_config();
+    EXPECT_EQ(readback_target.core_start, target.core_start);
+    EXPECT_FALSE(readback_target.core_end.has_value()) << "Unicast target should not report a multicast grid";
+    EXPECT_EQ(readback_target.addr, l1_addr);
+    EXPECT_EQ(readback_target.noc, NocId::NOC0);
+
+    // The single-argument configure() is documented to apply Strict.
+    EXPECT_EQ(window.get_io_ordering(), IoOrdering::Strict);
+
+    window.write32(0, 0xabcd1234);
+    EXPECT_EQ(window.read32(0), 0xabcd1234u);
+
+    window.write16(4, 0x5678);
+    EXPECT_EQ(window.read16(4), 0x5678u);
+
+    std::vector<uint8_t> block_pattern(0x100);
+    for (size_t i = 0; i < block_pattern.size(); i++) {
+        block_pattern[i] = static_cast<uint8_t>(i);
+    }
+    std::vector<uint8_t> block_readback(block_pattern.size(), 0);
+    window.write_block(0x200, block_pattern.data(), block_pattern.size());
+    window.read_block(0x200, block_readback.data(), block_readback.size());
+    EXPECT_EQ(block_readback, block_pattern);
+
+    std::vector<uint32_t> aligned_pattern(0x40);
+    for (size_t i = 0; i < aligned_pattern.size(); i++) {
+        aligned_pattern[i] = static_cast<uint32_t>(i) | 0xa5000000;
+    }
+    std::vector<uint32_t> aligned_readback(aligned_pattern.size(), 0);
+    const size_t aligned_bytes = aligned_pattern.size() * sizeof(uint32_t);
+    window.write_aligned(0x400, aligned_pattern.data(), aligned_bytes);
+    window.read_aligned(0x400, aligned_readback.data(), aligned_bytes);
+    EXPECT_EQ(aligned_readback, aligned_pattern);
+
+    // Posted is the mode tt-metal needs for the Blackhole DRAM window; make sure it survives configure().
+    window.configure(target, IoOrdering::Posted);
+    EXPECT_EQ(window.get_io_ordering(), IoOrdering::Posted);
+    EXPECT_EQ(window.get_target_config().addr, l1_addr) << "Ordering change should not disturb the target";
+
+    // WindowFlags have no TLB equivalent and must be rejected rather than silently dropped.
+    target.flags = WindowFlags::Atomic;
+    EXPECT_ANY_THROW(window.configure(target));
 }
 
 TEST_F(TestTlb, TLBStaticTensix) {


### PR DESCRIPTION
### Issue
Part of #2875

### Description
TlbWindow now implements the Base API IoWindow interface. Additive only: no consumer changes, no behavior change, nothing removed or renamed.

### List of the changes
 - Added IoOrdering enum in io_window_config.hpp, values matching the tlb_data ordering encoding
 - Added configure with an explicit ordering argument, plus get_io_ordering, to the IoWindow interface
 - TlbWindow derives from IoWindow and implements write_aligned, read_aligned, both configure overloads, get_target_config, get_io_ordering, get_memory_caching_type
 - Added a using declaration in SiliconTlbWindow so its configure override does not hide the new overloads

### Testing
 - Build and new test run locally
 - CI

### API Changes
This PR has API changes.
