### PR TITLE
[Base API] Resolve safe_* as window-level policy

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(
         chip_helpers/sysmem_buffer.cpp
         chip_helpers/tlb_manager.cpp
         pcie/tlb_window.cpp
+        pcie/io_window_reconfigure.cpp
         pcie/device_memcpy.cpp
         pcie/silicon_tlb_window.cpp
         pcie/silicon_tlb_handle.cpp

--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/io_window_config.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -49,8 +50,10 @@ struct ArchitectureTlbs {
     // Configuration of the window at the given index.
     tlb_configuration get_configuration(uint32_t tlb_index) const;
 
-    // The virtual channel to configure a window with, given what that window will carry.
-    tlb_static_vc get_static_vc(TlbVcDirection direction) const;
+    // The virtual channel to configure a window with, given what that window will carry. Only the
+    // direction field of the flags is read: reads are given one channel and writes another, so
+    // traffic in opposite directions never shares a channel.
+    tlb_static_vc get_static_vc(WindowFlags flags) const;
 };
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch);

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -36,9 +36,6 @@ public:
     void write_block(uint64_t offset, const void* data, size_t size) override;
     void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
-    uint16_t safe_read16(uint64_t offset) override;
-
 private:
     /**
      * Translate a TLB window offset to (core, address) and perform a write via the communicator.

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -23,7 +23,8 @@ class TlbHandle;
  */
 class SiliconTlbWindow : public TlbWindow {
 public:
-    SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
+    SiliconTlbWindow(
+        std::unique_ptr<TlbHandle> handle, const tlb_data config = {}, IoSafety io_safety = IoSafety::Disabled);
 
     // Implementation of memory access methods using direct pointer access.
     void write16(uint64_t offset, uint16_t value) override;
@@ -34,9 +35,6 @@ public:
     void read_register(uint64_t offset, void* data, size_t size) override;
     void write_block(uint64_t offset, const void* data, size_t size) override;
     void read_block(uint64_t offset, void* data, size_t size) override;
-
-    // Enables/disables SIGBUS recovery (see execute_safe below) for the memory-access methods above.
-    void set_safe_io(bool enable) override;
 
     // Wires the per-op MMIO timeout: on a single-op overrun hang_check is consulted for the window's
     // currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
@@ -84,7 +82,7 @@ private:
     decltype(auto) execute_safe(Func&& func, Args&&... args);
 
     // Unguarded bodies of the memory-access methods above; the public overrides route through
-    // execute_safe() when safe_io_ is enabled and call these directly otherwise.
+    // execute_safe() when io_safety_ is enabled and call these directly otherwise.
     void write16_impl(uint64_t offset, uint16_t value);
     uint16_t read16_impl(uint64_t offset);
     void write32_impl(uint64_t offset, uint32_t value);
@@ -94,7 +92,6 @@ private:
     void write_block_impl(uint64_t offset, const void* data, size_t size);
     void read_block_impl(uint64_t offset, void* data, size_t size);
 
-    bool safe_io_ = false;
     std::function<bool(NocId)> hang_check_;
     // Cached is_false_alarm callback bound to the currently configured NOC; refreshed by
     // update_io_timeout_callback() so the IO paths need not rebuild it per call.

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -13,7 +13,6 @@
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
-#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 class TlbHandle;
@@ -36,54 +35,8 @@ public:
     void write_block(uint64_t offset, const void* data, size_t size) override;
     void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
-
-    uint16_t safe_read16(uint64_t offset) override;
-
-    void safe_write32(uint64_t offset, uint32_t value) override;
-
-    uint32_t safe_read32(uint64_t offset) override;
-
-    void safe_write_register(uint64_t offset, const void* data, size_t size) override;
-
-    void safe_read_register(uint64_t offset, void* data, size_t size) override;
-
-    void safe_write_block(uint64_t offset, const void* data, size_t size) override;
-
-    void safe_read_block(uint64_t offset, void* data, size_t size) override;
-
-    void safe_write_block_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict) override;
-
-    void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
-        override;
-
-    void safe_read_register_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
-        override;
-
-    void safe_write_register_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict) override;
-
-    void safe_noc_multicast_write_reconfigure(
-        const void* src,
-        size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict) override;
+    // Enables/disables SIGBUS recovery (see execute_safe below) for the memory-access methods above.
+    void set_safe_io(bool enable) override;
 
     // Wires the per-op MMIO timeout: on a single-op overrun hang_check is consulted for the window's
     // currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
@@ -130,6 +83,18 @@ private:
     template <typename Func, typename... Args>
     decltype(auto) execute_safe(Func&& func, Args&&... args);
 
+    // Unguarded bodies of the memory-access methods above; the public overrides route through
+    // execute_safe() when safe_io_ is enabled and call these directly otherwise.
+    void write16_impl(uint64_t offset, uint16_t value);
+    uint16_t read16_impl(uint64_t offset);
+    void write32_impl(uint64_t offset, uint32_t value);
+    uint32_t read32_impl(uint64_t offset);
+    void write_register_impl(uint64_t offset, const void* data, size_t size);
+    void read_register_impl(uint64_t offset, void* data, size_t size);
+    void write_block_impl(uint64_t offset, const void* data, size_t size);
+    void read_block_impl(uint64_t offset, void* data, size_t size);
+
+    bool safe_io_ = false;
     std::function<bool(NocId)> hang_check_;
     // Cached is_false_alarm callback bound to the currently configured NOC; refreshed by
     // update_io_timeout_callback() so the IO paths need not rebuild it per call.

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -149,7 +149,7 @@ protected:
         tt_xy_pair core_end,
         NocId noc_id,
         uint64_t ordering,
-        TlbVcDirection direction,
+        WindowFlags flags,
         bool mcast = false,
         tt_xy_pair core_start = {}) const;
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -20,13 +20,28 @@
 namespace tt::umd {
 
 /**
+ * Safe-I/O policy of a window, fixed for its lifetime.
+ *
+ * With Enabled, the window's memory-access methods recover from a SIGBUS raised by a failing device
+ * access and throw SigbusError instead of letting the fault take the process down. Only
+ * SiliconTlbWindow can offer this, since simulation windows never touch mapped device memory; where it
+ * cannot be offered the policy is ignored.
+ *
+ * The underlying type is bool so that a caller still holding a flag can cast it directly.
+ */
+enum class IoSafety : bool {
+    Disabled = false,
+    Enabled = true,
+};
+
+/**
  * Base class for TlbWindow implementations that contains all shared logic.
  * The memory access methods are pure virtual to allow different implementations
  * for silicon (direct memory access) vs simulation (communicator-based access).
  */
 class TlbWindow : public IoWindow {
 public:
-    TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
+    TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {}, IoSafety io_safety = IoSafety::Disabled);
 
     virtual ~TlbWindow() = default;
 
@@ -53,13 +68,6 @@ public:
     // SiliconTlbWindow consults it (simulation windows do not run the timed path). See SiliconTlbWindow.
     virtual void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) {}
 
-    // Installs safe-I/O as window-level policy: once enabled, the memory-access methods above recover
-    // from SIGBUS by throwing SigbusError instead of crashing the process. No-op by default; only
-    // SiliconTlbWindow can actually offer this (simulation windows never touch mapped device memory).
-    // Callers needing chunked transfers use the free functions in io_window_reconfigure.hpp, which honor
-    // whatever policy is installed here since they operate through this window's ops.
-    virtual void set_safe_io(bool enable) {}
-
     // Shared utility methods.
     TlbHandle& handle_ref() const;
     size_t get_size() const override;
