### PR TITLE
check translation enabled from soc descriptor

### DIFF
--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -686,7 +686,7 @@ tt_xy_pair TTDevice::get_arc_core(const NocId noc_id) const {
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
+        get_soc_descriptor().noc_translation_enabled,
         error::RuntimeError,
         "Multicast not implemented for devices without NOC translation enabled.");
     ZoneScopedC(tracy::Color::Orange);
@@ -720,7 +720,7 @@ void TTDevice::noc_multicast_write(
 
 void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
     UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
+        get_soc_descriptor().noc_translation_enabled,
         error::RuntimeError,
         "Multicast not implemented for devices without NOC translation enabled.");
     auto [start, end] =


### PR DESCRIPTION
### Description
noc multicast checked whether translation was enabled by calling get_chip_info(), which makes unnecessary device reads to check what is already recorded in the soc descriptor. 
get_soc_descriptor() is both faster and avoids failures for n300 because get_chip_info() throws an exception for a simulated remote chip.