### PR TITLE
Add cross-host RDMA dma-buf P2P example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,3 +15,4 @@ endif()
 # Add all example subdirectories
 add_subdirectory(tt_device_example)
 add_subdirectory(reset_notification_example)
+add_subdirectory(rdma_dmabuf_p2p)

--- a/examples/rdma_dmabuf_p2p/CMakeLists.txt
+++ b/examples/rdma_dmabuf_p2p/CMakeLists.txt
@@ -1,0 +1,31 @@
+# This example drives real RDMA verbs, so it needs libibverbs. It is skipped rather than failing
+# the configure step when libibverbs-dev is not installed, so enabling TT_UMD_BUILD_EXAMPLES stays
+# safe on hosts without an RDMA stack.
+find_library(IBVERBS_LIBRARY NAMES ibverbs)
+if(NOT IBVERBS_LIBRARY)
+    message(STATUS "rdma_dmabuf_p2p example: libibverbs not found, skipping")
+    return()
+endif()
+
+add_executable(dmabuf_target dmabuf_target.cpp)
+
+target_link_libraries(
+    dmabuf_target
+    PRIVATE
+        umd::tt-umd
+        tt-logger::tt-logger
+        ${IBVERBS_LIBRARY}
+)
+
+# The initiator only speaks RDMA against a plain host buffer, so it does not link UMD.
+add_executable(dmabuf_initiator dmabuf_initiator.cpp)
+
+target_link_libraries(dmabuf_initiator PRIVATE ${IBVERBS_LIBRARY})
+
+set_target_properties(
+    dmabuf_target
+    dmabuf_initiator
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${CMAKE_BINARY_DIR}/examples/rdma_dmabuf_p2p/
+)

--- a/examples/rdma_dmabuf_p2p/CMakeLists.txt
+++ b/examples/rdma_dmabuf_p2p/CMakeLists.txt
@@ -1,9 +1,40 @@
 # This example drives real RDMA verbs, so it needs libibverbs. It is skipped rather than failing
 # the configure step when libibverbs-dev is not installed, so enabling TT_UMD_BUILD_EXAMPLES stays
 # safe on hosts without an RDMA stack.
+#
+# Both the library and the headers are located: a host with libibverbs1 but not libibverbs-dev passes
+# find_library and would then hard-fail the build on "#include <infiniband/verbs.h>: No such file or
+# directory" — exactly the case the skip is meant to cover.
 find_library(IBVERBS_LIBRARY NAMES ibverbs)
-if(NOT IBVERBS_LIBRARY)
-    message(STATUS "rdma_dmabuf_p2p example: libibverbs not found, skipping")
+find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
+if(NOT (IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR))
+    message(STATUS "rdma_dmabuf_p2p example: libibverbs library or headers not found, skipping")
+    return()
+endif()
+
+# The headers also have to be new enough: ibv_reg_dmabuf_mr() needs rdma-core >= v33 and
+# ibv_query_gid_ex() >= v32, and both are called unconditionally below. Without this check an older
+# rdma-core fails with a bare "was not declared in this scope" that says nothing about the cause.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${IBVERBS_LIBRARY})
+check_cxx_symbol_exists(
+    ibv_reg_dmabuf_mr
+    "infiniband/verbs.h"
+    HAVE_IBV_REG_DMABUF_MR
+)
+check_cxx_symbol_exists(
+    ibv_query_gid_ex
+    "infiniband/verbs.h"
+    HAVE_IBV_QUERY_GID_EX
+)
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(NOT (HAVE_IBV_REG_DMABUF_MR AND HAVE_IBV_QUERY_GID_EX))
+    message(
+        STATUS
+        "rdma_dmabuf_p2p example: libibverbs is too old (need rdma-core >= v33 for ibv_reg_dmabuf_mr and >= v32 for ibv_query_gid_ex), skipping"
+    )
     return()
 endif()
 
@@ -16,11 +47,13 @@ target_link_libraries(
         tt-logger::tt-logger
         ${IBVERBS_LIBRARY}
 )