@@ -81,6 +89,7 @@ protected:
 
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;
+    const IoSafety io_safety_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -155,10 +155,6 @@ protected:
 
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;
-
-private:
-    template <typename buffer_pointer, typename io_operation>
-    void transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -49,90 +49,16 @@ public:
     IoOrdering get_io_ordering() const override;
     HostMemoryCaching get_memory_caching_type() const override;
 
-    // Shared higher-level methods that use the virtual methods above.
-    virtual void read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
-
-    virtual void write_block_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    virtual void noc_multicast_write_reconfigure(
-        const void* src,
-        size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    // Register reconfigure methods perform 32-bit chunked transfers with strict ordering.
-    // Alignment enforcement is the caller's responsibility.
-    virtual void read_register_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
-
-    virtual void write_register_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    virtual void safe_write16(uint64_t offset, uint16_t value) = 0;
-
-    virtual uint16_t safe_read16(uint64_t offset) = 0;
-
-    virtual void safe_write32(uint64_t offset, uint32_t value);
-
-    virtual uint32_t safe_read32(uint64_t offset);
-
-    virtual void safe_write_register(uint64_t offset, const void* data, size_t size);
-
-    virtual void safe_read_register(uint64_t offset, void* data, size_t size);
-
-    virtual void safe_write_block(uint64_t offset, const void* data, size_t size);
-
-    virtual void safe_read_block(uint64_t offset, void* data, size_t size);
-
-    virtual void safe_write_block_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    virtual void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
-
-    virtual void safe_read_register_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
-
-    virtual void safe_write_register_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    virtual void safe_noc_multicast_write_reconfigure(
-        const void* src,
-        size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
     // Installs a per-op MMIO timeout hang check used by the timed memcpy path. No-op by default; only
     // SiliconTlbWindow consults it (simulation windows do not run the timed path). See SiliconTlbWindow.
     virtual void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) {}
+
+    // Installs safe-I/O as window-level policy: once enabled, the memory-access methods above recover
+    // from SIGBUS by throwing SigbusError instead of crashing the process. No-op by default; only
+    // SiliconTlbWindow can actually offer this (simulation windows never touch mapped device memory).
+    // Callers needing chunked transfers use the free functions in io_window_reconfigure.hpp, which honor
+    // whatever policy is installed here since they operate through this window's ops.
+    virtual void set_safe_io(bool enable) {}
 
     // Shared utility methods.
     TlbHandle& handle_ref() const;

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -38,10 +38,6 @@ public:
     void write_block(uint64_t offset, const void* data, size_t size) override;
     void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
-
-    uint16_t safe_read16(uint64_t offset) override;
-
 private:
     /**
      * Get the physical address for a TLB window offset.

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -28,7 +28,7 @@ namespace tt::umd {
 class PCIDevice;
 class TlbWindow;
 struct tlb_data;
-enum class TlbVcDirection;
+enum class WindowFlags : uint32_t;
 
 /**
  * PcieProtocol implements DeviceProtocol, PcieInterface, and DmaInterface for PCIe-connected
@@ -97,7 +97,7 @@ private:
         uint64_t addr,
         tt_xy_pair core_end,
         NocId noc_id,
-        TlbVcDirection direction,
+        WindowFlags flags,
         std::optional<tt_xy_pair> core_start = std::nullopt);
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
     bool dma_transfer_zero_copy(uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -102,11 +102,6 @@ private:
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
     bool dma_transfer_zero_copy(uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
 
-    template <bool safe>
-    void write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
-    template <bool safe>
-    void read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
-
     // Offset used to access NOC2AXI config + ARC specific memory (ICCM + CSM + APB).
     static constexpr uint32_t BAR0_OFFSET = 0x1FD00000;
 

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -36,6 +36,20 @@ enum class IoOrdering : uint8_t {
 };
 
 /**
+ * @brief Traffic an IoWindow mapping carries until the next configure().
+ *
+ * A window reconfigured before every transfer can commit to one direction, which lets an
+ * implementation route reads and writes over separate interconnect resources and so keep writes to a
+ * target ordered against each other. A window that serves both from one mapping asks for
+ * Bidirectional. Implementations with nothing to gain from the distinction ignore it.
+ */
+enum class IoDirection : uint8_t {
+    Bidirectional,  ///< Mapping serves both reads and writes.
+    Read,           ///< Mapping serves reads until it is configured again.
+    Write,          ///< Mapping serves writes until it is configured again.
+};
+
+/**
  * @brief Type-safe transaction attributes for an IoWindow target.
  */
 enum class WindowFlags : uint32_t {
@@ -78,6 +92,7 @@ struct TargetIoWindowConfig {
     uint64_t addr;                            ///< Destination address on the target core(s).
     std::optional<NocId> noc = std::nullopt;  ///< Optional routing selection.
     WindowFlags flags = WindowFlags::None;    ///< Transaction attributes.
+    IoDirection direction = IoDirection::Bidirectional;  ///< Traffic the mapping will carry.
 };
 
 /**

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -36,26 +36,25 @@ enum class IoOrdering : uint8_t {
 };
 
 /**
- * @brief Traffic an IoWindow mapping carries until the next configure().
- *
- * A window reconfigured before every transfer can commit to one direction, which lets an
- * implementation route reads and writes over separate interconnect resources and so keep writes to a
- * target ordered against each other. A window that serves both from one mapping asks for
- * Bidirectional. Implementations with nothing to gain from the distinction ignore it.
- */
-enum class IoDirection : uint8_t {
-    Bidirectional,  ///< Mapping serves both reads and writes.
-    Read,           ///< Mapping serves reads until it is configured again.
-    Write,          ///< Mapping serves writes until it is configured again.
-};
-
-/**
  * @brief Type-safe transaction attributes for an IoWindow target.
+ *
+ * Bits 2-3 form the direction field, holding the traffic the mapping carries until it is configured
+ * again. A mapping reconfigured before every transfer can commit to one direction, which lets an
+ * implementation route reads and writes over separate interconnect resources and so keep writes to a
+ * target ordered against each other. Zero — the default — is bidirectional: a mapping that serves
+ * both without being configured in between, and so cannot be given a resource of its own.
+ * Implementations with nothing to gain from the distinction ignore the field.
  */
 enum class WindowFlags : uint32_t {
     None = 0,
     Atomic = 1 << 0,  ///< Issue transaction as atomic on the target interconnect.
     Snoop = 1 << 1,   ///< Mark transaction as snoopable for cache coherency.
+
+    Bidirectional = 0 << 2,   ///< Mapping serves both reads and writes. Default.
+    UnicastWrite = 1 << 2,    ///< Mapping serves writes to a single core.
+    UnicastRead = 2 << 2,     ///< Mapping serves reads from a single core.
+    MulticastWrite = 3 << 2,  ///< Mapping serves writes to a core range.
+    DirectionMask = 3 << 2,   ///< Selects the direction field out of a set of flags.
 };
 
 constexpr WindowFlags operator|(WindowFlags lhs, WindowFlags rhs) noexcept {
@@ -91,8 +90,7 @@ struct TargetIoWindowConfig {
         std::nullopt;                         ///< Lower-right corner of a multicast grid, or nullopt for unicast.
     uint64_t addr;                            ///< Destination address on the target core(s).
     std::optional<NocId> noc = std::nullopt;  ///< Optional routing selection.
-    WindowFlags flags = WindowFlags::None;    ///< Transaction attributes.
-    IoDirection direction = IoDirection::Bidirectional;  ///< Traffic the mapping will carry.
+    WindowFlags flags = WindowFlags::None;    ///< Transaction attributes, including the direction field.
 };
 
 /**

--- a/device/api/umd/device/types/tlb.hpp
+++ b/device/api/umd/device/types/tlb.hpp
@@ -28,16 +28,6 @@ struct tlb_offsets {
     uint32_t static_vc_class_end;
 };
 
-// What a TLB window will carry. A window carrying a single direction can be given a virtual channel
-// of its own, so reads and writes never share one. BIDIRECTIONAL is for windows that stay
-// configured across both.
-enum class TlbVcDirection {
-    UNICAST_WRITE,
-    UNICAST_READ,
-    MULTICAST_WRITE,
-    BIDIRECTIONAL,
-};
-
 // The virtual channel a TLB window is configured to use.
 struct tlb_static_vc {
     uint64_t static_vc = 0;

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -39,8 +39,9 @@ tlb_configuration ArchitectureTlbs::get_configuration(const uint32_t tlb_index) 
     UMD_THROW(error::RuntimeError, fmt::format("No TLB window with index {}.", tlb_index));
 }
 
-tlb_static_vc ArchitectureTlbs::get_static_vc(const TlbVcDirection direction) const {
-    if (!static_vc_is_configurable || direction == TlbVcDirection::BIDIRECTIONAL) {
+tlb_static_vc ArchitectureTlbs::get_static_vc(const WindowFlags flags) const {
+    const WindowFlags direction = flags & WindowFlags::DirectionMask;
+    if (!static_vc_is_configurable || direction == WindowFlags::Bidirectional) {
         // Nothing left to choose: either the architecture wires the channel up itself, or the window
         // carries both directions and so cannot be given one of its own.
         return {.static_vc = use_static_vc};
@@ -50,8 +51,8 @@ tlb_static_vc ArchitectureTlbs::get_static_vc(const TlbVcDirection direction) co
     // and multicast writes get a class of their own.
     return {
         .static_vc = 1,
-        .static_vc_buddy = direction == TlbVcDirection::UNICAST_READ ? 1ULL : 0ULL,
-        .static_vc_class = direction == TlbVcDirection::MULTICAST_WRITE ? 0b10ULL : 0b00ULL,
+        .static_vc_buddy = direction == WindowFlags::UnicastRead ? 1ULL : 0ULL,
+        .static_vc_class = direction == WindowFlags::MulticastWrite ? 0b10ULL : 0b00ULL,
     };
 }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
@@ -258,8 +259,14 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
         tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
-        get_cached_wc_tlb_window()->write_block_reconfigure(
-            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed);
+        write_block_reconfigure(
+            *get_cached_wc_tlb_window(),
+            src,
+            translated_core,
+            l1_dest,
+            size,
+            get_selected_noc_id(),
+            IoOrdering::Relaxed);
     }
 }
 
@@ -284,8 +291,14 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
         tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
-        get_cached_wc_tlb_window()->read_block_reconfigure(
-            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed);
+        read_block_reconfigure(
+            *get_cached_wc_tlb_window(),
+            dest,
+            translated_core,
+            l1_src,
+            size,
+            get_selected_noc_id(),
+            IoOrdering::Relaxed);
     }
 }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -341,8 +341,7 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.set_static_vc(
-        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_WRITE));
+    config.set_static_vc(get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(WindowFlags::UnicastWrite));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -373,8 +372,7 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.set_static_vc(
-        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_READ));
+    config.set_static_vc(get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(WindowFlags::UnicastRead));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 

--- a/device/pcie/io_window_reconfigure.cpp
+++ b/device/pcie/io_window_reconfigure.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pcie/io_window_reconfigure.hpp"
+
+#include <algorithm>
+#include <optional>
+
+namespace tt::umd {
+
+namespace {
+
+// Each chunk is configured immediately before it is transferred, so the mapping only ever carries one
+// direction of traffic and says so. The direction follows from the transfer rather than from the caller.
+template <typename buffer_pointer, typename io_operation>
+void transfer_and_reconfigure(
+    IoWindow& window,
+    TargetIoWindowConfig config,
+    IoOrdering ordering,
+    buffer_pointer buffer,
+    size_t size,
+    io_operation op) {
+    while (size > 0) {
+        window.configure(config, ordering);
+        size_t transfer_size = std::min(size, window.get_size());
+        op(buffer, transfer_size);
+        size -= transfer_size;
+        config.addr += transfer_size;
+        buffer += transfer_size;
+    }
+}
+
+}  // namespace
+
+void read_block_reconfigure(
+    IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        ordering,
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [&window](uint8_t* buf, size_t sz) { window.read_block(0, buf, sz); });
+}
+
+void write_block_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_block(0, buf, sz); });
+}
+
+void read_register_reconfigure(
+    IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        ordering,
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [&window](uint8_t* buf, size_t sz) { window.read_aligned(0, buf, sz); });
+}
+
+void write_register_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_aligned(0, buf, sz); });
+}
+
+void noc_multicast_write_reconfigure(
+    IoWindow& window,
+    const void* src,
+    size_t size,
+    tt_xy_pair core_start,
+    tt_xy_pair core_end,
+    uint64_t addr,
+    NocId noc_id,
+    IoOrdering ordering) {
+    transfer_and_reconfigure(
+        window,
+        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        ordering,
+        static_cast<const uint8_t*>(src),
+        size,
+        [&window](const uint8_t* buf, size_t sz) { window.write_block(0, buf, sz); });
+}
+
+}  // namespace tt::umd

--- a/device/pcie/io_window_reconfigure.cpp
+++ b/device/pcie/io_window_reconfigure.cpp
@@ -37,7 +37,7 @@ void read_block_reconfigure(
     IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastRead},
         ordering,
         static_cast<uint8_t*>(mem_ptr),
         size,
@@ -54,7 +54,7 @@ void write_block_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastWrite},
         ordering,
         static_cast<const uint8_t*>(mem_ptr),
         size,
@@ -65,7 +65,7 @@ void read_register_reconfigure(
     IoWindow& window, void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Read},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastRead},
         ordering,
         static_cast<uint8_t*>(mem_ptr),
         size,
@@ -82,7 +82,7 @@ void write_register_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core, std::nullopt, addr, noc_id, WindowFlags::UnicastWrite},
         ordering,
         static_cast<const uint8_t*>(mem_ptr),
         size,
@@ -100,7 +100,7 @@ void noc_multicast_write_reconfigure(
     IoOrdering ordering) {
     transfer_and_reconfigure(
         window,
-        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::None, IoDirection::Write},
+        TargetIoWindowConfig{core_start, core_end, addr, noc_id, WindowFlags::MulticastWrite},
         ordering,
         static_cast<const uint8_t*>(src),
         size,

--- a/device/pcie/io_window_reconfigure.hpp
+++ b/device/pcie/io_window_reconfigure.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/io_window/io_window.hpp"
+#include "umd/device/types/io_window_config.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+
+/**
+ * Chunked block read/write against an IoWindow: reconfigures the window to (core, addr) and
+ * transfers up to window.get_size() bytes per iteration, advancing addr and the buffer pointer
+ * until size is exhausted.
+ *
+ * Postcondition: the window is left configured to the last chunk transferred, not restored to
+ * whatever it was configured to before the call. Each chunk is configured for the direction the
+ * transfer runs in, so a window whose hardware separates read and write traffic gets to do so.
+ */
+void read_block_reconfigure(
+    IoWindow& window,
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void write_block_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+// Register reconfigure functions transfer through read_aligned/write_aligned. Alignment
+// enforcement is the caller's responsibility.
+void read_register_reconfigure(
+    IoWindow& window,
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void write_register_reconfigure(
+    IoWindow& window,
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+void noc_multicast_write_reconfigure(
+    IoWindow& window,
+    const void* src,
+    size_t size,
+    tt_xy_pair core_start,
+    tt_xy_pair core_end,
+    uint64_t addr,
+    NocId noc_id,
+    IoOrdering ordering = IoOrdering::Strict);
+
+}  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -63,8 +63,4 @@ void RtlSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size
 
 void RtlSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
 
-void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
-
-uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
-
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -66,8 +66,8 @@ struct ScopedJumpGuard {
     signal(SIGBUS, SIG_DFL);
 }
 
-SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
-    TlbWindow(std::move(handle), config) {
+SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config, IoSafety io_safety) :
+    TlbWindow(std::move(handle), config, io_safety) {
     update_io_timeout_callback();
 }
 
@@ -98,8 +98,6 @@ void SiliconTlbWindow::update_io_timeout_callback() {
     auto hang_check = hang_check_;
     io_timeout_callback_ = [hang_check, noc]() -> bool { return !hang_check(noc); };
 }
-
-void SiliconTlbWindow::set_safe_io(bool enable) { safe_io_ = enable; }
 
 void SiliconTlbWindow::write16_impl(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
@@ -290,65 +288,65 @@ decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
 }
 
 void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::write16_impl, offset, value);
-    } else {
-        write16_impl(offset, value);
+        return;
     }
+    write16_impl(offset, value);
 }
 
 uint16_t SiliconTlbWindow::read16(uint64_t offset) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         return execute_safe(&SiliconTlbWindow::read16_impl, offset);
     }
     return read16_impl(offset);
 }
 
 void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::write32_impl, offset, value);
