### PR TITLE
[Base API] Extract *_reconfigure to free functions over IoWindow&

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(
         chip_helpers/sysmem_buffer.cpp
         chip_helpers/tlb_manager.cpp
         pcie/tlb_window.cpp
+        pcie/io_window_reconfigure.cpp
         pcie/device_memcpy.cpp
         pcie/silicon_tlb_window.cpp
         pcie/silicon_tlb_handle.cpp

--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/io_window_config.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -49,8 +50,10 @@ struct ArchitectureTlbs {
     // Configuration of the window at the given index.
     tlb_configuration get_configuration(uint32_t tlb_index) const;
 
-    // The virtual channel to configure a window with, given what that window will carry.
-    tlb_static_vc get_static_vc(TlbVcDirection direction) const;
+    // The virtual channel to configure a window with, given what that window will carry. Only the
+    // direction field of the flags is read: reads are given one channel and writes another, so
+    // traffic in opposite directions never shares a channel.
+    tlb_static_vc get_static_vc(WindowFlags flags) const;
 };
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch);

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -149,7 +149,7 @@ protected:
         tt_xy_pair core_end,
         NocId noc_id,
         uint64_t ordering,
-        TlbVcDirection direction,
+        WindowFlags flags,
         bool mcast = false,
         tt_xy_pair core_start = {}) const;
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -155,10 +155,6 @@ protected:
 
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;
-
-private:
-    template <typename buffer_pointer, typename io_operation>
-    void transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -28,7 +28,7 @@ namespace tt::umd {
 class PCIDevice;
 class TlbWindow;
 struct tlb_data;
-enum class TlbVcDirection;
+enum class WindowFlags : uint32_t;
 
 /**
  * PcieProtocol implements DeviceProtocol, PcieInterface, and DmaInterface for PCIe-connected
@@ -97,7 +97,7 @@ private:
         uint64_t addr,
         tt_xy_pair core_end,
         NocId noc_id,
-        TlbVcDirection direction,
+        WindowFlags flags,
         std::optional<tt_xy_pair> core_start = std::nullopt);
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
     bool dma_transfer_zero_copy(uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -36,6 +36,20 @@ enum class IoOrdering : uint8_t {
 };
 
 /**
+ * @brief Traffic an IoWindow mapping carries until the next configure().
+ *
+ * A window reconfigured before every transfer can commit to one direction, which lets an
+ * implementation route reads and writes over separate interconnect resources and so keep writes to a
+ * target ordered against each other. A window that serves both from one mapping asks for
+ * Bidirectional. Implementations with nothing to gain from the distinction ignore it.
+ */
+enum class IoDirection : uint8_t {
+    Bidirectional,  ///< Mapping serves both reads and writes.
+    Read,           ///< Mapping serves reads until it is configured again.
+    Write,          ///< Mapping serves writes until it is configured again.
+};
+
+/**
  * @brief Type-safe transaction attributes for an IoWindow target.
  */
 enum class WindowFlags : uint32_t {
@@ -78,6 +92,7 @@ struct TargetIoWindowConfig {
     uint64_t addr;                            ///< Destination address on the target core(s).
     std::optional<NocId> noc = std::nullopt;  ///< Optional routing selection.
     WindowFlags flags = WindowFlags::None;    ///< Transaction attributes.
+    IoDirection direction = IoDirection::Bidirectional;  ///< Traffic the mapping will carry.
 };
 
 /**

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -36,26 +36,25 @@ enum class IoOrdering : uint8_t {
 };
 
 /**
- * @brief Traffic an IoWindow mapping carries until the next configure().
- *
- * A window reconfigured before every transfer can commit to one direction, which lets an
- * implementation route reads and writes over separate interconnect resources and so keep writes to a
- * target ordered against each other. A window that serves both from one mapping asks for
- * Bidirectional. Implementations with nothing to gain from the distinction ignore it.
- */
-enum class IoDirection : uint8_t {
-    Bidirectional,  ///< Mapping serves both reads and writes.
-    Read,           ///< Mapping serves reads until it is configured again.
-    Write,          ///< Mapping serves writes until it is configured again.
-};
-
-/**
  * @brief Type-safe transaction attributes for an IoWindow target.
+ *
+ * Bits 2-3 form the direction field, holding the traffic the mapping carries until it is configured
+ * again. A mapping reconfigured before every transfer can commit to one direction, which lets an
+ * implementation route reads and writes over separate interconnect resources and so keep writes to a
+ * target ordered against each other. Zero — the default — is bidirectional: a mapping that serves
+ * both without being configured in between, and so cannot be given a resource of its own.
+ * Implementations with nothing to gain from the distinction ignore the field.
  */
 enum class WindowFlags : uint32_t {
     None = 0,
     Atomic = 1 << 0,  ///< Issue transaction as atomic on the target interconnect.
     Snoop = 1 << 1,   ///< Mark transaction as snoopable for cache coherency.
+
+    Bidirectional = 0 << 2,   ///< Mapping serves both reads and writes. Default.
+    UnicastWrite = 1 << 2,    ///< Mapping serves writes to a single core.
+    UnicastRead = 2 << 2,     ///< Mapping serves reads from a single core.
+    MulticastWrite = 3 << 2,  ///< Mapping serves writes to a core range.
+    DirectionMask = 3 << 2,   ///< Selects the direction field out of a set of flags.
 };
 
 constexpr WindowFlags operator|(WindowFlags lhs, WindowFlags rhs) noexcept {
@@ -91,8 +90,7 @@ struct TargetIoWindowConfig {
         std::nullopt;                         ///< Lower-right corner of a multicast grid, or nullopt for unicast.
     uint64_t addr;                            ///< Destination address on the target core(s).
     std::optional<NocId> noc = std::nullopt;  ///< Optional routing selection.
-    WindowFlags flags = WindowFlags::None;    ///< Transaction attributes.
-    IoDirection direction = IoDirection::Bidirectional;  ///< Traffic the mapping will carry.
+    WindowFlags flags = WindowFlags::None;    ///< Transaction attributes, including the direction field.
 };
 
 /**

--- a/device/api/umd/device/types/tlb.hpp
+++ b/device/api/umd/device/types/tlb.hpp
@@ -28,16 +28,6 @@ struct tlb_offsets {
     uint32_t static_vc_class_end;
 };
 
-// What a TLB window will carry. A window carrying a single direction can be given a virtual channel
-// of its own, so reads and writes never share one. BIDIRECTIONAL is for windows that stay
-// configured across both.
-enum class TlbVcDirection {
-    UNICAST_WRITE,
-    UNICAST_READ,
-    MULTICAST_WRITE,
-    BIDIRECTIONAL,
-};
-
 // The virtual channel a TLB window is configured to use.
 struct tlb_static_vc {
     uint64_t static_vc = 0;

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -39,8 +39,9 @@ tlb_configuration ArchitectureTlbs::get_configuration(const uint32_t tlb_index) 
     UMD_THROW(error::RuntimeError, fmt::format("No TLB window with index {}.", tlb_index));
 }
 
-tlb_static_vc ArchitectureTlbs::get_static_vc(const TlbVcDirection direction) const {
-    if (!static_vc_is_configurable || direction == TlbVcDirection::BIDIRECTIONAL) {
+tlb_static_vc ArchitectureTlbs::get_static_vc(const WindowFlags flags) const {
+    const WindowFlags direction = flags & WindowFlags::DirectionMask;
+    if (!static_vc_is_configurable || direction == WindowFlags::Bidirectional) {
         // Nothing left to choose: either the architecture wires the channel up itself, or the window
         // carries both directions and so cannot be given one of its own.
         return {.static_vc = use_static_vc};
@@ -50,8 +51,8 @@ tlb_static_vc ArchitectureTlbs::get_static_vc(const TlbVcDirection direction) co
     // and multicast writes get a class of their own.
     return {
         .static_vc = 1,
-        .static_vc_buddy = direction == TlbVcDirection::UNICAST_READ ? 1ULL : 0ULL,
-        .static_vc_class = direction == TlbVcDirection::MULTICAST_WRITE ? 0b10ULL : 0b00ULL,
+        .static_vc_buddy = direction == WindowFlags::UnicastRead ? 1ULL : 0ULL,
+        .static_vc_class = direction == WindowFlags::MulticastWrite ? 0b10ULL : 0b00ULL,
     };
 }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
@@ -258,8 +259,14 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
         tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
-        get_cached_wc_tlb_window()->write_block_reconfigure(
-            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed);
+        write_block_reconfigure(
+            *get_cached_wc_tlb_window(),
+            src,
+            translated_core,
+            l1_dest,
+            size,
+            get_selected_noc_id(),
+            IoOrdering::Relaxed);
     }
 }
 
@@ -284,8 +291,14 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
         tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
-        get_cached_wc_tlb_window()->read_block_reconfigure(
-            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed);
+        read_block_reconfigure(
+            *get_cached_wc_tlb_window(),
+            dest,
+            translated_core,
+            l1_src,
+            size,
+            get_selected_noc_id(),
+            IoOrdering::Relaxed);
     }
 }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -341,8 +341,7 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.set_static_vc(
-        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_WRITE));
+    config.set_static_vc(get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(WindowFlags::UnicastWrite));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -373,8 +372,7 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.set_static_vc(
-        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_READ));
+    config.set_static_vc(get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(WindowFlags::UnicastRead));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 

--- a/device/pcie/io_window_reconfigure.cpp
+++ b/device/pcie/io_window_reconfigure.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pcie/io_window_reconfigure.hpp"
+
+#include <algorithm>
+#include <optional>
+
+namespace tt::umd {
+
+namespace {
+
+// Each chunk is configured immediately before it is transferred, so the mapping only ever carries one
+// direction of traffic and says so. The direction follows from the transfer rather than from the caller.
+template <typename buffer_pointer, typename io_operation>
+void transfer_and_reconfigure(
+    IoWindow& window,
+    TargetIoWindowConfig config,
+    IoOrdering ordering,
+    buffer_pointer buffer,
+    size_t size,
+    io_operation op) {
+    while (size > 0) {
+        window.configure(config, ordering);
+        size_t transfer_size = std::min(size, window.get_size());
+        op(buffer, transfer_size);
+        size -= transfer_size;
+        config.addr += transfer_size;
+        buffer += transfer_size;
+    }
+}
+
+}  // namespace
+
+void read_block_reconfigure(
+    IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        ordering,
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [&window](uint8_t* buf, size_t sz) { window.read_block(0, buf, sz); });
+}
+
+void write_block_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_block(0, buf, sz); });
+}
+
+void read_register_reconfigure(
+    IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        ordering,
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [&window](uint8_t* buf, size_t sz) { window.read_aligned(0, buf, sz); });
+}
+
+void write_register_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_aligned(0, buf, sz); });
+}
+
+void noc_multicast_write_reconfigure(
+    IoWindow& window,
+    const void* src,
+    size_t size,
+    tt_xy_pair core_start,
+    tt_xy_pair core_end,
+    uint64_t addr,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(src),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_block(0, buf, sz); });
+}
+
+}  // namespace tt::umd

--- a/device/pcie/io_window_reconfigure.cpp
+++ b/device/pcie/io_window_reconfigure.cpp
@@ -37,7 +37,7 @@ void read_block_reconfigure(
     IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastRead},
         ordering,
         static_cast<uint8_t*>(mem_ptr),
         size,
@@ -54,7 +54,7 @@ void write_block_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastWrite},
         ordering,
         static_cast<const uint8_t*>(mem_ptr),
         size,
@@ -65,7 +65,7 @@ void read_register_reconfigure(
     IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastRead},
         ordering,
         static_cast<uint8_t*>(mem_ptr),
         size,
@@ -82,7 +82,7 @@ void write_register_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastWrite},
         ordering,
         static_cast<const uint8_t*>(mem_ptr),
         size,
@@ -100,7 +100,7 @@ void noc_multicast_write_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::MulticastWrite},
         ordering,
         static_cast<const uint8_t*>(src),
         size,

--- a/device/pcie/io_window_reconfigure.hpp
+++ b/device/pcie/io_window_reconfigure.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/io_window/io_window.hpp"
+#include "umd/device/types/io_window_config.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+
+/**
+ * Chunked block read/write against an IoWindow: reconfigures the window to (core, addr) and
+ * transfers up to window.get_size() bytes per iteration, advancing addr and the buffer pointer
+ * until size is exhausted.
+ *
+ * Postcondition: the window is left configured to the last chunk transferred, not restored to
+ * whatever it was configured to before the call. Each chunk is configured for the direction the
+ * transfer runs in, so a window whose hardware separates read and write traffic gets to do so.
+ */
+void read_block_reconfigure(
+    IoWindow& window,
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void write_block_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+// Register reconfigure functions transfer through read_aligned/write_aligned. Alignment
+// enforcement is the caller's responsibility.
+void read_register_reconfigure(
+    IoWindow& window,
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void write_register_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void noc_multicast_write_reconfigure(
+    IoWindow& window,
+    const void* src,
+    size_t size,
+    tt_xy_pair core_start,
+    tt_xy_pair core_end,
+    uint64_t addr,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+}  // namespace tt::umd

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -30,25 +30,6 @@ static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
 static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
 static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
 
-namespace {
-
-// Pinning a mapping to a static VC keeps its writes ordered, but a single VC carrying both directions
-// trips a hardware bug, so only a mapping that commits to one direction can be pinned. Multicast
-// writes take their own VC class, which is why the write case splits on mcast.
-TlbVcDirection to_tlb_vc_direction(const IoDirection direction, const bool mcast) {
-    switch (direction) {
-        case IoDirection::Read:
-            return TlbVcDirection::UNICAST_READ;
-        case IoDirection::Write:
-            return mcast ? TlbVcDirection::MULTICAST_WRITE : TlbVcDirection::UNICAST_WRITE;
-        case IoDirection::Bidirectional:
-        default:
-            return TlbVcDirection::BIDIRECTIONAL;
-    }
-}
-
-}  // namespace
-
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
     aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
@@ -61,7 +42,7 @@ tlb_data TlbWindow::make_tlb_config(
     tt_xy_pair core_end,
     NocId noc_id,
     uint64_t ordering,
-    TlbVcDirection direction,
+    WindowFlags flags,
     bool mcast,
     tt_xy_pair core_start) const {
     tlb_data config{};
@@ -70,7 +51,7 @@ tlb_data TlbWindow::make_tlb_config(
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = ordering;
-    config.set_static_vc(get_architecture_tlbs(handle_ref().get_arch()).get_static_vc(direction));
+    config.set_static_vc(get_architecture_tlbs(handle_ref().get_arch()).get_static_vc(flags));
     if (mcast) {
         config.mcast = true;
         config.x_start = core_start.x;
@@ -171,11 +152,12 @@ void TlbWindow::read_aligned(uint64_t offset, void* data, size_t size) {
 void TlbWindow::configure(const TargetIoWindowConfig& config) { configure(config, IoOrdering::Strict); }
 
 void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering ordering) {
-    // A TLB mapping has no way to express these; failing loudly beats silently dropping them.
+    // A TLB mapping has no way to express anything outside the direction field; failing loudly beats
+    // silently dropping it.
     UMD_ASSERT(
-        config.flags == WindowFlags::None,
+        (config.flags & ~WindowFlags::DirectionMask) == WindowFlags::None,
         error::RuntimeError,
-        "WindowFlags are not supported by TLB-backed IoWindows.");
+        "WindowFlags other than the direction field are not supported by TLB-backed IoWindows.");
 
     UMD_ASSERT(config.noc.has_value(), error::RuntimeError, "TLB-backed IoWindows must specify a NOC.");
 
@@ -185,7 +167,7 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         mcast ? config.core_end.value() : config.core_start,
         config.noc.value(),
         static_cast<uint64_t>(ordering),
-        to_tlb_vc_direction(config.direction, mcast),
+        config.flags,
         mcast,
         config.core_start));
 }

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -4,13 +4,12 @@
 
 #include "umd/device/pcie/tlb_window.hpp"
 
-#include <algorithm>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <utility>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -30,6 +29,25 @@ namespace tt::umd {
 static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
 static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
 static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
+
+namespace {
+
+// Pinning a mapping to a static VC keeps its writes ordered, but a single VC carrying both directions
+// trips a hardware bug, so only a mapping that commits to one direction can be pinned. Multicast
+// writes take their own VC class, which is why the write case splits on mcast.
+TlbVcDirection to_tlb_vc_direction(const IoDirection direction, const bool mcast) {
+    switch (direction) {
+        case IoDirection::Read:
+            return TlbVcDirection::UNICAST_READ;
+        case IoDirection::Write:
+            return mcast ? TlbVcDirection::MULTICAST_WRITE : TlbVcDirection::UNICAST_WRITE;
+        case IoDirection::Bidirectional:
+        default:
+            return TlbVcDirection::BIDIRECTIONAL;
+    }
+}
+
+}  // namespace
 
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
@@ -61,52 +79,28 @@ tlb_data TlbWindow::make_tlb_config(
     return config;
 }
 
-template <typename buffer_pointer, typename io_operation>
-void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op) {
-    while (size > 0) {
-        configure(config);
-        size_t transfer_size = std::min(size, get_size());
-        op(buffer, transfer_size);
-        size -= transfer_size;
-        config.local_offset += transfer_size;
-        buffer += transfer_size;
-    }
-}
-
+// Thin forwarders onto the free-function family in io_window_reconfigure.hpp, kept as virtual
+// members solely so SiliconTlbWindow's safe_* variants (execute_safe, taking a pointer-to-member)
+// keep working unchanged. Callers with no safe/unsafe distinction to make should call the free
+// functions directly instead of going through a TlbWindow.
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
-        static_cast<uint8_t*>(mem_ptr),
-        size,
-        [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
+    tt::umd::read_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
-        static_cast<uint8_t*>(mem_ptr),
-        size,
-        [this](uint8_t* buf, size_t sz) { read_register(0, buf, sz); });
+    tt::umd::read_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
-        static_cast<const uint8_t*>(mem_ptr),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+    tt::umd::write_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
-        static_cast<const uint8_t*>(mem_ptr),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_register(0, buf, sz); });
+    tt::umd::write_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::noc_multicast_write_reconfigure(
@@ -117,11 +111,8 @@ void TlbWindow::noc_multicast_write_reconfigure(
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core_end, noc_id, ordering, TlbVcDirection::MULTICAST_WRITE, true, core_start),
-        static_cast<const uint8_t*>(src),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+    tt::umd::noc_multicast_write_reconfigure(
+        *this, src, size, core_start, core_end, addr, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -174,7 +165,7 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         mcast ? config.core_end.value() : config.core_start,
         config.noc.value(),
         static_cast<uint64_t>(ordering),
-        TlbVcDirection::BIDIRECTIONAL,
+        to_tlb_vc_direction(config.direction, mcast),
         mcast,
         config.core_start));
 }

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -85,21 +85,37 @@ tlb_data TlbWindow::make_tlb_config(
 // functions directly instead of going through a TlbWindow.
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::read_block_reconfigure");
     tt::umd::read_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::read_register_reconfigure");
     tt::umd::read_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::write_block_reconfigure");
     tt::umd::write_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::write_register_reconfigure");
     tt::umd::write_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
@@ -111,6 +127,10 @@ void TlbWindow::noc_multicast_write_reconfigure(
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::noc_multicast_write_reconfigure");
     tt::umd::noc_multicast_write_reconfigure(
         *this, src, size, core_start, core_end, addr, noc_id, static_cast<IoOrdering>(ordering));
 }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -18,6 +18,7 @@
 #include <variant>
 #include <vector>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -103,7 +104,7 @@ void PcieProtocol::write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_
     if constexpr (safe) {
         get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        write_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -112,7 +113,7 @@ void PcieProtocol::read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr,
     if constexpr (safe) {
         get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        read_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -122,7 +123,7 @@ void PcieProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t add
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_write_register_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->write_register_reconfigure(mem_ptr, core, addr, size, noc_id);
+        write_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -132,7 +133,7 @@ void PcieProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
+        read_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -156,8 +157,7 @@ void PcieProtocol::noc_multicast_write(
         get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(
             src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
     } else {
-        get_cached_tlb_window()->noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
+        noc_multicast_write_reconfigure(*get_cached_tlb_window(), src, size, core_start, core_end, addr, noc_id);
     }
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -260,7 +260,7 @@ bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
+        create_dma_tlb_config(dst_addr, core, noc_id, WindowFlags::UnicastWrite),
         DmaDirection::H2D);
 }
 
@@ -269,7 +269,7 @@ bool PcieProtocol::dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pai
         dst,
         size,
         src_addr,
-        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        create_dma_tlb_config(src_addr, core, noc_id, WindowFlags::UnicastRead),
         DmaDirection::D2H);
 }
 
@@ -279,7 +279,7 @@ bool PcieProtocol::dma_multicast_write(
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
+        create_dma_tlb_config(dst_addr, core_end, noc_id, WindowFlags::MulticastWrite, core_start),
         DmaDirection::H2D);
 }
 