+target_include_directories(dmabuf_target PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 # The initiator only speaks RDMA against a plain host buffer, so it does not link UMD.
 add_executable(dmabuf_initiator dmabuf_initiator.cpp)
 
 target_link_libraries(dmabuf_initiator PRIVATE ${IBVERBS_LIBRARY})
+target_include_directories(dmabuf_initiator PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 set_target_properties(
     dmabuf_target

--- a/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RDMA initiator for the two-host dma-buf bandwidth test. Registers a normal host-memory MR filled
+// with a known test pattern, brings up an RC QP against the target, and issues repeated RDMA WRITEs
+// into the target's dma-buf-backed MR (see dmabuf_target.cpp) to measure sustained write bandwidth.
+// No UMD dependency here at all.
+#include <infiniband/verbs.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rdma_common.hpp"
+
+namespace {
+
+struct Args {
+    std::string host;
+    uint16_t port = 9999;
+    // 64 MiB: must match dmabuf_target's --size (Blackhole DRAM_BANK_SIZE is 4 GiB, so there's
+    // plenty of headroom vs the old Tensix-L1-backed 1.5 MiB ceiling).
+    uint64_t size = 64ull << 20;
+    uint64_t iters = 100;  // number of RDMA ops of --size bytes to issue, timed as one batch
+    int ib_port = 1;
+    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";  // "write" = host -> device NOC; "read" = device NOC -> host
+};
+
+Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto next = [&]() { return std::string(argv[++i]); };
+        if (arg == "--host") {
+            a.host = next();
+        } else if (arg == "--port") {
+            a.port = static_cast<uint16_t>(std::stoi(next()));
+        } else if (arg == "--size") {
+            a.size = std::stoull(next());
+        } else if (arg == "--iters") {
+            a.iters = std::stoull(next());
+        } else if (arg == "--ib-port") {
+            a.ib_port = std::stoi(next());
+        } else if (arg == "--gid-index") {
+            a.gid_index = std::stoi(next());
+        } else if (arg == "--op") {
+            a.op = next();
+        }
+    }
+    return a;
+}
+
+// Number of in-flight, unsignaled RDMA_WRITEs between each polled completion. RC QPs complete
+// WQEs in order, so polling one CQE every SIGNAL_INTERVAL writes still confirms all of them landed.
+// Kept at 1 (fully synchronous, one WRITE in flight at a time): at the default 64 MiB --size,
+// ibv_poll_cq overhead is negligible next to per-message transfer time, so there's nothing to gain
+// from batching completions — and batching here is actively dangerous, since going over 32 previously
+// left ~2 GiB of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget
+// ("transport retry counter exceeded") on a real fabric. Only raise this if you've confirmed the
+// fabric tolerates more bytes in flight for your chosen --size.
+constexpr uint64_t SIGNAL_INTERVAL = 1;
+
+}  // namespace
+
+int run(int argc, char** argv) {
+    Args args = parse_args(argc, argv);
+    if (args.host.empty()) {
+        std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]"
+                  << " [--op write|read] [--gid-index N]" << std::endl;
+        return 1;
+    }
+    if (args.op != "write" && args.op != "read") {
+        std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        return 1;
+    }
+    const bool is_read = (args.op == "read");
+
+    std::vector<uint8_t> local_buf(args.size);
+    if (is_read) {
+        // RDMA_READ pulls device memory into this buffer, so prefill with a sentinel that is NOT the
+        // expected pattern — otherwise a read that silently moved nothing would still "verify".
+        // The target seeds the real pattern into device memory via UMD before the handshake.
+        std::fill(local_buf.begin(), local_buf.end(), 0xAA);
+    } else {
+        // Test pattern: byte i = i & 0xFF, so the target can verify without needing to share the
+        // buffer contents out of band.
+        for (size_t i = 0; i < args.size; ++i) {
+            local_buf[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+    }
+
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        std::cerr << "No RDMA devices found" << std::endl;
+        return 1;
+    }
+    ibv_context* ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!ctx) {
+        std::cerr << "ibv_open_device failed" << std::endl;
+        return 1;
+    }
+
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
+        std::cerr << "ibv_query_port failed" << std::endl;
+        return 1;
+    }
+    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
+    if (is_roce) {
+        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
+    }
+
+    ibv_pd* pd = ibv_alloc_pd(ctx);
+    ibv_mr* mr = ibv_reg_mr(pd, local_buf.data(), local_buf.size(), IBV_ACCESS_LOCAL_WRITE);
+    if (!mr) {
+        perror("ibv_reg_mr failed");
+        return 1;
+    }
+
+    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
+    ibv_qp_init_attr qp_init_attr{};
+    qp_init_attr.send_cq = cq;
+    qp_init_attr.recv_cq = cq;
+    qp_init_attr.qp_type = IBV_QPT_RC;
+    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
+    // between polls.
+    qp_init_attr.cap.max_send_wr = static_cast<uint32_t>(SIGNAL_INTERVAL);
+    qp_init_attr.cap.max_recv_wr = 1;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
+    if (!qp) {
+        std::cerr << "ibv_create_qp failed" << std::endl;
+        return 1;
+    }
+
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_INIT;
+        attr.pkey_index = 0;
+        attr.port_num = args.ib_port;
+        attr.qp_access_flags = 0;
+        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to INIT" << std::endl;
+            return 1;
+        }
+    }
+
+    QpExchangeInfo local{};
+    local.qpn = qp->qp_num;
+    local.psn = 0x5678;
+    if (is_roce) {
+        ibv_gid gid{};
+        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
+            std::cerr << "ibv_query_gid failed" << std::endl;
+            return 1;
+        }
+        std::memcpy(local.gid, gid.raw, 16);
+    } else {
+        local.lid = port_attr.lid;
+    }
+
+    std::cout << "Connecting to " << args.host << ":" << args.port << "..." << std::endl;
+    int conn = tcp_connect(args.host, args.port);
+    QpExchangeInfo remote{};
+    recv_all(conn, &remote, sizeof(remote));
+    send_all(conn, &local, sizeof(local));
+    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << std::endl;
+
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTR;
+        attr.path_mtu = IBV_MTU_1024;
+        attr.dest_qp_num = remote.qpn;
+        attr.rq_psn = remote.psn;
+        attr.max_dest_rd_atomic = 1;
+        attr.min_rnr_timer = 12;
+        attr.ah_attr.port_num = args.ib_port;
+        if (is_roce) {
+            attr.ah_attr.is_global = 1;
+            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
+            attr.ah_attr.grh.sgid_index = args.gid_index;
+            attr.ah_attr.grh.hop_limit = 1;
+        } else {
+            attr.ah_attr.is_global = 0;
+            attr.ah_attr.dlid = remote.lid;
+        }
+        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTR" << std::endl;
+            return 1;
+        }
+    }
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTS;
+        attr.timeout = 14;
+        attr.retry_cnt = 7;
+        attr.rnr_retry = 7;
+        attr.sq_psn = local.psn;
+        attr.max_rd_atomic = 1;
+        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                    IBV_QP_MAX_QP_RD_ATOMIC;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTS" << std::endl;
+            return 1;
+        }
+    }
+
+    // Repeatedly move --size bytes between local_buf and the target's dma-buf MR at iova 0 (see
+    // dmabuf_target.cpp; the dma-buf MR was registered with iova=0, so remote_addr here must also be
+    // 0). Every iteration touches the same remote window, which is fine for a bandwidth measurement:
+    // in write mode each iteration reproduces the identical pattern, and in read mode the source
+    // device memory is never modified.
+    //
+    // Direction note: WRITE pushes host -> device NOC and is "posted" on the target's PCIe link
+    // (fire-and-forget, pipelines well). READ pulls device NOC -> host, which makes the target NIC
+    // issue *non-posted* PCIe reads against the card's BAR — each needs a completion to come back, so
+    // throughput is bounded by read-completion concurrency and latency rather than raw link
+    // bandwidth. Expect READ to be substantially slower than WRITE on the same link.
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<uint64_t>(local_buf.data());
+    sge.length = static_cast<uint32_t>(local_buf.size());
+    sge.lkey = mr->lkey;
+
+    ibv_send_wr wr{};
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = is_read ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
+    wr.wr.rdma.remote_addr = remote.remote_addr;
+    wr.wr.rdma.rkey = remote.rkey;
+
+    const char* op_name = is_read ? "READ" : "WRITE";
+    std::cout << "Issuing " << args.iters << " x " << args.size << " byte RDMA " << op_name << "s..." << std::endl;
+    auto t_start = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < args.iters; ++i) {
+        bool signal = ((i + 1) % SIGNAL_INTERVAL == 0) || (i + 1 == args.iters);
+        wr.wr_id = i;
+        wr.send_flags = signal ? IBV_SEND_SIGNALED : 0;
+
+        ibv_send_wr* bad_wr = nullptr;
+        if (ibv_post_send(qp, &wr, &bad_wr)) {
+            std::cerr << "ibv_post_send failed at iter " << i << std::endl;
+            return 1;
+        }
+
+        if (signal) {
+            ibv_wc wc{};
+            int n = 0;
+            while (n == 0) {
+                n = ibv_poll_cq(cq, 1, &wc);
+                if (n < 0) {
+                    std::cerr << "ibv_poll_cq failed" << std::endl;
+                    return 1;
+                }
+            }
+            if (wc.status != IBV_WC_SUCCESS) {
+                // wc.wr_id, not the loop counter i: once a fatal transport error hits, the QP flushes
+                // all outstanding WQEs, so the CQE we get back may belong to an earlier, still-unsignaled
+                // op rather than the one posted this iteration.
+                std::cerr << "RDMA " << op_name << " failed, wr_id=" << wc.wr_id << ": " << ibv_wc_status_str(wc.status)
+                          << std::endl;
+                return 1;
+            }
+        }
+    }
+    auto t_end = std::chrono::steady_clock::now();
+
+    double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
+    double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
+    double gbps = total_bytes / elapsed_s / 1e9;
+    std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
+              << " s => " << gbps << " GB/s" << std::endl;
+
+    // In read mode the data landed on *this* side, so verification happens here rather than on the
+    // target: check that the pattern the target seeded into device memory actually arrived, and that
+    // we're not just looking at the 0xAA sentinel.
+    bool all_match = true;
+    if (is_read) {
+        for (size_t i = 0; i < args.size && i < 4096; ++i) {
+            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
+            if (local_buf[i] != expected) {
+                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
+                          << static_cast<int>(local_buf[i]) << std::endl;
+                all_match = false;
+                break;
+            }
+        }
+        std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
+    }
+
+    // Signal the target that the batch is done (a real hardware ACK from the CQE above, not just
+    // "posted") so it can verify (write mode) or tear down (read mode).
+    char done = 1;
+    send_all(conn, &done, 1);
+
+    close(conn);
+    ibv_destroy_qp(qp);
+    ibv_destroy_cq(cq);
+    ibv_dereg_mr(mr);
+    ibv_dealloc_pd(pd);
+    ibv_close_device(ctx);
+    return all_match ? 0 : 1;
+}
+
+int main(int argc, char** argv) {
+    // tcp_connect()/send_all()/recv_all() and resolve_gid_index() throw; catch here so a
+    // handshake or config failure prints a clean error instead of an uncaught-exception core dump.
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
@@ -24,34 +24,46 @@ namespace {
 struct Args {
     std::string host;
     uint16_t port = 9999;
-    // 64 MiB: must match dmabuf_target's --size (Blackhole DRAM_BANK_SIZE is 4 GiB, so there's
-    // plenty of headroom vs the old Tensix-L1-backed 1.5 MiB ceiling).
-    uint64_t size = 64ull << 20;
-    uint64_t iters = 100;  // number of RDMA ops of --size bytes to issue, timed as one batch
-    int ib_port = 1;
+    // Must match dmabuf_target's --size, which defaults to the same value for the arch reasons
+    // documented there (2 MiB is the only size class valid on both Wormhole and Blackhole).
+    uint64_t size = 2ull << 20;
+    uint64_t iters = 100;      // number of RDMA ops of --size bytes to issue, timed as one batch
+    std::string dev;           // empty = first RDMA device with an ACTIVE port
+    int ib_port = -1;          // -1 = first ACTIVE port on that device
     int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
     std::string op = "write";  // "write" = host -> device NOC; "read" = device NOC -> host
 };
+
+void print_usage() {
+    std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]\n"
+              << "                        [--dev NAME] [--ib-port N] [--gid-index N] [--op write|read]" << std::endl;
+}
 
 Args parse_args(int argc, char** argv) {
     Args a;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        auto next = [&]() { return std::string(argv[++i]); };
         if (arg == "--host") {
-            a.host = next();
+            a.host = arg_value(argc, argv, i);
         } else if (arg == "--port") {
-            a.port = static_cast<uint16_t>(std::stoi(next()));
+            a.port = static_cast<uint16_t>(std::stoi(arg_value(argc, argv, i)));
         } else if (arg == "--size") {
-            a.size = std::stoull(next());
+            a.size = std::stoull(arg_value(argc, argv, i));
         } else if (arg == "--iters") {
-            a.iters = std::stoull(next());
+            a.iters = std::stoull(arg_value(argc, argv, i));
+        } else if (arg == "--dev") {
+            a.dev = arg_value(argc, argv, i);
         } else if (arg == "--ib-port") {
-            a.ib_port = std::stoi(next());
+            a.ib_port = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--gid-index") {
-            a.gid_index = std::stoi(next());
+            a.gid_index = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--op") {
-            a.op = next();
+            a.op = arg_value(argc, argv, i);
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage();
+            std::exit(0);
+        } else {
+            throw std::runtime_error("Unknown argument '" + arg + "'");
         }
     }
     return a;
@@ -59,12 +71,12 @@ Args parse_args(int argc, char** argv) {
 
 // Number of in-flight, unsignaled RDMA_WRITEs between each polled completion. RC QPs complete
 // WQEs in order, so polling one CQE every SIGNAL_INTERVAL writes still confirms all of them landed.
-// Kept at 1 (fully synchronous, one WRITE in flight at a time): at the default 64 MiB --size,
-// ibv_poll_cq overhead is negligible next to per-message transfer time, so there's nothing to gain
-// from batching completions — and batching here is actively dangerous, since going over 32 previously
-// left ~2 GiB of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget
-// ("transport retry counter exceeded") on a real fabric. Only raise this if you've confirmed the
-// fabric tolerates more bytes in flight for your chosen --size.
+// Kept at 1 (fully synchronous, one WRITE in flight at a time): at these transfer sizes ibv_poll_cq
+// overhead is negligible next to per-message transfer time, so there's nothing to gain from batching
+// completions — and batching here is actively dangerous, since going over 32 previously left ~2 GiB
+// of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget ("transport
+// retry counter exceeded") on a real fabric. Only raise this if you've confirmed the fabric tolerates
+// more bytes in flight for your chosen --size.
 constexpr uint64_t SIGNAL_INTERVAL = 1;
 
 }  // namespace
@@ -72,8 +84,7 @@ constexpr uint64_t SIGNAL_INTERVAL = 1;
 int run(int argc, char** argv) {
     Args args = parse_args(argc, argv);
     if (args.host.empty()) {
-        std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]"
-                  << " [--op write|read] [--gid-index N]" << std::endl;
+        print_usage();
         return 1;
     }
     if (args.op != "write" && args.op != "read") {
@@ -82,6 +93,22 @@ int run(int argc, char** argv) {
     }
     const bool is_read = (args.op == "read");
 
+    // Validate --size before allocating anything for it. One work request carries one SGE, whose
+    // length is a uint32_t, while --size is a uint64_t: --size 4294967296 (4 GiB, a natural choice on
+    // Blackhole) truncates sge.length to 0, so every WQE moves nothing, every CQE reports success,
+    // and the bandwidth line below — computed from --size x --iters — reports a fabricated number as
+    // a pass.
+    if (args.size == 0) {
+        std::cerr << "--size must be non-zero" << std::endl;
+        return 1;
+    }
+    if (args.size > UINT32_MAX) {
+        std::cerr << "--size " << args.size << " exceeds the " << UINT32_MAX
+                  << " byte limit of a single RDMA work request; split the transfer or use a smaller --size"
+                  << std::endl;
+        return 1;
+    }
+
     std::vector<uint8_t> local_buf(args.size);
     if (is_read) {
         // RDMA_READ pulls device memory into this buffer, so prefill with a sentinel that is NOT the
@@ -89,134 +116,68 @@ int run(int argc, char** argv) {
         // The target seeds the real pattern into device memory via UMD before the handshake.
         std::fill(local_buf.begin(), local_buf.end(), 0xAA);
     } else {
-        // Test pattern: byte i = i & 0xFF, so the target can verify without needing to share the
-        // buffer contents out of band.
-        for (size_t i = 0; i < args.size; ++i) {
-            local_buf[i] = static_cast<uint8_t>(i & 0xFF);
-        }
+        // Position-dependent pattern, so the target can verify without needing the buffer contents
+        // out of band, and a misaddressed or partial transfer cannot accidentally match.
+        fill_pattern(local_buf.data(), local_buf.size());
     }
 
-    int num_devices = 0;
-    ibv_device** dev_list = ibv_get_device_list(&num_devices);
-    if (!dev_list || num_devices == 0) {
-        std::cerr << "No RDMA devices found" << std::endl;
-        return 1;
+    RdmaPort rdma = open_active_rdma_port(args.dev, args.ib_port);
+    if (rdma.is_roce()) {
+        args.gid_index = resolve_gid_index(rdma.ctx, rdma.ib_port, args.gid_index);
     }
-    ibv_context* ctx = ibv_open_device(dev_list[0]);
-    ibv_free_device_list(dev_list);
-    if (!ctx) {
-        std::cerr << "ibv_open_device failed" << std::endl;
+
+    // port_attr.max_msg_sz is the device's own per-message ceiling (commonly 1 GiB), checked for the
+    // same reason as the uint32_t limit above; it needs an opened port, so it lands here.
+    if (args.size > rdma.port_attr.max_msg_sz) {
+        std::cerr << "--size " << args.size << " exceeds the port's max_msg_sz of " << rdma.port_attr.max_msg_sz
+                  << " bytes" << std::endl;
         return 1;
     }
 
-    ibv_port_attr port_attr{};
-    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
-        std::cerr << "ibv_query_port failed" << std::endl;
+    ibv_pd* pd = ibv_alloc_pd(rdma.ctx);
+    if (!pd) {
+        std::cerr << "ibv_alloc_pd failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
-    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
-    if (is_roce) {
-        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
-    }
 
-    ibv_pd* pd = ibv_alloc_pd(ctx);
     ibv_mr* mr = ibv_reg_mr(pd, local_buf.data(), local_buf.size(), IBV_ACCESS_LOCAL_WRITE);
     if (!mr) {
         perror("ibv_reg_mr failed");
         return 1;
     }
 
-    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
-    ibv_qp_init_attr qp_init_attr{};
-    qp_init_attr.send_cq = cq;
-    qp_init_attr.recv_cq = cq;
-    qp_init_attr.qp_type = IBV_QPT_RC;
-    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
-    // between polls.
-    qp_init_attr.cap.max_send_wr = static_cast<uint32_t>(SIGNAL_INTERVAL);
-    qp_init_attr.cap.max_recv_wr = 1;
-    qp_init_attr.cap.max_send_sge = 1;
-    qp_init_attr.cap.max_recv_sge = 1;
-    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
-    if (!qp) {
-        std::cerr << "ibv_create_qp failed" << std::endl;
+    ibv_cq* cq = ibv_create_cq(rdma.ctx, 1, nullptr, nullptr, 0);
+    if (!cq) {
+        std::cerr << "ibv_create_cq failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_INIT;
-        attr.pkey_index = 0;
-        attr.port_num = args.ib_port;
-        attr.qp_access_flags = 0;
-        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to INIT" << std::endl;
-            return 1;
-        }
-    }
+    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
+    // between polls. No remote access is served on this side, so the QP needs no access flags.
+    ibv_qp* qp = create_rc_qp(pd, cq, rdma.ib_port, static_cast<uint32_t>(SIGNAL_INTERVAL), 0);
 
-    QpExchangeInfo local{};
-    local.qpn = qp->qp_num;
-    local.psn = 0x5678;
-    if (is_roce) {
-        ibv_gid gid{};
-        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
-            std::cerr << "ibv_query_gid failed" << std::endl;
-            return 1;
-        }
-        std::memcpy(local.gid, gid.raw, 16);
-    } else {
-        local.lid = port_attr.lid;
-    }
+    QpExchangeInfo local = make_local_exchange_info(rdma, args.gid_index, qp->qp_num, 0x5678);
 
     std::cout << "Connecting to " << args.host << ":" << args.port << "..." << std::endl;
     int conn = tcp_connect(args.host, args.port);
     QpExchangeInfo remote{};
     recv_all(conn, &remote, sizeof(remote));
     send_all(conn, &local, sizeof(local));
-    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << std::endl;
+    check_peer_exchange_info(remote);
+    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << " mr_length=" << remote.mr_length
+              << std::endl;
 
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTR;
-        attr.path_mtu = IBV_MTU_1024;
-        attr.dest_qp_num = remote.qpn;
-        attr.rq_psn = remote.psn;
-        attr.max_dest_rd_atomic = 1;
-        attr.min_rnr_timer = 12;
-        attr.ah_attr.port_num = args.ib_port;
-        if (is_roce) {
-            attr.ah_attr.is_global = 1;
-            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
-            attr.ah_attr.grh.sgid_index = args.gid_index;
-            attr.ah_attr.grh.hop_limit = 1;
-        } else {
-            attr.ah_attr.is_global = 0;
-            attr.ah_attr.dlid = remote.lid;
-        }
-        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
-                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTR" << std::endl;
-            return 1;
-        }
+    // The two binaries are launched independently with their own --size. A larger local size overruns
+    // the target's MR and dies with IBV_WC_REM_ACCESS_ERR at iteration 0, indistinguishable from a
+    // permissions or dma-buf failure; a smaller one succeeds and prints a bandwidth figure for a
+    // window that was never fully written.
+    if (remote.mr_length != args.size) {
+        std::cerr << "Size mismatch: this side has --size " << args.size << " but the target exported "
+                  << remote.mr_length << " bytes. Launch both with the same --size." << std::endl;
+        return 1;
     }
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTS;
-        attr.timeout = 14;
-        attr.retry_cnt = 7;
-        attr.rnr_retry = 7;
-        attr.sq_psn = local.psn;
-        attr.max_rd_atomic = 1;
-        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
-                    IBV_QP_MAX_QP_RD_ATOMIC;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTS" << std::endl;
-            return 1;
-        }
-    }
+
+    connect_rc_qp(qp, rdma, args.gid_index, remote, local.psn);
 
     // Repeatedly move --size bytes between local_buf and the target's dma-buf MR at iova 0 (see
     // dmabuf_target.cpp; the dma-buf MR was registered with iova=0, so remote_addr here must also be
@@ -243,16 +204,19 @@ int run(int argc, char** argv) {
 
     const char* op_name = is_read ? "READ" : "WRITE";
     std::cout << "Issuing " << args.iters << " x " << args.size << " byte RDMA " << op_name << "s..." << std::endl;
+
+    bool batch_ok = true;
     auto t_start = std::chrono::steady_clock::now();
-    for (uint64_t i = 0; i < args.iters; ++i) {
+    for (uint64_t i = 0; i < args.iters && batch_ok; ++i) {
         bool signal = ((i + 1) % SIGNAL_INTERVAL == 0) || (i + 1 == args.iters);
         wr.wr_id = i;
         wr.send_flags = signal ? IBV_SEND_SIGNALED : 0;
 
         ibv_send_wr* bad_wr = nullptr;
         if (ibv_post_send(qp, &wr, &bad_wr)) {
-            std::cerr << "ibv_post_send failed at iter " << i << std::endl;
-            return 1;
+            std::cerr << "ibv_post_send failed at iter " << i << ": " << std::strerror(errno) << std::endl;
+            batch_ok = false;
+            break;
         }
 
         if (signal) {
@@ -262,61 +226,63 @@ int run(int argc, char** argv) {
                 n = ibv_poll_cq(cq, 1, &wc);
                 if (n < 0) {
                     std::cerr << "ibv_poll_cq failed" << std::endl;
-                    return 1;
+                    batch_ok = false;
+                    break;
                 }
             }
-            if (wc.status != IBV_WC_SUCCESS) {
+            if (batch_ok && wc.status != IBV_WC_SUCCESS) {
                 // wc.wr_id, not the loop counter i: once a fatal transport error hits, the QP flushes
                 // all outstanding WQEs, so the CQE we get back may belong to an earlier, still-unsignaled
                 // op rather than the one posted this iteration.
                 std::cerr << "RDMA " << op_name << " failed, wr_id=" << wc.wr_id << ": " << ibv_wc_status_str(wc.status)
                           << std::endl;
-                return 1;
+                batch_ok = false;
             }
         }
     }
     auto t_end = std::chrono::steady_clock::now();
 
-    double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
-    double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
-    double gbps = total_bytes / elapsed_s / 1e9;
-    std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
-              << " s => " << gbps << " GB/s" << std::endl;
+    if (batch_ok) {
+        double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
+        double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
+        double gbps = total_bytes / elapsed_s / 1e9;
+        std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
+                  << " s => " << gbps << " GB/s" << std::endl;
+    }
 
     // In read mode the data landed on *this* side, so verification happens here rather than on the
     // target: check that the pattern the target seeded into device memory actually arrived, and that
-    // we're not just looking at the 0xAA sentinel.
-    bool all_match = true;
-    if (is_read) {
-        for (size_t i = 0; i < args.size && i < 4096; ++i) {
-            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
-            if (local_buf[i] != expected) {
-                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
-                          << static_cast<int>(local_buf[i]) << std::endl;
-                all_match = false;
-                break;
-            }
+    // we're not just looking at the 0xAA sentinel. The compare covers the whole buffer, since a
+    // prefix-only check passes when only the first page was transferred.
+    bool all_match = batch_ok;
+    if (batch_ok && is_read) {
+        const size_t mismatch = find_pattern_mismatch(local_buf.data(), local_buf.size());
+        if (mismatch != local_buf.size()) {
+            std::cerr << "Mismatch at byte " << mismatch << ": expected " << static_cast<int>(pattern_byte(mismatch))
+                      << " got " << static_cast<int>(local_buf[mismatch]) << std::endl;
+            all_match = false;
         }
         std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
     }
 
-    // Signal the target that the batch is done (a real hardware ACK from the CQE above, not just
-    // "posted") so it can verify (write mode) or tear down (read mode).
-    char done = 1;
-    send_all(conn, &done, 1);
+    // Report the outcome to the target rather than an unconditional "done": it owns the device and is
+    // the natural side for a CI harness to watch, so a failure here has to reach its exit status too.
+    BatchResult result = all_match ? BatchResult::Pass : BatchResult::Fail;
+    send_all(conn, &result, 1);
 
     close(conn);
     ibv_destroy_qp(qp);
     ibv_destroy_cq(cq);
     ibv_dereg_mr(mr);
     ibv_dealloc_pd(pd);
-    ibv_close_device(ctx);
+    ibv_close_device(rdma.ctx);
     return all_match ? 0 : 1;
 }
 
 int main(int argc, char** argv) {
-    // tcp_connect()/send_all()/recv_all() and resolve_gid_index() throw; catch here so a
-    // handshake or config failure prints a clean error instead of an uncaught-exception core dump.
+    // tcp_connect()/send_all()/recv_all(), the RDMA bring-up helpers and resolve_gid_index() all
+    // throw; catch here so a handshake or config failure prints a clean error instead of an
+    // uncaught-exception core dump.
     try {
         return run(argc, argv);
     } catch (const std::exception& e) {

--- a/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
@@ -13,7 +13,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "rdma_common.hpp"
@@ -21,6 +23,7 @@
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -31,34 +34,65 @@ struct Args {
     uint16_t port = 9999;
     tt::ChipId chip = 0;
     uint64_t addr = 0;
-    // 64 MiB: comfortably under Blackhole DRAM_BANK_SIZE (4 GiB, device/api/umd/device/arch/
-    // blackhole_implementation.hpp) and large enough that per-message RDMA/CQE overhead doesn't
-    // dominate the bandwidth measurement. addr + size must stay within a single DRAM bank.
-    uint64_t size = 64ull << 20;
-    int ib_port = 1;
-    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
-    std::string op = "write";  // must match the initiator's --op: decides who seeds and who verifies
+    // 2 MiB, and it must stay a value that is a valid TLB window size class on every arch: Wormhole
+    // offers {1, 2, 16} MiB and Blackhole {2 MiB, 4 GiB} (get_tlb_sizes() in the *_implementation.hpp
+    // headers). export_dmabuf() rounds up to the next class that can cover the request, so a larger
+    // default throws outright on Wormhole ("No TLB window size can cover ...") and on Blackhole
+    // quietly consumes one of the few 4 GiB windows. Raise it with --size when you know the arch.
+    uint64_t size = 2ull << 20;
+    std::string dev;                   // empty = first RDMA device with an ACTIVE port
+    int ib_port = -1;                  // -1 = first ACTIVE port on that device
+    int gid_index = -1;                // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";          // must match the initiator's --op: decides who seeds and who verifies
+    std::string ordering = "relaxed";  // TLB window ordering mode for the export
 };
+
+void print_usage() {
+    std::cerr << "Usage: dmabuf_target [--port N] [--chip N] [--addr 0xN] [--size N] [--dev NAME]\n"
+              << "                     [--ib-port N] [--gid-index N] [--op write|read]\n"
+              << "                     [--ordering relaxed|posted|strict]" << std::endl;
+}
+
+uint64_t parse_ordering(const std::string& name) {
+    if (name == "relaxed") {
+        return tlb_data::Relaxed;
+    }
+    if (name == "posted") {
+        return tlb_data::Posted;
+    }
+    if (name == "strict") {
+        return tlb_data::Strict;
+    }
+    throw std::runtime_error("--ordering must be relaxed, posted or strict, got '" + name + "'");
+}
 
 Args parse_args(int argc, char** argv) {
     Args a;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        auto next = [&]() { return std::string(argv[++i]); };
         if (arg == "--port") {
-            a.port = static_cast<uint16_t>(std::stoi(next()));
+            a.port = static_cast<uint16_t>(std::stoi(arg_value(argc, argv, i)));
         } else if (arg == "--chip") {
-            a.chip = std::stoi(next());
+            a.chip = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--addr") {
-            a.addr = std::stoull(next(), nullptr, 0);
+            a.addr = std::stoull(arg_value(argc, argv, i), nullptr, 0);
         } else if (arg == "--size") {
-            a.size = std::stoull(next());
+            a.size = std::stoull(arg_value(argc, argv, i));
+        } else if (arg == "--dev") {
+            a.dev = arg_value(argc, argv, i);
         } else if (arg == "--ib-port") {
-            a.ib_port = std::stoi(next());
+            a.ib_port = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--gid-index") {
-            a.gid_index = std::stoi(next());
+            a.gid_index = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--op") {
-            a.op = next();
+            a.op = arg_value(argc, argv, i);
+        } else if (arg == "--ordering") {
+            a.ordering = arg_value(argc, argv, i);
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage();
+            std::exit(0);
+        } else {
+            throw std::runtime_error("Unknown argument '" + arg + "'");
         }
     }
     return a;
@@ -70,9 +104,11 @@ int run(int argc, char** argv) {
     Args args = parse_args(argc, argv);
     if (args.op != "write" && args.op != "read") {
         std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        print_usage();
         return 1;
     }
     const bool is_read = (args.op == "read");
+    const uint64_t ordering = parse_ordering(args.ordering);
 
     // --- UMD side: export a TLB window as a dma-buf ------------------------------------------
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
@@ -85,38 +121,28 @@ int run(int argc, char** argv) {
     CoreCoord core = dram_cores.front();
 
     std::cout << "Exporting TLB window: chip=" << args.chip << " core=(" << core.x << "," << core.y << ") addr=0x"
-              << std::hex << args.addr << std::dec << " size=" << args.size << std::endl;
+              << std::hex << args.addr << std::dec << " size=" << args.size << " ordering=" << args.ordering
+              << std::endl;
 
     // export_dmabuf() takes the export length directly and rounds the underlying TLB window up to
     // the arch's next valid size class internally, so --size needs no arch-specific adjustment here.
-    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size);
+    // It throws on every failure path (bad alignment, no window large enough, KMD too old), so the
+    // returned fd is always valid; main()'s handler turns a throw into a clean "Fatal: ..." line.
+    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size, ordering);
     std::cout << "Got dma-buf fd " << dmabuf_fd << std::endl;
 
     // --- RDMA side: register the dma-buf as an MR --------------------------------------------
-    int num_devices = 0;
-    ibv_device** dev_list = ibv_get_device_list(&num_devices);
-    if (!dev_list || num_devices == 0) {
-        std::cerr << "No RDMA devices found" << std::endl;
-        return 1;
+    RdmaPort rdma = open_active_rdma_port(args.dev, args.ib_port);
+    if (rdma.is_roce()) {
+        args.gid_index = resolve_gid_index(rdma.ctx, rdma.ib_port, args.gid_index);
     }
-    ibv_context* ctx = ibv_open_device(dev_list[0]);
-    ibv_free_device_list(dev_list);
-    if (!ctx) {
-        std::cerr << "ibv_open_device failed" << std::endl;
+
+    ibv_pd* pd = ibv_alloc_pd(rdma.ctx);
+    if (!pd) {
+        std::cerr << "ibv_alloc_pd failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    ibv_port_attr port_attr{};
-    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
-        std::cerr << "ibv_query_port failed" << std::endl;
-        return 1;
-    }
-    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
-    if (is_roce) {
-        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
-    }
-
-    ibv_pd* pd = ibv_alloc_pd(ctx);
     // offset=0, iova=0: the dma-buf has no CPU-side virtual address, so remote_addr on the
     // initiator's WRITE/READ must also be 0 to match this MR's iova.
     //
@@ -130,61 +156,27 @@ int run(int argc, char** argv) {
         return 1;
     }
 
-    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
-    ibv_qp_init_attr qp_init_attr{};
-    qp_init_attr.send_cq = cq;
-    qp_init_attr.recv_cq = cq;
-    qp_init_attr.qp_type = IBV_QPT_RC;
-    qp_init_attr.cap.max_send_wr = 1;
-    qp_init_attr.cap.max_recv_wr = 1;
-    qp_init_attr.cap.max_send_sge = 1;
-    qp_init_attr.cap.max_recv_sge = 1;
-    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
-    if (!qp) {
-        std::cerr << "ibv_create_qp failed" << std::endl;
+    ibv_cq* cq = ibv_create_cq(rdma.ctx, 1, nullptr, nullptr, 0);
+    if (!cq) {
+        std::cerr << "ibv_create_cq failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    // INIT
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_INIT;
-        attr.pkey_index = 0;
-        attr.port_num = args.ib_port;
-        // Same reasoning as the MR flags above: the QP must permit remote reads too, or an
-        // RDMA_READ is rejected at the QP level even though the MR allows it.
-        attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
-        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to INIT" << std::endl;
-            return 1;
-        }
-    }
+    // The QP must permit remote reads too, or an RDMA_READ is rejected at the QP level even though
+    // the MR above allows it.
+    ibv_qp* qp = create_rc_qp(pd, cq, rdma.ib_port, 1, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
 
-    QpExchangeInfo local{};
-    local.qpn = qp->qp_num;
-    local.psn = 0x1234;
+    QpExchangeInfo local = make_local_exchange_info(rdma, args.gid_index, qp->qp_num, 0x1234);
     local.rkey = mr->rkey;
     local.remote_addr = 0;
-    if (is_roce) {
-        ibv_gid gid{};
-        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
-            std::cerr << "ibv_query_gid failed" << std::endl;
-            return 1;
-        }
-        std::memcpy(local.gid, gid.raw, 16);
-    } else {
-        local.lid = port_attr.lid;
-    }
+    local.mr_length = args.size;
 
     // In read mode the initiator pulls *from* device memory, so the pattern has to already be there.
     // Seed it via UMD (a path independent of the exported window) before the handshake, so it is in
     // place before the peer can possibly issue a READ.
     if (is_read) {
         std::vector<uint8_t> seed(args.size);
-        for (size_t i = 0; i < args.size; ++i) {
-            seed[i] = static_cast<uint8_t>(i & 0xFF);
-        }
+        fill_pattern(seed.data(), seed.size());
         cluster->write_to_device(seed.data(), seed.size(), args.chip, core, args.addr);
         std::cout << "Seeded " << args.size << " bytes of test pattern into device memory via UMD" << std::endl;
     }
@@ -195,79 +187,45 @@ int run(int argc, char** argv) {
     QpExchangeInfo remote{};
     send_all(conn, &local, sizeof(local));
     recv_all(conn, &remote, sizeof(remote));
+    check_peer_exchange_info(remote);
     std::cout << "Peer QPN=" << remote.qpn << std::endl;
 
-    // RTR
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTR;
-        attr.path_mtu = IBV_MTU_1024;
-        attr.dest_qp_num = remote.qpn;
-        attr.rq_psn = remote.psn;
-        attr.max_dest_rd_atomic = 1;
-        attr.min_rnr_timer = 12;
-        attr.ah_attr.port_num = args.ib_port;
-        if (is_roce) {
-            attr.ah_attr.is_global = 1;
-            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
-            attr.ah_attr.grh.sgid_index = args.gid_index;
-            attr.ah_attr.grh.hop_limit = 1;
-        } else {
-            attr.ah_attr.is_global = 0;
-            attr.ah_attr.dlid = remote.lid;
-        }
-        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
-                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTR" << std::endl;
-            return 1;
-        }
-    }
-    // RTS
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTS;
-        attr.timeout = 14;
-        attr.retry_cnt = 7;
-        attr.rnr_retry = 7;
-        attr.sq_psn = local.psn;
-        attr.max_rd_atomic = 1;
-        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
-                    IBV_QP_MAX_QP_RD_ATOMIC;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTS" << std::endl;
-            return 1;
-        }
+    connect_rc_qp(qp, rdma, args.gid_index, remote, local.psn);
+
+    // Wait for the initiator to report the outcome of its RDMA batch (a real hardware ACK, not just
+    // "posted"), so a failure on its side becomes a failure here too.
+    BatchResult peer_result = BatchResult::Fail;
+    recv_all(conn, &peer_result, 1);
+    if (peer_result != BatchResult::Pass) {
+        std::cerr << "Initiator reported FAIL for its RDMA batch" << std::endl;
     }
 
-    // Wait for the initiator to signal its RDMA batch has completed (a real hardware ACK, not just
-    // "posted").
-    char done = 0;
-    recv_all(conn, &done, 1);
-
-    bool all_match = true;
+    bool all_match = (peer_result == BatchResult::Pass);
     if (is_read) {
         // The data moved device -> host, so the initiator holds it and verifies on its side; there is
         // nothing to check here. Device memory should be unchanged from what we seeded.
         std::cout << "Initiator signaled read complete; it verifies the pattern on its side." << std::endl;
-    } else {
+    } else if (all_match) {
         std::cout << "Initiator signaled write complete; verifying via UMD readback..." << std::endl;
+
+        // The initiator's CQE only proves its NIC got a RoCE-level ACK; it says nothing about the
+        // resulting PCIe -> TLB -> NOC -> DRAM writes having landed. The readback below goes through a
+        // *different* TLB window, and the exported window's default Relaxed ordering imposes nothing
+        // against it, so without a barrier this races the tail of the RDMA batch and shows up as an
+        // intermittent, unreproducible "Mismatch at byte N" that reads as a dma-buf bug.
+        cluster->dram_membar(args.chip, std::unordered_set<CoreCoord>{core});
 
         std::vector<uint8_t> readback(args.size);
         cluster->read_from_device(readback.data(), args.chip, core, args.addr, args.size);
 
-        for (size_t i = 0; i < args.size && i < 4096; ++i) {
-            // Initiator fills its buffer with pattern byte = (i & 0xFF); check the first 4KiB, enough
-            // to catch a wrong-address / wrong-fd / stale-data class of bug without a slow full compare.
-            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
-            if (readback[i] != expected) {
-                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
-                          << static_cast<int>(readback[i]) << std::endl;
-                all_match = false;
-                break;
-            }
+        // Full compare against a position-dependent pattern: a prefix-only check passes when just the
+        // first page landed, and a byte-periodic pattern cannot detect a wrong-address bug at all.
+        const size_t mismatch = find_pattern_mismatch(readback.data(), readback.size());
+        if (mismatch != readback.size()) {
+            std::cerr << "Mismatch at byte " << mismatch << ": expected " << static_cast<int>(pattern_byte(mismatch))
+                      << " got " << static_cast<int>(readback[mismatch]) << std::endl;
+            all_match = false;
         }
-
         std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
     }
 
@@ -277,13 +235,13 @@ int run(int argc, char** argv) {
     ibv_destroy_cq(cq);
     ibv_dereg_mr(mr);
     ibv_dealloc_pd(pd);
-    ibv_close_device(ctx);
+    ibv_close_device(rdma.ctx);
     return all_match ? 0 : 1;
 }
 
 int main(int argc, char** argv) {
-    // recv_all()/send_all() throw on a dropped connection (e.g. the initiator dying mid-run); catch
-    // here so a peer failure prints a clean error instead of an uncaught-exception core dump.
+    // recv_all()/send_all(), the RDMA bring-up helpers and export_dmabuf() all throw; catch here so a
+    // peer or config failure prints a clean error instead of an uncaught-exception core dump.
     try {
         return run(argc, argv);
     } catch (const std::exception& e) {

--- a/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RDMA target for the two-host dma-buf bandwidth test. Exports a TLB window via UMD's
+// Cluster::export_dmabuf(), registers the resulting fd as an RDMA MR with ibv_reg_dmabuf_mr(), and
+// waits for a peer NIC to RDMA-WRITE into it (repeatedly, to measure sustained bandwidth). Verifies
+// the final write landed by reading the same NOC address back through UMD (a path independent of
+// the exported window).
+#include <infiniband/verbs.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rdma_common.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+namespace {
+
+struct Args {
+    uint16_t port = 9999;
+    tt::ChipId chip = 0;
+    uint64_t addr = 0;
+    // 64 MiB: comfortably under Blackhole DRAM_BANK_SIZE (4 GiB, device/api/umd/device/arch/
+    // blackhole_implementation.hpp) and large enough that per-message RDMA/CQE overhead doesn't
+    // dominate the bandwidth measurement. addr + size must stay within a single DRAM bank.
+    uint64_t size = 64ull << 20;
+    int ib_port = 1;
+    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";  // must match the initiator's --op: decides who seeds and who verifies
+};
+
+Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto next = [&]() { return std::string(argv[++i]); };
+        if (arg == "--port") {
+            a.port = static_cast<uint16_t>(std::stoi(next()));
+        } else if (arg == "--chip") {
+            a.chip = std::stoi(next());
+        } else if (arg == "--addr") {
+            a.addr = std::stoull(next(), nullptr, 0);
+        } else if (arg == "--size") {
+            a.size = std::stoull(next());
+        } else if (arg == "--ib-port") {
+            a.ib_port = std::stoi(next());
+        } else if (arg == "--gid-index") {
+            a.gid_index = std::stoi(next());
+        } else if (arg == "--op") {
+            a.op = next();
+        }
+    }
+    return a;
+}
+
+}  // namespace
+
+int run(int argc, char** argv) {
+    Args args = parse_args(argc, argv);
+    if (args.op != "write" && args.op != "read") {
+        std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        return 1;
+    }
+    const bool is_read = (args.op == "read");
+
+    // --- UMD side: export a TLB window as a dma-buf ------------------------------------------
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    const SocDescriptor& soc_desc = cluster->get_soc_descriptor(args.chip);
+    std::vector<CoreCoord> dram_cores = soc_desc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    if (dram_cores.empty()) {
+        std::cerr << "No DRAM cores found on chip " << args.chip << std::endl;
+        return 1;
+    }
+    CoreCoord core = dram_cores.front();
+
+    std::cout << "Exporting TLB window: chip=" << args.chip << " core=(" << core.x << "," << core.y << ") addr=0x"
+              << std::hex << args.addr << std::dec << " size=" << args.size << std::endl;
+
+    // export_dmabuf() takes the export length directly and rounds the underlying TLB window up to
+    // the arch's next valid size class internally, so --size needs no arch-specific adjustment here.
+    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size);
+    std::cout << "Got dma-buf fd " << dmabuf_fd << std::endl;
+
+    // --- RDMA side: register the dma-buf as an MR --------------------------------------------
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        std::cerr << "No RDMA devices found" << std::endl;
+        return 1;
+    }
+    ibv_context* ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!ctx) {
+        std::cerr << "ibv_open_device failed" << std::endl;
+        return 1;
+    }
+
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
+        std::cerr << "ibv_query_port failed" << std::endl;
+        return 1;
+    }
+    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
+    if (is_roce) {
+        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
+    }
+
+    ibv_pd* pd = ibv_alloc_pd(ctx);
+    // offset=0, iova=0: the dma-buf has no CPU-side virtual address, so remote_addr on the
+    // initiator's WRITE/READ must also be 0 to match this MR's iova.
+    //
+    // REMOTE_READ is granted unconditionally alongside REMOTE_WRITE so one target invocation serves
+    // either direction. Omitting it is the classic way an RDMA_READ dies with
+    // IBV_WC_REM_ACCESS_ERR on the initiator while the write path looks perfectly healthy.
+    ibv_mr* mr = ibv_reg_dmabuf_mr(
+        pd, 0, args.size, 0, dmabuf_fd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
+    if (!mr) {
+        perror("ibv_reg_dmabuf_mr failed");
+        return 1;
+    }
+
+    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
+    ibv_qp_init_attr qp_init_attr{};
+    qp_init_attr.send_cq = cq;
+    qp_init_attr.recv_cq = cq;
+    qp_init_attr.qp_type = IBV_QPT_RC;
+    qp_init_attr.cap.max_send_wr = 1;
+    qp_init_attr.cap.max_recv_wr = 1;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
+    if (!qp) {
+        std::cerr << "ibv_create_qp failed" << std::endl;
+        return 1;
+    }
+
+    // INIT
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_INIT;
+        attr.pkey_index = 0;
+        attr.port_num = args.ib_port;
+        // Same reasoning as the MR flags above: the QP must permit remote reads too, or an
+        // RDMA_READ is rejected at the QP level even though the MR allows it.
+        attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
+        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to INIT" << std::endl;
+            return 1;
+        }
+    }
+
+    QpExchangeInfo local{};
+    local.qpn = qp->qp_num;
+    local.psn = 0x1234;
+    local.rkey = mr->rkey;
+    local.remote_addr = 0;
+    if (is_roce) {
+        ibv_gid gid{};
+        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
+            std::cerr << "ibv_query_gid failed" << std::endl;
+            return 1;
+        }
+        std::memcpy(local.gid, gid.raw, 16);
+    } else {
+        local.lid = port_attr.lid;
+    }
+
+    // In read mode the initiator pulls *from* device memory, so the pattern has to already be there.
+    // Seed it via UMD (a path independent of the exported window) before the handshake, so it is in
+    // place before the peer can possibly issue a READ.
+    if (is_read) {
+        std::vector<uint8_t> seed(args.size);
+        for (size_t i = 0; i < args.size; ++i) {
+            seed[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+        cluster->write_to_device(seed.data(), seed.size(), args.chip, core, args.addr);
+        std::cout << "Seeded " << args.size << " bytes of test pattern into device memory via UMD" << std::endl;
+    }
+
+    // --- OOB handshake -------------------------------------------------------------------------
+    std::cout << "Waiting for initiator on port " << args.port << "..." << std::endl;
+    int conn = tcp_listen_accept(args.port);
+    QpExchangeInfo remote{};
+    send_all(conn, &local, sizeof(local));
+    recv_all(conn, &remote, sizeof(remote));
+    std::cout << "Peer QPN=" << remote.qpn << std::endl;
+
+    // RTR
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTR;
+        attr.path_mtu = IBV_MTU_1024;
+        attr.dest_qp_num = remote.qpn;
+        attr.rq_psn = remote.psn;
+        attr.max_dest_rd_atomic = 1;
+        attr.min_rnr_timer = 12;
+        attr.ah_attr.port_num = args.ib_port;
+        if (is_roce) {
+            attr.ah_attr.is_global = 1;
+            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
+            attr.ah_attr.grh.sgid_index = args.gid_index;
+            attr.ah_attr.grh.hop_limit = 1;
+        } else {
+            attr.ah_attr.is_global = 0;
+            attr.ah_attr.dlid = remote.lid;
+        }
+        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTR" << std::endl;
+            return 1;
+        }
+    }
+    // RTS
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTS;
+        attr.timeout = 14;
+        attr.retry_cnt = 7;
+        attr.rnr_retry = 7;
+        attr.sq_psn = local.psn;
+        attr.max_rd_atomic = 1;
+        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                    IBV_QP_MAX_QP_RD_ATOMIC;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTS" << std::endl;
+            return 1;
+        }
+    }
+
+    // Wait for the initiator to signal its RDMA batch has completed (a real hardware ACK, not just
+    // "posted").
+    char done = 0;
+    recv_all(conn, &done, 1);
+
+    bool all_match = true;
+    if (is_read) {
+        // The data moved device -> host, so the initiator holds it and verifies on its side; there is
+        // nothing to check here. Device memory should be unchanged from what we seeded.
+        std::cout << "Initiator signaled read complete; it verifies the pattern on its side." << std::endl;
+    } else {
+        std::cout << "Initiator signaled write complete; verifying via UMD readback..." << std::endl;
+
+        std::vector<uint8_t> readback(args.size);
+        cluster->read_from_device(readback.data(), args.chip, core, args.addr, args.size);
+
+        for (size_t i = 0; i < args.size && i < 4096; ++i) {
+            // Initiator fills its buffer with pattern byte = (i & 0xFF); check the first 4KiB, enough
+            // to catch a wrong-address / wrong-fd / stale-data class of bug without a slow full compare.
+            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
+            if (readback[i] != expected) {
+                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
+                          << static_cast<int>(readback[i]) << std::endl;
+                all_match = false;
+                break;
+            }
+        }
+
+        std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
+    }
+
+    close(conn);
+    close(dmabuf_fd);
+    ibv_destroy_qp(qp);
+    ibv_destroy_cq(cq);
+    ibv_dereg_mr(mr);
+    ibv_dealloc_pd(pd);
+    ibv_close_device(ctx);
+    return all_match ? 0 : 1;
+}
+
+int main(int argc, char** argv) {
+    // recv_all()/send_all() throw on a dropped connection (e.g. the initiator dying mid-run); catch
+    // here so a peer failure prints a clean error instead of an uncaught-exception core dump.
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/examples/rdma_dmabuf_p2p/rdma_common.hpp
+++ b/examples/rdma_dmabuf_p2p/rdma_common.hpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared helpers for the two-host dma-buf RDMA example: the out-of-band TCP handshake used to
-// exchange QP/rkey info, and RoCEv2 GID selection.
+// Shared helpers for the two-host dma-buf RDMA example: command-line parsing, the out-of-band TCP
+// handshake used to exchange QP/rkey info, RDMA device/GID selection, RC QP bring-up, and the
+// verification pattern. Both binaries use these, so the bring-up exists once rather than twice.
 #pragma once
 
 #include <arpa/inet.h>
@@ -13,6 +14,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -20,16 +23,171 @@
 #include <string>
 
 // Out-of-band info exchanged between the two hosts to bring up the RC QP.
-// Sent as a flat, fixed-size struct over a plain TCP socket (no serialization library needed).
+//
+// Sent as a flat struct over a plain TCP socket (no serialization library needed). The field order
+// is chosen so every member is naturally aligned with no implicit padding, and the static_assert
+// below pins the resulting size: a silent layout change between the initiator's and the target's
+// build would otherwise corrupt the handshake in a way that surfaces as an unrelated RDMA error.
+// `magic` catches the mismatched-build case at runtime. Both hosts are assumed to be the same
+// endianness (x86 <-> x86); this is an example, not a portable wire protocol.
 struct QpExchangeInfo {
+    uint32_t magic = 0;  // MAGIC below; guards against a mismatched or stale peer build
     uint32_t qpn = 0;
     uint32_t psn = 0;
-    uint16_t lid = 0;          // valid only if the port's link layer is InfiniBand
-    uint8_t gid[16] = {0};     // valid only if the port's link layer is Ethernet (RoCE)
-    uint32_t rkey = 0;         // target's dma-buf MR rkey; unused/zero from the initiator
-    uint64_t remote_addr = 0;  // target's dma-buf MR iova (we register with iova=0, so this is 0);
-                               // kept explicit so the initiator doesn't have to hardcode it
+    uint32_t rkey = 0;           // target's dma-buf MR rkey; unused/zero from the initiator
+    uint64_t remote_addr = 0;    // target's dma-buf MR iova (we register with iova=0, so this is 0);
+                                 // kept explicit so the initiator doesn't have to hardcode it
+    uint64_t mr_length = 0;      // target's MR length in bytes. The two binaries are launched
+                                 // independently with their own --size; the initiator compares this
+                                 // against its own and refuses a mismatch, which would otherwise be
+                                 // either IBV_WC_REM_ACCESS_ERR at iter 0 (initiator larger) or a
+                                 // bandwidth figure for a partly-written window (initiator smaller).
+    uint16_t lid = 0;            // valid only if the port's link layer is InfiniBand
+    uint16_t reserved = 0;       // explicit, so the 16-byte gid below stays aligned with no padding
+    uint8_t gid[16] = {0};       // valid only if the port's link layer is Ethernet (RoCE)
+    uint8_t reserved2[4] = {0};  // explicit tail padding to the struct's 8-byte alignment, so the
+                                 // wire size is stated here rather than chosen by the compiler
+
+    static constexpr uint32_t MAGIC = 0x54544442;  // "TTDB"
 };
+
+static_assert(sizeof(QpExchangeInfo) == 56, "QpExchangeInfo must stay padding-free; the peer parses it byte-for-byte");
+
+// Sent by the initiator after its RDMA batch, in place of the old unconditional 1 byte. The target
+// propagates a FAIL into its own exit status: without this the initiator can print FAIL and return 1
+// while the target returns 0, and a CI harness watching the target (the side that owns the device)
+// records a clean pass on a data-corruption run.
+enum class BatchResult : uint8_t {
+    Pass = 1,
+    Fail = 2,
+};
+
+// Position-dependent verification pattern: a golden-ratio multiplier per 64-bit word, so the value
+// at a given offset is unique across any realistic window. A byte-periodic pattern (e.g. i & 0xFF)
+// cannot detect a wrong-address bug at all, since any offset that is a multiple of the period
+// verifies clean.
+constexpr uint64_t PATTERN_MULT = 0x9E3779B97F4A7C15ULL;
+
+inline uint8_t pattern_byte(size_t offset) {
+    const uint64_t word = static_cast<uint64_t>(offset / sizeof(uint64_t)) * PATTERN_MULT;
+    return static_cast<uint8_t>(word >> (8 * (offset % sizeof(uint64_t))));
+}
+
+inline void fill_pattern(uint8_t* buf, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        buf[i] = pattern_byte(i);
+    }
+}
+
+// Returns the offset of the first mismatching byte, or `size` if the whole buffer matches. The
+// compare covers the entire buffer: checking only a prefix lets a transfer where just the first page
+// landed pass.
+inline size_t find_pattern_mismatch(const uint8_t* buf, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        if (buf[i] != pattern_byte(i)) {
+            return i;
+        }
+    }
+    return size;
+}
+
+// --- command line ----------------------------------------------------------------------------
+
+// Value of the argument following `argv[i]`, advancing `i`. Throws when the flag is trailing:
+// `argv[++i]` at i == argc - 1 reads argv[argc], the guaranteed NULL terminator, and constructing a
+// std::string from it is UB (in practice a segfault inside strlen, before any usage message).
+inline std::string arg_value(int argc, char** argv, int& i) {
+    const std::string flag = argv[i];
+    if (i + 1 >= argc) {
+        throw std::runtime_error(flag + " requires a value");
+    }
+    return std::string(argv[++i]);
+}
+
+// --- RDMA device / port selection ------------------------------------------------------------
+
+// An opened RDMA device plus the port to use on it. The caller owns `ctx` and must ibv_close_device()
+// it.
+struct RdmaPort {
+    ibv_context* ctx = nullptr;
+    std::string dev_name;
+    int ib_port = 1;
+    ibv_port_attr port_attr{};
+
+    bool is_roce() const { return port_attr.link_layer == IBV_LINK_LAYER_ETHERNET; }
+};
+
+// Opens an RDMA device and picks a port that is actually usable.
+//
+// With no --dev/--ib-port override, scans every device and every port 1..phys_port_cnt and takes the
+// first in state IBV_PORT_ACTIVE. Taking dev_list[0]/port 1 blindly picks a DOWN NIC on a multi-NIC
+// host, which then either reports "no RoCEv2 GID" or brings the QP up on a dead port and times out —
+// while UMD's own has_any_active_rdma_port() check has already passed on a *different* device.
+//
+// An explicit device or port is honoured, but a non-ACTIVE choice is rejected rather than used.
+inline RdmaPort open_active_rdma_port(const std::string& requested_dev, int requested_port) {
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        if (dev_list) {
+            ibv_free_device_list(dev_list);
+        }
+        throw std::runtime_error("No RDMA devices found under /sys/class/infiniband");
+    }
+
+    RdmaPort result;
+    std::string tried;
+    for (int d = 0; d < num_devices && !result.ctx; ++d) {
+        const std::string name = ibv_get_device_name(dev_list[d]);
+        if (!requested_dev.empty() && name != requested_dev) {
+            continue;
+        }
+
+        ibv_context* ctx = ibv_open_device(dev_list[d]);
+        if (!ctx) {
+            tried += " " + name + "(open failed)";
+            continue;
+        }
+
+        ibv_device_attr dev_attr{};
+        if (ibv_query_device(ctx, &dev_attr)) {
+            ibv_close_device(ctx);
+            tried += " " + name + "(query failed)";
+            continue;
+        }
+
+        const int first_port = requested_port > 0 ? requested_port : 1;
+        const int last_port = requested_port > 0 ? requested_port : dev_attr.phys_port_cnt;
+        for (int p = first_port; p <= last_port; ++p) {
+            ibv_port_attr port_attr{};
+            if (ibv_query_port(ctx, p, &port_attr)) {
+                tried += " " + name + ":" + std::to_string(p) + "(query failed)";
+                continue;
+            }
+            if (port_attr.state != IBV_PORT_ACTIVE) {
+                tried += " " + name + ":" + std::to_string(p) + "(" + ibv_port_state_str(port_attr.state) + ")";
+                continue;
+            }
+            result.ctx = ctx;
+            result.dev_name = name;
+            result.ib_port = p;
+            result.port_attr = port_attr;
+            break;
+        }
+        if (!result.ctx) {
+            ibv_close_device(ctx);
+        }
+    }
+    ibv_free_device_list(dev_list);
+
+    if (!result.ctx) {
+        throw std::runtime_error("No RDMA port in the ACTIVE state found; tried:" + (tried.empty() ? " none" : tried));
+    }
+    std::cout << "Using RDMA device " << result.dev_name << " port " << result.ib_port << " ("
+              << ibv_port_state_str(result.port_attr.state) << ", active_mtu=" << (128 << result.port_attr.active_mtu)
+              << " B)" << std::endl;
+    return result;
+}
 
 // Format a GID for logging, matching the ipv4-mapped-aware style of `show_gids`.
 inline std::string gid_to_string(const ibv_gid& gid) {
@@ -110,13 +268,133 @@ inline int resolve_gid_index(ibv_context* ctx, int ib_port, int requested) {
     return idx;
 }
 
+// --- RC QP bring-up --------------------------------------------------------------------------
+
+// Creates an RC QP in the INIT state. `access_flags` is the QP-level permission set: a QP serving
+// RDMA_READ needs IBV_ACCESS_REMOTE_READ here even when its MR already grants it, or the read is
+// rejected at the QP level.
+inline ibv_qp* create_rc_qp(ibv_pd* pd, ibv_cq* cq, int ib_port, uint32_t max_send_wr, int access_flags) {
+    ibv_qp_init_attr init_attr{};
+    init_attr.send_cq = cq;
+    init_attr.recv_cq = cq;
+    init_attr.qp_type = IBV_QPT_RC;
+    init_attr.cap.max_send_wr = max_send_wr;
+    init_attr.cap.max_recv_wr = 1;
+    init_attr.cap.max_send_sge = 1;
+    init_attr.cap.max_recv_sge = 1;
+
+    ibv_qp* qp = ibv_create_qp(pd, &init_attr);
+    if (!qp) {
+        throw std::runtime_error(std::string("ibv_create_qp failed: ") + std::strerror(errno));
+    }
+
+    ibv_qp_attr attr{};
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = static_cast<uint8_t>(ib_port);
+    attr.qp_access_flags = access_flags;
+    const int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+    if (ibv_modify_qp(qp, &attr, flags)) {
+        const std::string err = std::strerror(errno);
+        ibv_destroy_qp(qp);
+        throw std::runtime_error("ibv_modify_qp to INIT failed: " + err);
+    }
+    return qp;
+}
+
+// Moves `qp` INIT -> RTR (pointed at the peer described by `remote`) -> RTS.
+//
+// path_mtu is negotiated down from the port's active_mtu rather than hardcoded: pinning a
+// jumbo-frame fabric (active_mtu 4096) to 1 KiB inflates per-packet header overhead ~4x, so the very
+// bandwidth number this example exists to produce comes out silently low — and on a port whose
+// active_mtu is below the hardcoded value the RTR transition simply fails.
+//
+// hop_limit is 64, not 1. This is a cross-host example and the GID selection above deliberately
+// prefers the routable IPv4-mapped RoCEv2 GID, so a hop limit of 1 makes every packet die at the
+// first router the moment the hosts aren't on one L2 segment — surfacing as "transport retry counter
+// exceeded", which is exactly the symptom this file attributes to a RoCEv1 GID above.
+inline void connect_rc_qp(
+    ibv_qp* qp, const RdmaPort& port, int gid_index, const QpExchangeInfo& remote, uint32_t local_psn) {
+    const ibv_mtu mtu = std::min(port.port_attr.active_mtu, IBV_MTU_4096);
+
+    ibv_qp_attr rtr{};
+    rtr.qp_state = IBV_QPS_RTR;
+    rtr.path_mtu = mtu;
+    rtr.dest_qp_num = remote.qpn;
+    rtr.rq_psn = remote.psn;
+    rtr.max_dest_rd_atomic = 1;
+    rtr.min_rnr_timer = 12;
+    rtr.ah_attr.port_num = static_cast<uint8_t>(port.ib_port);
+    if (port.is_roce()) {
+        rtr.ah_attr.is_global = 1;
+        std::memcpy(rtr.ah_attr.grh.dgid.raw, remote.gid, 16);
+        rtr.ah_attr.grh.sgid_index = static_cast<uint8_t>(gid_index);
+        rtr.ah_attr.grh.hop_limit = 64;
+    } else {
+        rtr.ah_attr.is_global = 0;
+        rtr.ah_attr.dlid = remote.lid;
+    }
+    int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+    if (ibv_modify_qp(qp, &rtr, flags)) {
+        throw std::runtime_error(std::string("ibv_modify_qp to RTR failed: ") + std::strerror(errno));
+    }
+
+    ibv_qp_attr rts{};
+    rts.qp_state = IBV_QPS_RTS;
+    rts.timeout = 14;
+    rts.retry_cnt = 7;
+    rts.rnr_retry = 7;
+    rts.sq_psn = local_psn;
+    rts.max_rd_atomic = 1;
+    flags =
+        IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC;
+    if (ibv_modify_qp(qp, &rts, flags)) {
+        throw std::runtime_error(std::string("ibv_modify_qp to RTS failed: ") + std::strerror(errno));
+    }
+}
+
+// Fills in the local half of the handshake for `port`.
+inline QpExchangeInfo make_local_exchange_info(const RdmaPort& port, int gid_index, uint32_t qpn, uint32_t psn) {
+    QpExchangeInfo info{};
+    info.magic = QpExchangeInfo::MAGIC;
+    info.qpn = qpn;
+    info.psn = psn;
+    if (port.is_roce()) {
+        ibv_gid gid{};
+        if (ibv_query_gid(port.ctx, port.ib_port, gid_index, &gid)) {
+            throw std::runtime_error("ibv_query_gid failed");
+        }
+        std::memcpy(info.gid, gid.raw, 16);
+    } else {
+        info.lid = port.port_attr.lid;
+    }
+    return info;
+}
+
+inline void check_peer_exchange_info(const QpExchangeInfo& remote) {
+    if (remote.magic != QpExchangeInfo::MAGIC) {
+        throw std::runtime_error(
+            "Handshake magic mismatch (got " + std::to_string(remote.magic) +
+            "): the peer is running a different or stale build of this example");
+    }
+}
+
+// --- out-of-band TCP -------------------------------------------------------------------------
+
+// MSG_NOSIGNAL: without it, a send() to a socket whose peer has died (Ctrl-C, or a failed WQE) kills
+// this process with SIGPIPE — no exception, no error message, and no chance to close the exported
+// dma-buf and release the TLB window. EINTR is retried rather than treated as a connection error.
 inline void send_all(int fd, const void* buf, size_t len) {
     const char* p = static_cast<const char*>(buf);
     size_t sent = 0;
     while (sent < len) {
-        ssize_t n = send(fd, p + sent, len - sent, 0);
+        ssize_t n = send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
         if (n <= 0) {
-            throw std::runtime_error("send_all: connection error");
+            throw std::runtime_error(std::string("send_all: connection error: ") + std::strerror(errno));
         }
         sent += static_cast<size_t>(n);
     }
@@ -127,8 +405,14 @@ inline void recv_all(int fd, void* buf, size_t len) {
     size_t got = 0;
     while (got < len) {
         ssize_t n = recv(fd, p + got, len - got, 0);
-        if (n <= 0) {
-            throw std::runtime_error("recv_all: connection error");
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        if (n == 0) {
+            throw std::runtime_error("recv_all: peer closed the connection");
+        }
+        if (n < 0) {
+            throw std::runtime_error(std::string("recv_all: connection error: ") + std::strerror(errno));
         }
         got += static_cast<size_t>(n);
     }
@@ -148,13 +432,16 @@ inline int tcp_listen_accept(uint16_t port) {
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);
     if (bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        close(listen_fd);
         throw std::runtime_error("bind() failed");
     }
     if (listen(listen_fd, 1) < 0) {
+        close(listen_fd);
         throw std::runtime_error("listen() failed");
     }
     int conn_fd = accept(listen_fd, nullptr, nullptr);
     if (conn_fd < 0) {
+        close(listen_fd);
         throw std::runtime_error("accept() failed");
     }
     close(listen_fd);

--- a/examples/rdma_dmabuf_p2p/rdma_common.hpp
+++ b/examples/rdma_dmabuf_p2p/rdma_common.hpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared helpers for the two-host dma-buf RDMA example: the out-of-band TCP handshake used to
+// exchange QP/rkey info, and RoCEv2 GID selection.
+#pragma once
+
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+// Out-of-band info exchanged between the two hosts to bring up the RC QP.
+// Sent as a flat, fixed-size struct over a plain TCP socket (no serialization library needed).
+struct QpExchangeInfo {
+    uint32_t qpn = 0;
+    uint32_t psn = 0;
+    uint16_t lid = 0;          // valid only if the port's link layer is InfiniBand
+    uint8_t gid[16] = {0};     // valid only if the port's link layer is Ethernet (RoCE)
+    uint32_t rkey = 0;         // target's dma-buf MR rkey; unused/zero from the initiator
+    uint64_t remote_addr = 0;  // target's dma-buf MR iova (we register with iova=0, so this is 0);
+                               // kept explicit so the initiator doesn't have to hardcode it
+};
+
+// Format a GID for logging, matching the ipv4-mapped-aware style of `show_gids`.
+inline std::string gid_to_string(const ibv_gid& gid) {
+    char buf[INET6_ADDRSTRLEN] = {0};
+    if (!inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf))) {
+        return "<unprintable>";
+    }
+    return buf;
+}
+
+// Pick the GID index to use for a RoCE port.
+//
+// This matters a lot and is easy to get wrong: on these Broadcom BCM957608 NICs, GID index 0 is
+// RoCE *v1* with a link-local fe80:: address. RoCEv1 is a non-routable L2 protocol, and connecting
+// with it (even between hosts on the same subnet) produces no traffic the peer ever ACKs — the
+// symptom is the initiator failing its very first WRITE with "transport retry counter exceeded",
+// which is indistinguishable at a glance from a hardware/dma-buf problem. `ib_write_bw -x 0`
+// reproduces the same stall, so it's a fabric-config issue, not anything to do with UMD.
+//
+// Prefer a RoCEv2 GID with an IPv4-mapped address (::ffff:a.b.c.d), which is the routable,
+// switch-friendly choice; fall back to any non-link-local RoCEv2 GID. Returns -1 if none is found.
+inline int find_roce_v2_gid_index(ibv_context* ctx, int ib_port) {
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, ib_port, &port_attr)) {
+        return -1;
+    }
+
+    int fallback = -1;
+    for (int i = 0; i < port_attr.gid_tbl_len; ++i) {
+        ibv_gid_entry entry{};
+        if (ibv_query_gid_ex(ctx, static_cast<uint32_t>(ib_port), static_cast<uint32_t>(i), &entry, 0)) {
+            continue;  // ENODATA for empty table slots
+        }
+        if (entry.gid_type != IBV_GID_TYPE_ROCE_V2) {
+            continue;
+        }
+
+        const uint8_t* r = entry.gid.raw;
+        bool ipv4_mapped = (r[10] == 0xff && r[11] == 0xff);
+        for (int b = 0; b < 10 && ipv4_mapped; ++b) {
+            ipv4_mapped = (r[b] == 0x00);
+        }
+        if (ipv4_mapped) {
+            return i;
+        }
+        bool link_local = (r[0] == 0xfe && r[1] == 0x80);
+        if (!link_local && fallback < 0) {
+            fallback = i;
+        }
+    }
+    return fallback;
+}
+
+// Resolve the GID index to use: honor an explicit override if given (>= 0), otherwise auto-detect.
+// Throws if neither yields a usable RoCEv2 GID, since silently falling back to index 0 is exactly
+// the failure mode described above.
+inline int resolve_gid_index(ibv_context* ctx, int ib_port, int requested) {
+    if (requested >= 0) {
+        ibv_gid_entry entry{};
+        if (!ibv_query_gid_ex(ctx, static_cast<uint32_t>(ib_port), static_cast<uint32_t>(requested), &entry, 0) &&
+            entry.gid_type != IBV_GID_TYPE_ROCE_V2) {
+            std::cerr << "Warning: --gid-index " << requested << " is not a RoCEv2 GID; "
+                      << "expect 'transport retry counter exceeded' if the fabric is routed." << std::endl;
+        }
+        return requested;
+    }
+
+    int idx = find_roce_v2_gid_index(ctx, ib_port);
+    if (idx < 0) {
+        throw std::runtime_error(
+            "No RoCEv2 GID found on this port; pass --gid-index explicitly (see the GID table under "
+            "/sys/class/infiniband/<dev>/ports/<port>/gid_attrs/types/)");
+    }
+
+    ibv_gid gid{};
+    ibv_query_gid(ctx, ib_port, idx, &gid);
+    std::cout << "Auto-selected RoCEv2 GID index " << idx << " (" << gid_to_string(gid) << ")" << std::endl;
+    return idx;
+}
+
+inline void send_all(int fd, const void* buf, size_t len) {
+    const char* p = static_cast<const char*>(buf);
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = send(fd, p + sent, len - sent, 0);
+        if (n <= 0) {
+            throw std::runtime_error("send_all: connection error");
+        }
+        sent += static_cast<size_t>(n);
+    }
+}
+
+inline void recv_all(int fd, void* buf, size_t len) {
+    char* p = static_cast<char*>(buf);
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = recv(fd, p + got, len - got, 0);
+        if (n <= 0) {
+            throw std::runtime_error("recv_all: connection error");
+        }
+        got += static_cast<size_t>(n);
+    }
+}
+
+// Target side: listen on `port`, accept exactly one connection, return its fd.
+inline int tcp_listen_accept(uint16_t port) {
+    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        throw std::runtime_error("socket() failed");
+    }
+    int one = 1;
+    setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(port);
+    if (bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        throw std::runtime_error("bind() failed");
+    }
+    if (listen(listen_fd, 1) < 0) {
+        throw std::runtime_error("listen() failed");
+    }
+    int conn_fd = accept(listen_fd, nullptr, nullptr);
+    if (conn_fd < 0) {
+        throw std::runtime_error("accept() failed");
+    }
+    close(listen_fd);
+    return conn_fd;
+}
+
+// Initiator side: connect to host:port, return the connected fd.
+inline int tcp_connect(const std::string& host, uint16_t port) {
+    addrinfo hints{};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* res = nullptr;
+    std::string port_str = std::to_string(port);
+    if (getaddrinfo(host.c_str(), port_str.c_str(), &hints, &res) != 0) {
+        throw std::runtime_error("getaddrinfo() failed for host " + host);
+    }
+    int fd = -1;
+    for (addrinfo* rp = res; rp != nullptr; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
+            break;
+        }
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0) {
+        throw std::runtime_error("connect() failed to " + host + ":" + port_str);
+    }
+    return fd;
+}