-    } else {
-        write32_impl(offset, value);
+        return;
     }
+    write32_impl(offset, value);
 }
 
 uint32_t SiliconTlbWindow::read32(uint64_t offset) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         return execute_safe(&SiliconTlbWindow::read32_impl, offset);
     }
     return read32_impl(offset);
 }
 
 void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::write_register_impl, offset, data, size);
-    } else {
-        write_register_impl(offset, data, size);
+        return;
     }
+    write_register_impl(offset, data, size);
 }
 
 void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::read_register_impl, offset, data, size);
-    } else {
-        read_register_impl(offset, data, size);
+        return;
     }
+    read_register_impl(offset, data, size);
 }
 
 void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::write_block_impl, offset, data, size);
-    } else {
-        write_block_impl(offset, data, size);
+        return;
     }
+    write_block_impl(offset, data, size);
 }
 
 void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
-    if (safe_io_) {
+    if (io_safety_ == IoSafety::Enabled) {
         execute_safe(&SiliconTlbWindow::read_block_impl, offset, data, size);
-    } else {
-        read_block_impl(offset, data, size);
+        return;
     }
+    read_block_impl(offset, data, size);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -99,27 +99,103 @@ void SiliconTlbWindow::update_io_timeout_callback() {
     io_timeout_callback_ = [hang_check, noc]() -> bool { return !hang_check(noc); };
 }
 
+void SiliconTlbWindow::set_safe_io(bool enable) { safe_io_ = enable; }
+
+template <typename Func, typename... Args>
+decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
+    if (sigsetjmp(point, 1) == 0) {
+        ScopedJumpGuard guard;
+        return std::invoke(std::forward<Func>(func), this, std::forward<Args>(args)...);
+    } else {
+        std::atomic_signal_fence(std::memory_order_seq_cst);
+        jump_set = 0;
+        throw error::SigbusError("SIGBUS signal detected: Device access failed.");
+    }
+}
+
 void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write16_impl, offset, value);