@@ -289,7 +289,7 @@ bool PcieProtocol::dma_read_zero_copy(
         dst_iova,
         size,
         src_addr,
-        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        create_dma_tlb_config(src_addr, core, noc_id, WindowFlags::UnicastRead),
         DmaDirection::D2H);
 }
 
@@ -299,7 +299,7 @@ bool PcieProtocol::dma_write_zero_copy(
         src_iova,
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
+        create_dma_tlb_config(dst_addr, core, noc_id, WindowFlags::UnicastWrite),
         DmaDirection::H2D);
 }
 
@@ -309,7 +309,7 @@ bool PcieProtocol::dma_multicast_write_zero_copy(
         src_iova,
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
+        create_dma_tlb_config(dst_addr, core_end, noc_id, WindowFlags::MulticastWrite, core_start),
         DmaDirection::H2D);
 }
 
@@ -318,14 +318,14 @@ bool PcieProtocol::dma_multicast_write_zero_copy(
 // (the target core). When core_start is provided, the transfer becomes a multicast to the
 // core range [core_start, core_end].
 tlb_data PcieProtocol::create_dma_tlb_config(
-    uint64_t addr, tt_xy_pair core_end, NocId noc_id, TlbVcDirection direction, std::optional<tt_xy_pair> core_start) {
+    uint64_t addr, tt_xy_pair core_end, NocId noc_id, WindowFlags flags, std::optional<tt_xy_pair> core_start) {
     tlb_data config{};
     config.local_offset = addr;
     config.x_end = core_end.x;
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = tlb_data::Relaxed;
-    config.set_static_vc(get_architecture_tlbs(pci_device_->get_arch()).get_static_vc(direction));
+    config.set_static_vc(get_architecture_tlbs(pci_device_->get_arch()).get_static_vc(flags));
     if (core_start) {
         config.x_start = core_start->x;
         config.y_start = core_start->y;

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -12,6 +12,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -169,7 +170,7 @@ void SimulationTTDevice::host_write(CoreCoord core, uint64_t addr, const void* m
         return;
     }
     if (should_use_cached_tlb_window()) {
-        cached_tlb_window_->write_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+        write_block_reconfigure(*cached_tlb_window_, mem_ptr, translated_core, addr, size, get_selected_noc_id());
     } else {
         tile_write_bytes(translated_core, addr, mem_ptr, size);
     }
@@ -185,7 +186,7 @@ void SimulationTTDevice::host_read(CoreCoord core, uint64_t addr, void* mem_ptr,
         return;
     }
     if (should_use_cached_tlb_window()) {
-        cached_tlb_window_->read_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+        read_block_reconfigure(*cached_tlb_window_, mem_ptr, translated_core, addr, size, get_selected_noc_id());
     } else {
         tile_read_bytes(translated_core, addr, mem_ptr, size);
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "tracy.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
@@ -402,7 +403,7 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
             // DeviceTimeoutError propagating out of the probe read is therefore not expected — let it surface
             // rather than silently masking it as a hang.
             uint32_t value = 0;
-            window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
+            read_block_reconfigure(*window, &value, core, addr, sizeof(value), noc);
             return value;
         });
 }


### PR DESCRIPTION
### Issue
Part of https://github.com/tenstorrent/tt-umd/issues/2875

### Description
Extracts the *_reconfigure family (read_block, write_block, read_register, write_register, noc_multicast_write) out of TlbWindow into free functions expressed purely against the IoWindow spec surface. PcieProtocol's non-safe path, LocalChip, the TTDevice hang probe, and SimulationTTDevice only needed this family, not the rest of TlbWindow — they now depend on IoWindow instead.

### List of the changes
 - New device/pcie/io_window_reconfigure.{hpp,cpp}: the 5 free functions + the chunking loop, built on configure(TargetIoWindowConfig, IoOrdering) + read_block/write_block/read_aligned/write_aligned/get_size.
 - TlbWindow keeps thin forwarding members (unchanged behavior) so SiliconTlbWindow's safe_* variants keep compiling; resolving safe_* is separate follow-up work.
 - Updated the 4 non-safe call sites in PcieProtocol, LocalChip, TTDevice, SimulationTTDevice to call the free functions directly.
 - Per transfer traffic direction is now a two bit field in WindowFlags (bits 2 and 3, zero meaning bidirectional), so it reaches the window through the spec surface and TlbVcDirection is no longer needed. Without this the helpers would configure every mapping as bidirectional and drop the static VC pinning added in #3067.

### Testing
No behavior change - the helpers set the same direction the TlbWindow members did, so the static VC settings are identical to main on every path. Existing TLB/window tests cover this path.

### API Changes
This PR has API changes.
 - WindowFlags gains Bidirectional, UnicastWrite, UnicastRead, MulticastWrite and DirectionMask.
 - TlbVcDirection is removed; ArchitectureTlbs::get_static_vc takes WindowFlags instead.