### PR DESCRIPTION
### Issue
#3283

### Description
Adds a two-host RDMA example that validates Cluster::export_dmabuf() over real RDMA hardware and measures sustained bandwidth. The target exports a TLB window over a DRAM core as a dma-buf and registers it as an RDMA MR; the initiator RDMA-writes or reads into it from a peer host with no host-CPU copy on the target data path.

This is the cross-host counterpart to the single-host loopback gtest in #3176. It needs two hosts with RDMA NICs, so it is not CI-runnable and lives under examples/ rather than the test suite. Currently intended for Blackhole Galaxy systems and only exercised there.

### List of the changes
 - Added examples/rdma_dmabuf_p2p/: dmabuf_target.cpp (exports the dma-buf via UMD, verifies via an independent read path), dmabuf_initiator.cpp (peer side, links no UMD), rdma_common.hpp (TCP handshake, RDMA device and GID selection, RC QP bring-up and verification pattern shared by both binaries).
 - Added examples/rdma_dmabuf_p2p/CMakeLists.txt and wired it into examples/CMakeLists.txt.
 - Review fixes to the bring-up: hop_limit 64 rather than 1 so packets survive a routed fabric, path_mtu negotiated from the port active_mtu rather than hardcoded, and device and port selection that requires IBV_PORT_ACTIVE, plus a --dev flag.
 - Review fixes to verification: a position dependent pattern compared over the whole buffer rather than a byte periodic one over the first 4 KiB, dram_membar before the UMD readback, and a pass or fail byte from the initiator that the target propagates into its exit status.
 - Robustness: bounds checked argument values, --size rejected above the uint32 work request length and the port max_msg_sz, a 2 MiB default that matches a Blackhole TLB size class, a padding free handshake struct with a pinned size and a magic guard that also carries the MR length, MSG_NOSIGNAL and EINTR handling, and an --ordering flag for the export.

### Testing
Built both binaries with TT_UMD_BUILD_EXAMPLES=ON and TT_UMD_BUILD_RDMA=ON, warning free, and exercised the argument parsing and validation paths locally. End to end run on paired RDMA hosts was done earlier on the original branch and not re-run against this rebase.

### API Changes
This PR has no API changes.