+    } else {
+        write16_impl(offset, value);
+    }
+}
+
+uint16_t SiliconTlbWindow::read16(uint64_t offset) {
+    if (safe_io_) {
+        return execute_safe(&SiliconTlbWindow::read16_impl, offset);
+    }
+    return read16_impl(offset);
+}
+
+void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write32_impl, offset, value);
+    } else {
+        write32_impl(offset, value);
+    }
+}
+
+uint32_t SiliconTlbWindow::read32(uint64_t offset) {
+    if (safe_io_) {
+        return execute_safe(&SiliconTlbWindow::read32_impl, offset);
+    }
+    return read32_impl(offset);
+}
+
+void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write_register_impl, offset, data, size);
+    } else {
+        write_register_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::read_register_impl, offset, data, size);
+    } else {
+        read_register_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write_block_impl, offset, data, size);
+    } else {
+        write_block_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::read_block_impl, offset, data, size);
+    } else {
+        read_block_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::write16_impl(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
     write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, io_timeout_callback_);
 }
 
-uint16_t SiliconTlbWindow::read16(uint64_t offset) {
+uint16_t SiliconTlbWindow::read16_impl(uint64_t offset) {
     validate(offset, sizeof(uint16_t));
     return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), io_timeout_callback_);
 }
 
-void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
+void SiliconTlbWindow::write32_impl(uint64_t offset, uint32_t value) {
     validate(offset, sizeof(uint32_t));
     write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, io_timeout_callback_);
 }
 
-uint32_t SiliconTlbWindow::read32(uint64_t offset) {
+uint32_t SiliconTlbWindow::read32_impl(uint64_t offset) {
     validate(offset, sizeof(uint32_t));
     return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), io_timeout_callback_);
 }
 
-void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
+void SiliconTlbWindow::write_register_impl(uint64_t offset, const void *data, size_t size) {
     size_t n = size / sizeof(uint32_t);
     auto *src = static_cast<const uint32_t *>(data);
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
@@ -129,7 +205,7 @@ void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t 
     write_regs(dst, src, n, io_timeout_callback_);
 }
 
-void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
+void SiliconTlbWindow::read_register_impl(uint64_t offset, void *data, size_t size) {
     size_t n = size / sizeof(uint32_t);
     auto *src = reinterpret_cast<const volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
     auto *dst = static_cast<uint32_t *>(data);
@@ -139,7 +215,7 @@ void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
     read_regs((void *)src, n, (void *)dst, io_timeout_callback_);
 }
 
-void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
+void SiliconTlbWindow::write_block_impl(uint64_t offset, const void *data, size_t size) {
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
@@ -151,7 +227,7 @@ void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t siz
     }
 }
 
