### PR TITLE
Add Cluster::get_sysmem_window_noc_base and deprecate get_pcie_base_addr_from_device (#3068)

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -648,7 +648,7 @@ public:
     std::uint64_t get_sysmem_window_noc_base(const ChipId chip_id) const;
 
     /**
-     * Get base PCIe address that is used to access the device.
+     * Get the NOC base address of the chip's sysmem (PCIe) window.
      *
      * @param chip_id Chip to target.
      *

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -641,11 +641,22 @@ public:
     void* host_dma_address(std::uint64_t offset, ChipId src_device_id, uint16_t channel) const;
 
     /**
-     * Get base PCIe address that is used to access the device.
+     * Get the NOC base address of the chip's sysmem (PCIe) window.
      *
      * @param chip_id Chip to target.
      */
-    std::uint64_t get_pcie_base_addr_from_device(const ChipId chip_id) const;
+    std::uint64_t get_sysmem_window_noc_base(const ChipId chip_id) const;
+
+    /**
+     * Get base PCIe address that is used to access the device.
+     *
+     * @param chip_id Chip to target.
+     *
+     * @deprecated Renamed to get_sysmem_window_noc_base(), which describes what the returned address
+     * actually is. This overload only forwards to it and will be removed once all clients migrate.
+     */
+    [[deprecated("Use get_sysmem_window_noc_base() instead.")]] std::uint64_t get_pcie_base_addr_from_device(
+        const ChipId chip_id) const;
 
     //---------- Misc system functions
 

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -78,7 +78,7 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
         // physical_address is this chip's host base for the channel -- what UMD programs as the outbound
         // iATU region target (host_base_ is per-chip distinct). The chip-side NOC sysmem-window address is
-        // separate (get_pcie_base_addr_from_device), so the iATU maps NOC-window offset -> this host base.
+        // separate (get_sysmem_window_noc_base), so the iATU maps NOC-window offset -> this host base.
         hugepage_mapping_per_channel.push_back(
             {system_memory_ + i * (1ULL << 30), channel_size, host_base_ + i * (1ULL << 30)});
     }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1222,7 +1222,7 @@ std::uint32_t Cluster::get_numa_node_for_pcie_device(std::uint32_t device_id) {
     return chips_.at(device_id)->get_numa_node();
 }
 
-std::uint64_t Cluster::get_pcie_base_addr_from_device(const ChipId chip_id) const {
+std::uint64_t Cluster::get_sysmem_window_noc_base(const ChipId chip_id) const {
     // TODO: Should probably be lowered to TTDevice.
     tt::ARCH arch = get_soc_descriptor(chip_id).arch;
     if (arch == tt::ARCH::WORMHOLE_B0) {
@@ -1233,6 +1233,10 @@ std::uint64_t Cluster::get_pcie_base_addr_from_device(const ChipId chip_id) cons
     } else {
         return 0;
     }
+}
+
+std::uint64_t Cluster::get_pcie_base_addr_from_device(const ChipId chip_id) const {
+    return get_sysmem_window_noc_base(chip_id);
 }
 
 std::optional<SemVer> Cluster::get_ethernet_firmware_version() const { return eth_fw_version; }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -75,7 +75,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
     ChipId chip_id = umd_cluster->get_cluster_description()->get_chips_with_mmio().begin()->first;
 
     // TODO: In future, will be accessed through Chip api.
-    umd_cluster->get_pcie_base_addr_from_device(chip_id);
+    umd_cluster->get_sysmem_window_noc_base(chip_id);
     umd_cluster->get_num_host_channels(chip_id);
 }
 

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -571,7 +571,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
     for (const ChipId mmio_chip_id : mmio_chips) {
         const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
         const auto pcie_core = pci_cores.at(0);
-        const auto base_address = cluster->get_pcie_base_addr_from_device(mmio_chip_id);
+        const auto base_address = cluster->get_sysmem_window_noc_base(mmio_chip_id);
 
         // Distinct per-chip sentinel so a misrouted DMA (landing in another chip's window, or aliasing
         // host_base 0) surfaces as a readback mismatch instead of coincidentally matching.

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -246,7 +246,7 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     // We haven't actually mapped the hugepage yet, since cluster->start_device or
     // sysmem_manager->pin_or_map_sysmem_to_device wasn't called yet. So this will be the first buffer that was mapped,
     // and it is expected to have the starting NOC address.
-    EXPECT_EQ(sysmem_buffer->get_noc_addr().value(), cluster->get_pcie_base_addr_from_device(mmio_chip));
+    EXPECT_EQ(sysmem_buffer->get_noc_addr().value(), cluster->get_sysmem_window_noc_base(mmio_chip));
 
     uint8_t* sysmem_data = static_cast<uint8_t*>(sysmem_buffer->get_buffer_va());
     for (uint32_t i = 0; i < one_mb; ++i) {
@@ -279,7 +279,7 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     // If we map another buffer it is expected to have a higher NOC address.
     std::unique_ptr<SysmemBuffer> sysmem_buffer2 = sysmem_manager->allocate_sysmem_buffer(one_mb, true);
     EXPECT_TRUE(sysmem_buffer2->get_noc_addr().has_value());
-    EXPECT_GT(sysmem_buffer2->get_noc_addr().value(), cluster->get_pcie_base_addr_from_device(mmio_chip));
+    EXPECT_GT(sysmem_buffer2->get_noc_addr().value(), cluster->get_sysmem_window_noc_base(mmio_chip));
 }
 
 TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {


### PR DESCRIPTION
### Issue
#3068 (phase 1 of 2).

### Description
`Cluster::get_pcie_base_addr_from_device()` returns the NOC base address of the chip's sysmem (PCIe) window; the current name reads as a raw PCIe BAR base and is misleading. This adds `get_sysmem_window_noc_base()` as the real implementation and leaves the old name as a `[[deprecated]]` forwarder so clients can migrate before it is removed in the follow-up PR.

### List of the changes
- Add `Cluster::get_sysmem_window_noc_base()`; `get_pcie_base_addr_from_device()` becomes a `[[deprecated]]` forwarder to it.
- Move in-repo callers to the new name.

### Testing
CI

### API Changes
- Added: `Cluster::get_sysmem_window_noc_base(ChipId)`.
- Deprecated: `Cluster::get_pcie_base_addr_from_device(ChipId)` - still functional, removed in the follow-up PR.