-void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
+void SiliconTlbWindow::read_block_impl(uint64_t offset, void *data, size_t size) {
     const volatile void *src = tlb_handle->get_base() + get_total_offset(offset);
 
     validate(offset, size);
@@ -273,78 +349,6 @@ void SiliconTlbWindow::read_regs(
         uint32_t temp = read32_from_device(src++, on_timeout);
         memcpy(dest++, &temp, sizeof(temp));
     }
-}
-
-template <typename Func, typename... Args>
-decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
-    if (sigsetjmp(point, 1) == 0) {
-        ScopedJumpGuard guard;
-        return std::invoke(std::forward<Func>(func), this, std::forward<Args>(args)...);
-    } else {
-        std::atomic_signal_fence(std::memory_order_seq_cst);
-        jump_set = 0;
-        throw error::SigbusError("SIGBUS signal detected: Device access failed.");
-    }
-}
-
-void SiliconTlbWindow::safe_write16(uint64_t offset, uint16_t value) {
-    execute_safe(&SiliconTlbWindow::write16, offset, value);
-}
-
-uint16_t SiliconTlbWindow::safe_read16(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read16, offset); }
-
-void SiliconTlbWindow::safe_write32(uint64_t offset, uint32_t value) {
-    execute_safe(&SiliconTlbWindow::write32, offset, value);
-}
-
-uint32_t SiliconTlbWindow::safe_read32(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read32, offset); }
-
-void SiliconTlbWindow::safe_write_register(uint64_t offset, const void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::write_register, offset, data, size);
-}
-
-void SiliconTlbWindow::safe_read_register(uint64_t offset, void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::read_register, offset, data, size);
-}
-
-void SiliconTlbWindow::safe_write_block(uint64_t offset, const void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::write_block, offset, data, size);
-}
-
-void SiliconTlbWindow::safe_read_block(uint64_t offset, void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::read_block, offset, data, size);
-}
-
-void SiliconTlbWindow::safe_write_block_reconfigure(
-    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void SiliconTlbWindow::safe_read_block_reconfigure(
-    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void SiliconTlbWindow::safe_read_register_reconfigure(
-    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::read_register_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void SiliconTlbWindow::safe_write_register_reconfigure(
-    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::write_register_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
-    const void *src,
-    size_t size,
-    tt_xy_pair core_start,
-    tt_xy_pair core_end,
-    uint64_t addr,
-    NocId noc_id,
-    uint64_t ordering) {
-    execute_safe(
-        &SiliconTlbWindow::noc_multicast_write_reconfigure, src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -101,80 +101,6 @@ void SiliconTlbWindow::update_io_timeout_callback() {
 
 void SiliconTlbWindow::set_safe_io(bool enable) { safe_io_ = enable; }
 
-template <typename Func, typename... Args>
-decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
-    if (sigsetjmp(point, 1) == 0) {
-        ScopedJumpGuard guard;
-        return std::invoke(std::forward<Func>(func), this, std::forward<Args>(args)...);
-    } else {
-        std::atomic_signal_fence(std::memory_order_seq_cst);
-        jump_set = 0;
-        throw error::SigbusError("SIGBUS signal detected: Device access failed.");
-    }
-}
-
-void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::write16_impl, offset, value);
-    } else {
-        write16_impl(offset, value);
-    }
-}
-
-uint16_t SiliconTlbWindow::read16(uint64_t offset) {
-    if (safe_io_) {
-        return execute_safe(&SiliconTlbWindow::read16_impl, offset);
-    }
-    return read16_impl(offset);
-}
-
-void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::write32_impl, offset, value);
-    } else {
-        write32_impl(offset, value);
-    }
-}
-
-uint32_t SiliconTlbWindow::read32(uint64_t offset) {
-    if (safe_io_) {
-        return execute_safe(&SiliconTlbWindow::read32_impl, offset);
-    }
-    return read32_impl(offset);
-}
-
-void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::write_register_impl, offset, data, size);
-    } else {
-        write_register_impl(offset, data, size);
-    }
-}
-
-void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::read_register_impl, offset, data, size);
-    } else {
-        read_register_impl(offset, data, size);
-    }
-}
-
-void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::write_block_impl, offset, data, size);
-    } else {
-        write_block_impl(offset, data, size);
-    }
-}
-
-void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
-    if (safe_io_) {
-        execute_safe(&SiliconTlbWindow::read_block_impl, offset, data, size);
-    } else {
-        read_block_impl(offset, data, size);
-    }
-}
-
 void SiliconTlbWindow::write16_impl(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
     write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, io_timeout_callback_);
@@ -348,6 +274,80 @@ void SiliconTlbWindow::read_regs(
     while (word_len-- != 0) {
         uint32_t temp = read32_from_device(src++, on_timeout);
         memcpy(dest++, &temp, sizeof(temp));
+    }
+}
+
+template <typename Func, typename... Args>
+decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
+    if (sigsetjmp(point, 1) == 0) {
+        ScopedJumpGuard guard;
+        return std::invoke(std::forward<Func>(func), this, std::forward<Args>(args)...);
+    } else {
+        std::atomic_signal_fence(std::memory_order_seq_cst);
+        jump_set = 0;
+        throw error::SigbusError("SIGBUS signal detected: Device access failed.");
+    }
+}
+
+void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write16_impl, offset, value);
+    } else {
+        write16_impl(offset, value);
+    }
+}
+
+uint16_t SiliconTlbWindow::read16(uint64_t offset) {
+    if (safe_io_) {
+        return execute_safe(&SiliconTlbWindow::read16_impl, offset);
+    }
+    return read16_impl(offset);
+}
+
+void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write32_impl, offset, value);
+    } else {
+        write32_impl(offset, value);
+    }
+}
+
+uint32_t SiliconTlbWindow::read32(uint64_t offset) {
+    if (safe_io_) {
+        return execute_safe(&SiliconTlbWindow::read32_impl, offset);
+    }
+    return read32_impl(offset);
+}
+
+void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write_register_impl, offset, data, size);
+    } else {
+        write_register_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::read_register_impl, offset, data, size);
+    } else {
+        read_register_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::write_block_impl, offset, data, size);
+    } else {
+        write_block_impl(offset, data, size);
+    }
+}
+
+void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
+    if (safe_io_) {
+        execute_safe(&SiliconTlbWindow::read_block_impl, offset, data, size);
+    } else {
+        read_block_impl(offset, data, size);
     }
 }
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -9,7 +9,6 @@
 #include <stdexcept>
 #include <utility>
 
-#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -58,62 +57,6 @@ tlb_data TlbWindow::make_tlb_config(
         config.y_start = core_start.y;
     }
     return config;
-}
-
-// Thin forwarders onto the free-function family in io_window_reconfigure.hpp, kept as virtual
-// members solely so SiliconTlbWindow's safe_* variants (execute_safe, taking a pointer-to-member)
-// keep working unchanged. Callers with no safe/unsafe distinction to make should call the free
-// functions directly instead of going through a TlbWindow.
-void TlbWindow::read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    UMD_ASSERT(
-        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
-        error::RuntimeError,
-        "Invalid ordering value passed to TlbWindow::read_block_reconfigure");
-    tt::umd::read_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
-}
-
-void TlbWindow::read_register_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    UMD_ASSERT(
-        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
-        error::RuntimeError,
-        "Invalid ordering value passed to TlbWindow::read_register_reconfigure");
-    tt::umd::read_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
-}
-
-void TlbWindow::write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    UMD_ASSERT(
-        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
-        error::RuntimeError,
-        "Invalid ordering value passed to TlbWindow::write_block_reconfigure");
-    tt::umd::write_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
-}
-
-void TlbWindow::write_register_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    UMD_ASSERT(
-        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
-        error::RuntimeError,
-        "Invalid ordering value passed to TlbWindow::write_register_reconfigure");
-    tt::umd::write_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
-}
-
-void TlbWindow::noc_multicast_write_reconfigure(
-    const void* src,
-    size_t size,
-    tt_xy_pair core_start,
-    tt_xy_pair core_end,
-    uint64_t addr,
-    NocId noc_id,
-    uint64_t ordering) {
-    UMD_ASSERT(
-        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
-        error::RuntimeError,
-        "Invalid ordering value passed to TlbWindow::noc_multicast_write_reconfigure");
-    tt::umd::noc_multicast_write_reconfigure(
-        *this, src, size, core_start, core_end, addr, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -199,51 +142,6 @@ uint64_t TlbWindow::get_total_offset(uint64_t offset) const { return offset + of
 
 uint64_t TlbWindow::get_base_address() const {
     return handle_ref().get_config().local_offset + offset_from_aligned_addr;
-}
-
-void TlbWindow::safe_write32(uint64_t offset, uint32_t value) { write32(offset, value); }
-
-uint32_t TlbWindow::safe_read32(uint64_t offset) { return read32(offset); }
-
-void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t size) {
-    write_register(offset, data, size);
-}
-
-void TlbWindow::safe_read_register(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
-
-void TlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size) { write_block(offset, data, size); }
-
-void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
-
-void TlbWindow::safe_write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    write_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void TlbWindow::safe_read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void TlbWindow::safe_read_register_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    read_register_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void TlbWindow::safe_write_register_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    write_register_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
-}
-
-void TlbWindow::safe_noc_multicast_write_reconfigure(
-    const void* src,
-    size_t size,
-    tt_xy_pair core_start,
-    tt_xy_pair core_end,
-    uint64_t addr,
-    NocId noc_id,
-    uint64_t ordering) {
-    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -29,7 +29,8 @@ static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
 static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
 static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
 
-TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
+TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config, IoSafety io_safety) :
+    tlb_handle(std::move(handle)), io_safety_(io_safety) {
     tlb_data aligned_config = config;
     aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
     tlb_handle->configure(aligned_config);

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -30,25 +30,6 @@ static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
 static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
 static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
 
-namespace {
-
-// Pinning a mapping to a static VC keeps its writes ordered, but a single VC carrying both directions
-// trips a hardware bug, so only a mapping that commits to one direction can be pinned. Multicast
-// writes take their own VC class, which is why the write case splits on mcast.
-TlbVcDirection to_tlb_vc_direction(const IoDirection direction, const bool mcast) {
-    switch (direction) {
-        case IoDirection::Read:
-            return TlbVcDirection::UNICAST_READ;
-        case IoDirection::Write:
-            return mcast ? TlbVcDirection::MULTICAST_WRITE : TlbVcDirection::UNICAST_WRITE;
-        case IoDirection::Bidirectional:
-        default:
-            return TlbVcDirection::BIDIRECTIONAL;
-    }
-}
-
-}  // namespace
-
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
     aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
@@ -61,7 +42,7 @@ tlb_data TlbWindow::make_tlb_config(
     tt_xy_pair core_end,
     NocId noc_id,
     uint64_t ordering,
-    TlbVcDirection direction,
+    WindowFlags flags,
     bool mcast,
     tt_xy_pair core_start) const {
     tlb_data config{};
@@ -70,7 +51,7 @@ tlb_data TlbWindow::make_tlb_config(
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = ordering;
-    config.set_static_vc(get_architecture_tlbs(handle_ref().get_arch()).get_static_vc(direction));
+    config.set_static_vc(get_architecture_tlbs(handle_ref().get_arch()).get_static_vc(flags));
     if (mcast) {
         config.mcast = true;
         config.x_start = core_start.x;
@@ -171,11 +152,12 @@ void TlbWindow::read_aligned(uint64_t offset, void* data, size_t size) {
 void TlbWindow::configure(const TargetIoWindowConfig& config) { configure(config, IoOrdering::Strict); }
 
 void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering ordering) {
-    // A TLB mapping has no way to express these; failing loudly beats silently dropping them.
+    // A TLB mapping has no way to express anything outside the direction field; failing loudly beats
+    // silently dropping it.
     UMD_ASSERT(
-        config.flags == WindowFlags::None,
+        (config.flags & ~WindowFlags::DirectionMask) == WindowFlags::None,
         error::RuntimeError,
-        "WindowFlags are not supported by TLB-backed IoWindows.");
+        "WindowFlags other than the direction field are not supported by TLB-backed IoWindows.");
 
     UMD_ASSERT(config.noc.has_value(), error::RuntimeError, "TLB-backed IoWindows must specify a NOC.");
 
@@ -185,7 +167,7 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         mcast ? config.core_end.value() : config.core_start,
         config.noc.value(),
         static_cast<uint64_t>(ordering),
-        to_tlb_vc_direction(config.direction, mcast),
+        config.flags,
         mcast,
         config.core_start));
 }

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -4,13 +4,12 @@
 
 #include "umd/device/pcie/tlb_window.hpp"
 
-#include <algorithm>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <utility>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -30,6 +29,25 @@ namespace tt::umd {
 static_assert(static_cast<uint64_t>(IoOrdering::Relaxed) == tlb_data::Relaxed);
 static_assert(static_cast<uint64_t>(IoOrdering::Strict) == tlb_data::Strict);
 static_assert(static_cast<uint64_t>(IoOrdering::Posted) == tlb_data::Posted);
+
+namespace {
+
+// Pinning a mapping to a static VC keeps its writes ordered, but a single VC carrying both directions
+// trips a hardware bug, so only a mapping that commits to one direction can be pinned. Multicast
+// writes take their own VC class, which is why the write case splits on mcast.
+TlbVcDirection to_tlb_vc_direction(const IoDirection direction, const bool mcast) {
+    switch (direction) {
+        case IoDirection::Read:
+            return TlbVcDirection::UNICAST_READ;
+        case IoDirection::Write:
+            return mcast ? TlbVcDirection::MULTICAST_WRITE : TlbVcDirection::UNICAST_WRITE;
+        case IoDirection::Bidirectional:
+        default:
+            return TlbVcDirection::BIDIRECTIONAL;
+    }
+}
+
+}  // namespace
 
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
@@ -61,52 +79,28 @@ tlb_data TlbWindow::make_tlb_config(
     return config;
 }
 
-template <typename buffer_pointer, typename io_operation>
-void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op) {
-    while (size > 0) {
-        configure(config);
-        size_t transfer_size = std::min(size, get_size());
-        op(buffer, transfer_size);
-        size -= transfer_size;
-        config.local_offset += transfer_size;
-        buffer += transfer_size;
-    }
-}
-
+// Thin forwarders onto the free-function family in io_window_reconfigure.hpp, kept as virtual
+// members solely so SiliconTlbWindow's safe_* variants (execute_safe, taking a pointer-to-member)
+// keep working unchanged. Callers with no safe/unsafe distinction to make should call the free
+// functions directly instead of going through a TlbWindow.
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
-        static_cast<uint8_t*>(mem_ptr),
-        size,
-        [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
+    tt::umd::read_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
-        static_cast<uint8_t*>(mem_ptr),
-        size,
-        [this](uint8_t* buf, size_t sz) { read_register(0, buf, sz); });
+    tt::umd::read_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
-        static_cast<const uint8_t*>(mem_ptr),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+    tt::umd::write_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
-        static_cast<const uint8_t*>(mem_ptr),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_register(0, buf, sz); });
+    tt::umd::write_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::noc_multicast_write_reconfigure(
@@ -117,11 +111,8 @@ void TlbWindow::noc_multicast_write_reconfigure(
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
-    transfer_and_reconfigure(
-        make_tlb_config(addr, core_end, noc_id, ordering, TlbVcDirection::MULTICAST_WRITE, true, core_start),
-        static_cast<const uint8_t*>(src),
-        size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+    tt::umd::noc_multicast_write_reconfigure(
+        *this, src, size, core_start, core_end, addr, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -174,7 +165,7 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         mcast ? config.core_end.value() : config.core_start,
         config.noc.value(),
         static_cast<uint64_t>(ordering),
-        TlbVcDirection::BIDIRECTIONAL,
+        to_tlb_vc_direction(config.direction, mcast),
         mcast,
         config.core_start));
 }

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -85,21 +85,37 @@ tlb_data TlbWindow::make_tlb_config(
 // functions directly instead of going through a TlbWindow.
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::read_block_reconfigure");
     tt::umd::read_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::read_register_reconfigure");
     tt::umd::read_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::write_block_reconfigure");
     tt::umd::write_block_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::write_register_reconfigure");
     tt::umd::write_register_reconfigure(*this, mem_ptr, core, addr, size, noc_id, static_cast<IoOrdering>(ordering));
 }
 
@@ -111,6 +127,10 @@ void TlbWindow::noc_multicast_write_reconfigure(
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
+    UMD_ASSERT(
+        ordering == tlb_data::Relaxed || ordering == tlb_data::Strict || ordering == tlb_data::Posted,
+        error::RuntimeError,
+        "Invalid ordering value passed to TlbWindow::noc_multicast_write_reconfigure");
     tt::umd::noc_multicast_write_reconfigure(
         *this, src, size, core_start, core_end, addr, noc_id, static_cast<IoOrdering>(ordering));
 }

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -86,8 +86,4 @@ uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     return reinterpret_cast<uint64_t>(tlb_handle->get_base()) + get_total_offset(offset);
 }
 
-void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
-
-uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
-
 }  // namespace tt::umd

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -18,6 +18,7 @@
 #include <variant>
 #include <vector>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -103,7 +104,7 @@ void PcieProtocol::write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_
     if constexpr (safe) {
         get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        write_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -112,7 +113,7 @@ void PcieProtocol::read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr,
     if constexpr (safe) {
         get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        read_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -122,7 +123,7 @@ void PcieProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t add
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_write_register_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->write_register_reconfigure(mem_ptr, core, addr, size, noc_id);
+        write_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -132,7 +133,7 @@ void PcieProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
+        read_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -156,8 +157,7 @@ void PcieProtocol::noc_multicast_write(
         get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(
             src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
     } else {
-        get_cached_tlb_window()->noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
+        noc_multicast_write_reconfigure(*get_cached_tlb_window(), src, size, core_start, core_end, addr, noc_id);
     }
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -72,10 +72,12 @@ void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& han
 
 TlbWindow* PcieProtocol::get_cached_tlb_window() {
     if (cached_tlb_window_ == nullptr) {
-        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
-            get_architecture_tlbs(pci_device_->get_arch()).cached_window_size, TlbMapping::UC));
+        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(
+            pci_device_->allocate_tlb(
+                get_architecture_tlbs(pci_device_->get_arch()).cached_window_size, TlbMapping::UC),
+            tlb_data{},
+            static_cast<IoSafety>(use_safe_api_));
         cached_tlb_window_->set_io_timeout_hang_check(hang_check_);
-        cached_tlb_window_->set_safe_io(use_safe_api_);
     }
     return cached_tlb_window_.get();
 }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -260,7 +260,7 @@ bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
+        create_dma_tlb_config(dst_addr, core, noc_id, WindowFlags::UnicastWrite),
         DmaDirection::H2D);
 }
 
@@ -269,7 +269,7 @@ bool PcieProtocol::dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pai
         dst,
         size,
         src_addr,
-        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        create_dma_tlb_config(src_addr, core, noc_id, WindowFlags::UnicastRead),
         DmaDirection::D2H);
 }
 
@@ -279,7 +279,7 @@ bool PcieProtocol::dma_multicast_write(
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
+        create_dma_tlb_config(dst_addr, core_end, noc_id, WindowFlags::MulticastWrite, core_start),
         DmaDirection::H2D);
 }
 
@@ -289,7 +289,7 @@ bool PcieProtocol::dma_read_zero_copy(
         dst_iova,
         size,
         src_addr,
-        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        create_dma_tlb_config(src_addr, core, noc_id, WindowFlags::UnicastRead),
         DmaDirection::D2H);
 }
 
@@ -299,7 +299,7 @@ bool PcieProtocol::dma_write_zero_copy(
         src_iova,
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
+        create_dma_tlb_config(dst_addr, core, noc_id, WindowFlags::UnicastWrite),
         DmaDirection::H2D);
 }
 
@@ -309,7 +309,7 @@ bool PcieProtocol::dma_multicast_write_zero_copy(
         src_iova,
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
+        create_dma_tlb_config(dst_addr, core_end, noc_id, WindowFlags::MulticastWrite, core_start),
         DmaDirection::H2D);
 }
 
@@ -318,14 +318,14 @@ bool PcieProtocol::dma_multicast_write_zero_copy(
 // (the target core). When core_start is provided, the transfer becomes a multicast to the
 // core range [core_start, core_end].
 tlb_data PcieProtocol::create_dma_tlb_config(
-    uint64_t addr, tt_xy_pair core_end, NocId noc_id, TlbVcDirection direction, std::optional<tt_xy_pair> core_start) {
+    uint64_t addr, tt_xy_pair core_end, NocId noc_id, WindowFlags flags, std::optional<tt_xy_pair> core_start) {
     tlb_data config{};
     config.local_offset = addr;
     config.x_end = core_end.x;
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = tlb_data::Relaxed;
-    config.set_static_vc(get_architecture_tlbs(pci_device_->get_arch()).get_static_vc(direction));
+    config.set_static_vc(get_architecture_tlbs(pci_device_->get_arch()).get_static_vc(flags));
     if (core_start) {
         config.x_start = core_start->x;
         config.y_start = core_start->y;

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -75,66 +75,34 @@ TlbWindow* PcieProtocol::get_cached_tlb_window() {
         cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
             get_architecture_tlbs(pci_device_->get_arch()).cached_window_size, TlbMapping::UC));
         cached_tlb_window_->set_io_timeout_hang_check(hang_check_);
+        cached_tlb_window_->set_safe_io(use_safe_api_);
     }
     return cached_tlb_window_.get();
 }
 
 void PcieProtocol::write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    // The cached window carries the per-op MMIO timeout veto (built from its configured NOC + the wired
+    // hang check) and the installed safe-I/O policy; see SiliconTlbWindow. The reconfigure call sets the
+    // NOC before the transfer runs.
     std::lock_guard<std::mutex> lock(io_lock_);
-    if (use_safe_api_) {
-        write_data_impl<true>(mem_ptr, core, addr, size, noc_id);
-    } else {
-        write_data_impl<false>(mem_ptr, core, addr, size, noc_id);
-    }
+    write_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
 }
 
 void PcieProtocol::read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
-    if (use_safe_api_) {
-        read_data_impl<true>(mem_ptr, core, addr, size, noc_id);
-    } else {
-        read_data_impl<false>(mem_ptr, core, addr, size, noc_id);
-    }
-}
-
-template <bool safe>
-void PcieProtocol::write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
-    // The cached window carries the per-op MMIO timeout veto (built from its configured NOC + the wired
-    // hang check); see SiliconTlbWindow. The reconfigure call sets the NOC before the transfer runs.
-    if constexpr (safe) {
-        get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
-    } else {
-        write_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
-    }
-}
-
-template <bool safe>
-void PcieProtocol::read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
-    if constexpr (safe) {
-        get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
-    } else {
-        read_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
-    }
+    read_block_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
 }
 
 void PcieProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
     std::lock_guard<std::mutex> lock(io_lock_);
-    if (use_safe_api_) {
-        get_cached_tlb_window()->safe_write_register_reconfigure(mem_ptr, core, addr, size, noc_id);
-    } else {
-        write_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
-    }
+    write_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
 }
 
 void PcieProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
     std::lock_guard<std::mutex> lock(io_lock_);
-    if (use_safe_api_) {
-        get_cached_tlb_window()->safe_read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
-    } else {
-        read_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
-    }
+    read_register_reconfigure(*get_cached_tlb_window(), mem_ptr, core, addr, size, noc_id);
 }
 
 bool PcieProtocol::write_to_core_range(
@@ -153,12 +121,7 @@ void PcieProtocol::set_power_state(PowerState state) {
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
-    if (use_safe_api_) {
-        get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
-    } else {
-        noc_multicast_write_reconfigure(*get_cached_tlb_window(), src, size, core_start, core_end, addr, noc_id);
-    }
+    noc_multicast_write_reconfigure(*get_cached_tlb_window(), src, size, core_start, core_end, addr, noc_id);
 }
 
 void PcieProtocol::bar_write32(uint32_t addr, uint32_t data) {

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -12,6 +12,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -169,7 +170,7 @@ void SimulationTTDevice::host_write(CoreCoord core, uint64_t addr, const void* m
         return;
     }
     if (should_use_cached_tlb_window()) {
-        cached_tlb_window_->write_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+        write_block_reconfigure(*cached_tlb_window_, mem_ptr, translated_core, addr, size, get_selected_noc_id());
     } else {
         tile_write_bytes(translated_core, addr, mem_ptr, size);
     }
@@ -185,7 +186,7 @@ void SimulationTTDevice::host_read(CoreCoord core, uint64_t addr, void* mem_ptr,
         return;
     }
     if (should_use_cached_tlb_window()) {
-        cached_tlb_window_->read_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+        read_block_reconfigure(*cached_tlb_window_, mem_ptr, translated_core, addr, size, get_selected_noc_id());
     } else {
         tile_read_bytes(translated_core, addr, mem_ptr, size);
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
+#include "pcie/io_window_reconfigure.hpp"
 #include "tracy.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
@@ -402,7 +403,7 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
             // DeviceTimeoutError propagating out of the probe read is therefore not expected — let it surface
             // rather than silently masking it as a hang.
             uint32_t value = 0;
-            window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
+            read_block_reconfigure(*window, &value, core, addr, sizeof(value), noc);
             return value;
         });
 }

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
@@ -420,14 +421,14 @@ TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathRoundTrip) {
 
     // Write through the 4GB window (hits BAR4), read back through both the direct API and the
     // same 4GB window — all three views must agree.
-    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size, NocId::NOC0);
+    write_block_reconfigure(*tlb_window, write_data.data(), core, addr, data_size, NocId::NOC0);
 
     std::vector<uint8_t> direct_read(data_size, 0);
     tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
     EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write";
 
     std::vector<uint8_t> tlb_read(data_size, 0);
-    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size, NocId::NOC0);
+    read_block_reconfigure(*tlb_window, tlb_read.data(), core, addr, data_size, NocId::NOC0);
     EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write";
 }
 
@@ -452,14 +453,14 @@ TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathDramRoundTrip) {
     constexpr uint64_t addr = 0x1000;
     auto write_data = make_pattern(data_size, [](size_t i) { return (i * 13 + 5) % 256; });
 
-    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size, NocId::NOC0);
+    write_block_reconfigure(*tlb_window, write_data.data(), core, addr, data_size, NocId::NOC0);
 
     std::vector<uint8_t> direct_read(data_size, 0);
     tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
     EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write to DRAM";
 
     std::vector<uint8_t> tlb_read(data_size, 0);
-    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size, NocId::NOC0);
+    read_block_reconfigure(*tlb_window, tlb_read.data(), core, addr, data_size, NocId::NOC0);
     EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write to DRAM";
 }
 

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "pcie/io_window_reconfigure.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/io_window/io_window.hpp"
@@ -653,10 +654,10 @@ TEST_F(TestTlb, TestRegisterReconfigureL1RoundTrip) {
 
         auto tlb_window = std::make_unique<SiliconTlbWindow>(pci_device->allocate_tlb(tlb_size, TlbMapping::UC));
 
-        tlb_window->write_register_reconfigure(pattern.data(), xy, l1_start, test_size, NocId::NOC0);
+        write_register_reconfigure(*tlb_window, pattern.data(), xy, l1_start, test_size, NocId::NOC0);
 
         std::vector<uint32_t> readback(num_words, 0);
-        tlb_window->read_register_reconfigure(readback.data(), xy, l1_start, test_size, NocId::NOC0);
+        read_register_reconfigure(*tlb_window, readback.data(), xy, l1_start, test_size, NocId::NOC0);
 
         EXPECT_EQ(readback, pattern) << "Mismatch on core " << it->str();
     }


### PR DESCRIPTION
### Issue
Part of https://github.com/tenstorrent/tt-umd/issues/2875

### Description
use_safe_api_ is PcieProtocol-lifetime state, not a per-call choice, and the hang check is already installed per-window. This makes safety the same kind of window-level policy, collapsing the mirrored safe_*/*_reconfigure method family and the if constexpr(safe) dispatch into direct calls through the free *_reconfigure functions.

### List of the changes
 - TlbWindow gains an IoSafety constructor parameter (defaults to Disabled, fixed for the window's lifetime); its safe_* and *_reconfigure member forwarders are removed.
 - SiliconTlbWindow routes each memory-access op through execute_safe() only when IoSafety::Enabled; sim windows drop their trivial safe_write16/safe_read16 overrides.
 - PcieProtocol constructs the cached window with IoSafety derived from use_safe_api_ and calls the free reconfigure functions unconditionally, removing the write_data_impl<bool safe>/read_data_impl<bool safe> templates.

### Testing
 - CI
 - Local runs of adjusted warm reset tests from tests/api/test_warm_reset.cpp 

### API Changes
- removing the safe_*/*_reconfigure member methods from TlbWindow
- new IoSafety enum, taken as a defaulted TlbWindow/SiliconTlbWindow constructor parameter
