### PR TITLE
Document the RDMA dma-buf tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ option(TT_UMD_BUILD_SIMULATION "Enables build of tt_umd simulation harnessing" O
 option(TT_UMD_BUILD_PYTHON "Enables build of tt_umd python bindings" OFF)
 option(TT_UMD_BUILD_TOOLS "Enables build of tt_umd tools" ON)
 option(TT_UMD_BUILD_EXAMPLES "Enables build of tt_umd examples" OFF)
+# The RDMA dma-buf test and example need libibverbs and RDMA hardware, so they are opt-in rather
+# than auto-detected: with this ON, missing or too-old libibverbs is a configure error rather than
+# a silent skip, so a host that cannot build them says so instead of quietly producing nothing.
+option(TT_UMD_BUILD_RDMA "Enables build of the RDMA dma-buf test and example (requires libibverbs)" OFF)
 option(TT_UMD_BUILD_ALL "Enables build of all tt_umd components (tests, simulation, python, tools, examples)" OFF)
 option(TT_UMD_BUILD_STATIC "Enables build of tt_umd as a static library" OFF)
 option(TT_UMD_ENABLE_TRACY "Enable Tracy profiling support" OFF)
@@ -169,6 +173,11 @@ if(TT_UMD_BUILD_PYTHON)
 endif()
 if(TT_UMD_BUILD_TOOLS)
     add_subdirectory(tools)
+endif()
+
+# Locate and version-check libibverbs once, for both the RDMA test and the RDMA example.
+if(TT_UMD_BUILD_RDMA)
+    include(${PROJECT_SOURCE_DIR}/cmake/ibverbs.cmake)
 endif()
 
 if(TT_UMD_BUILD_EXAMPLES)

--- a/cmake/ibverbs.cmake
+++ b/cmake/ibverbs.cmake
@@ -1,0 +1,53 @@
+# libibverbs discovery for the RDMA dma-buf test and example, both gated behind TT_UMD_BUILD_RDMA.
+#
+# Included once from the top level when that option is ON, and defines an imported target
+# `ibverbs::ibverbs` carrying both the library and its include directory. Consumers just link it.
+#
+# Everything here is a hard error rather than a silent skip: the option is opt-in, so a host that
+# cannot satisfy it should say what to install instead of quietly building nothing.
+
+# Both the library and the headers are located. libibverbs1 without libibverbs-dev would pass a
+# library-only check and then fail the build on a missing header.
+find_library(IBVERBS_LIBRARY NAMES ibverbs)
+find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
+if(NOT (IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR))
+    message(
+        FATAL_ERROR
+        "TT_UMD_BUILD_RDMA is ON but libibverbs was not found (library: ${IBVERBS_LIBRARY}, headers: ${IBVERBS_INCLUDE_DIR}). Install libibverbs-dev, or configure with -DTT_UMD_BUILD_RDMA=OFF."
+    )
+endif()
+
+# The headers must also be new enough: ibv_reg_dmabuf_mr() needs rdma-core >= v33 and
+# ibv_query_gid_ex() >= v32, and both are called unconditionally. Without this check an older
+# rdma-core fails with a bare "was not declared in this scope" that says nothing about the cause.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${IBVERBS_LIBRARY})
+check_cxx_symbol_exists(
+    ibv_reg_dmabuf_mr
+    "infiniband/verbs.h"
+    HAVE_IBV_REG_DMABUF_MR
+)
+check_cxx_symbol_exists(
+    ibv_query_gid_ex
+    "infiniband/verbs.h"
+    HAVE_IBV_QUERY_GID_EX
+)
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(NOT (HAVE_IBV_REG_DMABUF_MR AND HAVE_IBV_QUERY_GID_EX))
+    message(
+        FATAL_ERROR
+        "TT_UMD_BUILD_RDMA is ON but libibverbs is too old: need rdma-core >= v33 for ibv_reg_dmabuf_mr and >= v32 for ibv_query_gid_ex."
+    )
+endif()
+
+add_library(ibverbs::ibverbs UNKNOWN IMPORTED)
+set_target_properties(
+    ibverbs::ibverbs
+    PROPERTIES
+        IMPORTED_LOCATION
+            "${IBVERBS_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES
+            "${IBVERBS_INCLUDE_DIR}"
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,3 +15,4 @@ endif()
 # Add all example subdirectories
 add_subdirectory(tt_device_example)
 add_subdirectory(reset_notification_example)
+add_subdirectory(rdma_dmabuf_p2p)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,4 +15,7 @@ endif()
 # Add all example subdirectories
 add_subdirectory(tt_device_example)
 add_subdirectory(reset_notification_example)
-add_subdirectory(rdma_dmabuf_p2p)
+# Opt-in via TT_UMD_BUILD_RDMA: needs libibverbs to build and two RDMA hosts to run.
+if(TT_UMD_BUILD_RDMA)
+    add_subdirectory(rdma_dmabuf_p2p)
+endif()

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains examples demonstrating how to use various software compo
 Demonstrates TTDevice usage, showcasing basic device operations and the difference between functionality available before and after calling `init_tt_device()`.
 
 ### `rdma_dmabuf_p2p/`
-Two-host benchmark for `Cluster::export_dmabuf()`: a peer NIC RDMA-writes (or reads) directly against a TLB window over a DRAM core on the other host's card. Requires RDMA hardware on both hosts and `libibverbs`; skipped at configure time if `libibverbs` is missing.
+Two-host benchmark for `Cluster::export_dmabuf()`: a peer NIC RDMA-writes (or reads) directly against a TLB window over a DRAM core on the other host's card. Requires RDMA hardware on both hosts and libibverbs (library + headers, e.g. `libibverbs-dev`); skipped at configure time if the ibverbs library is missing.
 
 ## Building Examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,9 @@ This directory contains examples demonstrating how to use various software compo
 ### `tt_device_example/`
 Demonstrates TTDevice usage, showcasing basic device operations and the difference between functionality available before and after calling `init_tt_device()`.
 
+### `rdma_dmabuf_p2p/`
+Two-host benchmark for `Cluster::export_dmabuf()`: a peer NIC RDMA-writes (or reads) directly against a TLB window over a DRAM core on the other host's card. Requires RDMA hardware on both hosts and `libibverbs`; skipped at configure time if `libibverbs` is missing.
+
 ## Building Examples
 
 Examples are not built by default. To build them:

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains examples demonstrating how to use various software compo
 Demonstrates TTDevice usage, showcasing basic device operations and the difference between functionality available before and after calling `init_tt_device()`.
 
 ### `rdma_dmabuf_p2p/`
-Two-host benchmark for `Cluster::export_dmabuf()`: a peer NIC RDMA-writes (or reads) directly against a TLB window over a DRAM core on the other host's card. Requires RDMA hardware on both hosts and libibverbs (library + headers, e.g. `libibverbs-dev`); skipped at configure time if the ibverbs library is missing.
+Two-host benchmark for `Cluster::export_dmabuf()`: a peer NIC RDMA-writes (or reads) directly against a TLB window over a DRAM core on the other host's card. Blackhole only at the moment (intended for Blackhole Galaxy systems). Requires RDMA hardware on both hosts and libibverbs (library + headers, e.g. `libibverbs-dev`). Built only with `-DTT_UMD_BUILD_RDMA=ON`, which is OFF by default; with it ON, missing or too-old libibverbs is a configure error rather than a silent skip.
 
 ## Building Examples
 
@@ -21,6 +21,9 @@ cmake -B build -DTT_UMD_BUILD_EXAMPLES=ON
 # Build
 cmake --build build
 ```
+
+`rdma_dmabuf_p2p` additionally needs `-DTT_UMD_BUILD_RDMA=ON`, since it requires libibverbs at build
+time and RDMA hardware to run.
 
 Each example directory contains its own README with specific usage instructions.
 

--- a/examples/rdma_dmabuf_p2p/CMakeLists.txt
+++ b/examples/rdma_dmabuf_p2p/CMakeLists.txt
@@ -1,43 +1,5 @@
-# This example drives real RDMA verbs, so it needs libibverbs. It is skipped rather than failing
-# the configure step when libibverbs-dev is not installed, so enabling TT_UMD_BUILD_EXAMPLES stays
-# safe on hosts without an RDMA stack.
-#
-# Both the library and the headers are located: a host with libibverbs1 but not libibverbs-dev passes
-# find_library and would then hard-fail the build on "#include <infiniband/verbs.h>: No such file or
-# directory" — exactly the case the skip is meant to cover.
-find_library(IBVERBS_LIBRARY NAMES ibverbs)
-find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
-if(NOT (IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR))
-    message(STATUS "rdma_dmabuf_p2p example: libibverbs library or headers not found, skipping")
-    return()
-endif()
-
-# The headers also have to be new enough: ibv_reg_dmabuf_mr() needs rdma-core >= v33 and
-# ibv_query_gid_ex() >= v32, and both are called unconditionally below. Without this check an older
-# rdma-core fails with a bare "was not declared in this scope" that says nothing about the cause.
-include(CheckCXXSymbolExists)
-set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE_DIR})
-set(CMAKE_REQUIRED_LIBRARIES ${IBVERBS_LIBRARY})
-check_cxx_symbol_exists(
-    ibv_reg_dmabuf_mr
-    "infiniband/verbs.h"
-    HAVE_IBV_REG_DMABUF_MR
-)
-check_cxx_symbol_exists(
-    ibv_query_gid_ex
-    "infiniband/verbs.h"
-    HAVE_IBV_QUERY_GID_EX
-)
-unset(CMAKE_REQUIRED_INCLUDES)
-unset(CMAKE_REQUIRED_LIBRARIES)
-if(NOT (HAVE_IBV_REG_DMABUF_MR AND HAVE_IBV_QUERY_GID_EX))
-    message(
-        STATUS
-        "rdma_dmabuf_p2p example: libibverbs is too old (need rdma-core >= v33 for ibv_reg_dmabuf_mr and >= v32 for ibv_query_gid_ex), skipping"
-    )
-    return()
-endif()
-
+# Reached only when TT_UMD_BUILD_RDMA is ON; libibverbs is located and version-checked once in
+# cmake/ibverbs.cmake.
 add_executable(dmabuf_target dmabuf_target.cpp)
 
 target_link_libraries(
@@ -45,15 +7,13 @@ target_link_libraries(
     PRIVATE
         umd::tt-umd
         tt-logger::tt-logger
-        ${IBVERBS_LIBRARY}
+        ibverbs::ibverbs
 )
-target_include_directories(dmabuf_target PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 # The initiator only speaks RDMA against a plain host buffer, so it does not link UMD.
 add_executable(dmabuf_initiator dmabuf_initiator.cpp)
 
-target_link_libraries(dmabuf_initiator PRIVATE ${IBVERBS_LIBRARY})
-target_include_directories(dmabuf_initiator PRIVATE ${IBVERBS_INCLUDE_DIR})
+target_link_libraries(dmabuf_initiator PRIVATE ibverbs::ibverbs)
 
 set_target_properties(
     dmabuf_target

--- a/examples/rdma_dmabuf_p2p/CMakeLists.txt
+++ b/examples/rdma_dmabuf_p2p/CMakeLists.txt
@@ -1,0 +1,31 @@
+# This example drives real RDMA verbs, so it needs libibverbs. It is skipped rather than failing
+# the configure step when libibverbs-dev is not installed, so enabling TT_UMD_BUILD_EXAMPLES stays
+# safe on hosts without an RDMA stack.
+find_library(IBVERBS_LIBRARY NAMES ibverbs)
+if(NOT IBVERBS_LIBRARY)
+    message(STATUS "rdma_dmabuf_p2p example: libibverbs not found, skipping")
+    return()
+endif()
+
+add_executable(dmabuf_target dmabuf_target.cpp)
+
+target_link_libraries(
+    dmabuf_target
+    PRIVATE
+        umd::tt-umd
+        tt-logger::tt-logger
+        ${IBVERBS_LIBRARY}
+)
+
+# The initiator only speaks RDMA against a plain host buffer, so it does not link UMD.
+add_executable(dmabuf_initiator dmabuf_initiator.cpp)
+
+target_link_libraries(dmabuf_initiator PRIVATE ${IBVERBS_LIBRARY})
+
+set_target_properties(
+    dmabuf_target
+    dmabuf_initiator
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${CMAKE_BINARY_DIR}/examples/rdma_dmabuf_p2p/
+)

--- a/examples/rdma_dmabuf_p2p/CMakeLists.txt
+++ b/examples/rdma_dmabuf_p2p/CMakeLists.txt
@@ -1,9 +1,40 @@
 # This example drives real RDMA verbs, so it needs libibverbs. It is skipped rather than failing
 # the configure step when libibverbs-dev is not installed, so enabling TT_UMD_BUILD_EXAMPLES stays
 # safe on hosts without an RDMA stack.
+#
+# Both the library and the headers are located: a host with libibverbs1 but not libibverbs-dev passes
+# find_library and would then hard-fail the build on "#include <infiniband/verbs.h>: No such file or
+# directory" — exactly the case the skip is meant to cover.
 find_library(IBVERBS_LIBRARY NAMES ibverbs)
-if(NOT IBVERBS_LIBRARY)
-    message(STATUS "rdma_dmabuf_p2p example: libibverbs not found, skipping")
+find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
+if(NOT (IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR))
+    message(STATUS "rdma_dmabuf_p2p example: libibverbs library or headers not found, skipping")
+    return()
+endif()
+
+# The headers also have to be new enough: ibv_reg_dmabuf_mr() needs rdma-core >= v33 and
+# ibv_query_gid_ex() >= v32, and both are called unconditionally below. Without this check an older
+# rdma-core fails with a bare "was not declared in this scope" that says nothing about the cause.
+include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${IBVERBS_LIBRARY})
+check_cxx_symbol_exists(
+    ibv_reg_dmabuf_mr
+    "infiniband/verbs.h"
+    HAVE_IBV_REG_DMABUF_MR
+)
+check_cxx_symbol_exists(
+    ibv_query_gid_ex
+    "infiniband/verbs.h"
+    HAVE_IBV_QUERY_GID_EX
+)
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(NOT (HAVE_IBV_REG_DMABUF_MR AND HAVE_IBV_QUERY_GID_EX))
+    message(
+        STATUS
+        "rdma_dmabuf_p2p example: libibverbs is too old (need rdma-core >= v33 for ibv_reg_dmabuf_mr and >= v32 for ibv_query_gid_ex), skipping"
+    )
     return()
 endif()
 
@@ -16,11 +47,13 @@ target_link_libraries(
         tt-logger::tt-logger
         ${IBVERBS_LIBRARY}
 )
+target_include_directories(dmabuf_target PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 # The initiator only speaks RDMA against a plain host buffer, so it does not link UMD.
 add_executable(dmabuf_initiator dmabuf_initiator.cpp)
 
 target_link_libraries(dmabuf_initiator PRIVATE ${IBVERBS_LIBRARY})
+target_include_directories(dmabuf_initiator PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 set_target_properties(
     dmabuf_target

--- a/examples/rdma_dmabuf_p2p/README.md
+++ b/examples/rdma_dmabuf_p2p/README.md
@@ -12,47 +12,81 @@ the target side.
 - `dmabuf_initiator.cpp` — runs on the peer host. Registers a plain host-memory MR, connects to the
   target, brings up an RC QP, and issues `--iters` back-to-back RDMA operations, timing the batch to
   report bandwidth. Links no UMD at all.
-- `rdma_common.hpp` — the out-of-band TCP handshake and RoCEv2 GID selection shared by the two.
+- `rdma_common.hpp` — the TCP handshake, RDMA device/GID selection, RC QP bring-up and verification
+  pattern shared by the two.
+
+**Scope: Blackhole only.** This is currently intended for Blackhole Galaxy systems, and has only been
+developed and run there. Wormhole is not a supported target: nothing in the code rejects it, but none
+of it has been exercised on Wormhole and the defaults below are picked for Blackhole. Treat a Wormhole
+run as unverified.
 
 For a single-host smoke test that needs no peer and no network config, see
 `TestDmabufRdmaLoopback.ExportedDmabufIsRdmaReadable` in `tests/rdma/test_dmabuf_loopback.cpp`
 instead — it exercises the same export path over an RDMA loopback QP pair on one NIC port. It lives
-in the `rdma_tests` target, which is excluded from the default build and requires libibverbs:
+in the `rdma_tests` target, behind the same `TT_UMD_BUILD_RDMA` flag as this example:
 
 ```bash
+cmake -B build -DTT_UMD_BUILD_TESTS=ON -DTT_UMD_BUILD_RDMA=ON
 cmake --build build --target rdma_tests
 ./build/test/umd/rdma/rdma_tests
 ```
 
 ## Prerequisites (both hosts)
 
+Four separate things have to be in place. Only the first comes from a package; the rest are part of
+bringing up the NIC and the driver.
+
+### 1. Userspace RDMA libraries
+
 ```bash
-# tt-kmd version — need >= 2.10.0-rc1 for TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF
-cat /sys/module/tenstorrent/version
-
-# kernel — need >= 5.8
-uname -r
-
-# RDMA NIC present and active
-ibv_devices
-ibv_devinfo   # note the device name and port link_layer (Ethernet=RoCE vs InfiniBand)
-
-# rdma-core dev headers
 sudo apt-get install -y libibverbs-dev rdma-core ibverbs-utils
 ```
 
-If `/sys/module/tenstorrent/version` is older than 2.10.0-rc1, `export_dmabuf()` throws — the kmd on
+`libibverbs-dev` is what this example links against (library *and* headers — `libibverbs1` alone is
+not enough), and `ibverbs-utils` provides the `ibv_devices` / `ibv_devinfo` diagnostics used below.
+On RHEL-family distros the equivalents are `rdma-core-devel` and `libibverbs-utils`.
+
+### 2. A working RDMA NIC
+
+The kernel driver and NIC firmware are vendor-specific and are part of installing the NIC, not
+something the packages above provide. Most current NICs are served by an in-tree kernel module
+(`mlx5_core` for NVIDIA/Mellanox, `bnxt_re` for Broadcom), in which case `rdma-core` is all the
+userspace you need; a vendor stack such as NVIDIA DOCA-OFED replaces both and works too.
+
+```bash
+ibv_devices    # the NIC shows up here only once its RDMA driver is loaded
+ibv_devinfo    # state must be PORT_ACTIVE; note link_layer (Ethernet = RoCE, InfiniBand)
+```
+
+An empty `ibv_devices` means the RDMA driver is not loaded, and nothing below will work.
+
+### 3. The RoCE port configured
+
+For RoCE the port needs an IP address, because the routable RoCEv2 GID the binaries auto-select is
+derived from it. This is ordinary host networking and fabric configuration, outside the scope of
+these binaries. `show_gids` (from `ibverbs-utils`) lists what is available; if it shows no RoCEv2
+IPv4-mapped entry, the address is missing or the port is on RoCEv1 only.
+
+### 4. tt-kmd new enough to export a dma-buf
+
+```bash
+cat /sys/module/tenstorrent/version   # need >= 2.10.0-rc1 for TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF
+uname -r                              # need kernel >= 5.8
+```
+
+If either is too old, `export_dmabuf()` throws with a message naming both versions, and the kmd on
 that host needs updating first.
 
 ## Build (both hosts)
 
 ```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DTT_UMD_BUILD_EXAMPLES=ON
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DTT_UMD_BUILD_EXAMPLES=ON -DTT_UMD_BUILD_RDMA=ON
 cmake --build build -j"$(nproc)"
 ```
 
-Binaries land in `build/examples/rdma_dmabuf_p2p/`. If `libibverbs` is not installed the example is
-skipped at configure time rather than failing the build.
+Binaries land in `build/examples/rdma_dmabuf_p2p/`. `TT_UMD_BUILD_RDMA` is OFF by default, so a
+normal build never needs libibverbs; with it ON, missing or too-old libibverbs is a configure error
+naming what to install rather than a silent skip.
 
 ## Run
 
@@ -109,10 +143,10 @@ read-completion concurrency and latency rather than raw link bandwidth.
 - `addr + size` must stay within a single DRAM bank. On Blackhole the usable bank space ends short
   of the nominal `DRAM_BANK_SIZE` — keep clear of the tail when picking large `--size`/`--addr`.
 - The underlying TLB window size is chosen by `tt_tlb_alloc()`, which accepts only specific size
-  classes (1/2/16 MiB on Wormhole, 2 MiB or 4 GiB on Blackhole). `export_dmabuf()` rounds `--size`
-  up to the smallest class that fits, so no manual adjustment is needed — but a `--size` above the
-  largest class fails outright, which is why the default is 2 MiB, the only class valid on both
-  archs. On Blackhole anything above 2 MiB consumes one of the few 4 GiB windows.
+  classes — on Blackhole exactly 2 MiB or 4 GiB (see the size class tables in
+  `device/arch/architecture_tlbs.cpp`). `export_dmabuf()` rounds `--size` up to the smallest class
+  that fits, so no manual adjustment is needed. This is why the default is 2 MiB: anything larger
+  consumes one of the few 4 GiB windows.
 - `--size` is capped at 4 GiB minus one byte by the `uint32_t` length of a single RDMA work request,
   and further by the port's `max_msg_sz` (often 1 GiB). Both are rejected up front.
 - GID selection matters and is easy to get wrong. On some NICs GID index 0 is RoCE *v1* with a

--- a/examples/rdma_dmabuf_p2p/README.md
+++ b/examples/rdma_dmabuf_p2p/README.md
@@ -59,17 +59,18 @@ skipped at configure time rather than failing the build.
 On the target host (owns the exported dma-buf):
 
 ```bash
-./build/examples/rdma_dmabuf_p2p/dmabuf_target --port 9999 --chip 0 --size 67108864
+./build/examples/rdma_dmabuf_p2p/dmabuf_target --port 9999 --chip 0 --size 2097152
 ```
 
 It blocks waiting for a TCP connection from the initiator, exchanges QP/rkey info automatically,
-waits for the initiator's "done" signal, then verifies and prints PASS/FAIL.
+waits for the initiator's pass/fail signal, then verifies and prints PASS/FAIL. A failure reported by
+the initiator becomes a non-zero exit status here too, so watching this side alone is enough for CI.
 
 On the initiator host:
 
 ```bash
 ./build/examples/rdma_dmabuf_p2p/dmabuf_initiator --host <target-host> --port 9999 \
-    --size 67108864 --iters 200
+    --size 2097152 --iters 200
 ```
 
 It times the batch and prints something like:
@@ -86,10 +87,12 @@ Wrote 13421772800 bytes in 1.842 s => 7.287 GB/s
 | `--host` | initiator | — | Target hostname |
 | `--chip` | target | 0 | Chip id to export from |
 | `--addr` | target | 0 | DRAM address to export (page-aligned) |
-| `--size` | both | 64 MiB | Bytes per RDMA operation; must match on both sides |
+| `--size` | both | 2 MiB | Bytes per RDMA operation; must match on both sides (enforced via the handshake) |
 | `--iters` | initiator | 100 | RDMA operations issued back-to-back before timing |
-| `--ib-port` | both | 1 | HCA port number |
+| `--dev` | both | auto | RDMA device name; auto-picks the first with an ACTIVE port |
+| `--ib-port` | both | auto | HCA port number; auto-picks the first ACTIVE port |
 | `--gid-index` | both | auto | GID index; auto-detects a RoCEv2 IPv4-mapped GID |
+| `--ordering` | target | `relaxed` | TLB window ordering for the export: `relaxed`, `posted` or `strict` |
 | `--op` | both | `write` | `write` (host → device) or `read` (device → host); must match |
 
 `--op read` reverses the direction: the target seeds the pattern via `write_to_device()` before the
@@ -107,10 +110,16 @@ read-completion concurrency and latency rather than raw link bandwidth.
   of the nominal `DRAM_BANK_SIZE` — keep clear of the tail when picking large `--size`/`--addr`.
 - The underlying TLB window size is chosen by `tt_tlb_alloc()`, which accepts only specific size
   classes (1/2/16 MiB on Wormhole, 2 MiB or 4 GiB on Blackhole). `export_dmabuf()` rounds `--size`
-  up to the smallest class that fits, so no manual adjustment is needed.
+  up to the smallest class that fits, so no manual adjustment is needed — but a `--size` above the
+  largest class fails outright, which is why the default is 2 MiB, the only class valid on both
+  archs. On Blackhole anything above 2 MiB consumes one of the few 4 GiB windows.
+- `--size` is capped at 4 GiB minus one byte by the `uint32_t` length of a single RDMA work request,
+  and further by the port's `max_msg_sz` (often 1 GiB). Both are rejected up front.
 - GID selection matters and is easy to get wrong. On some NICs GID index 0 is RoCE *v1* with a
   link-local address; RoCEv1 is non-routable, and connecting with it produces traffic the peer never
   ACKs — the symptom is a first operation failing with "transport retry counter exceeded", which
   looks nothing like a fabric-config problem. The auto-detection in `rdma_common.hpp` prefers a
   RoCEv2 IPv4-mapped GID for this reason.
 - Large `--size` raises the initiator's pinned host memory; if `ibv_reg_mr` fails, raise `ulimit -l`.
+- Both sides must be built from the same commit: the handshake struct is exchanged as a raw struct
+  and carries a magic value, so a mismatched peer build is rejected rather than silently misparsed.

--- a/examples/rdma_dmabuf_p2p/README.md
+++ b/examples/rdma_dmabuf_p2p/README.md
@@ -1,0 +1,110 @@
+# RDMA dma-buf peer-to-peer example
+
+Validates `Cluster::export_dmabuf()` over real RDMA hardware and measures sustained bandwidth: a
+NIC on one host issues repeated RDMA operations, over the network, directly against a TLB window
+over a DRAM core on the *other* host's card — landing in device NOC memory with no host-CPU copy on
+the target side.
+
+- `dmabuf_target.cpp` — runs on the host whose TLB window is the RDMA target. Exports the dma-buf
+  via UMD, registers it as an RDMA MR, publishes QP/rkey info over a TCP handshake, waits for the
+  peer to finish, then reads device memory back via UMD (a path completely independent of the
+  exported window) to verify.
+- `dmabuf_initiator.cpp` — runs on the peer host. Registers a plain host-memory MR, connects to the
+  target, brings up an RC QP, and issues `--iters` back-to-back RDMA operations, timing the batch to
+  report bandwidth. Links no UMD at all.
+- `rdma_common.hpp` — the out-of-band TCP handshake and RoCEv2 GID selection shared by the two.
+
+For a single-host smoke test that needs no peer and no network config, see
+`TestClusterExportDmabufLoopback` in `tests/unified/test_tlb.cpp` instead — it exercises the same
+export path over an RDMA loopback QP pair on one NIC port.
+
+## Prerequisites (both hosts)
+
+```bash
+# tt-kmd version — need >= 2.10.0-rc1 for TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF
+cat /sys/module/tenstorrent/version
+
+# kernel — need >= 5.8
+uname -r
+
+# RDMA NIC present and active
+ibv_devices
+ibv_devinfo   # note the device name and port link_layer (Ethernet=RoCE vs InfiniBand)
+
+# rdma-core dev headers
+sudo apt-get install -y libibverbs-dev rdma-core ibverbs-utils
+```
+
+If `/sys/module/tenstorrent/version` is older than 2.10.0-rc1, `export_dmabuf()` throws — the kmd on
+that host needs updating first.
+
+## Build (both hosts)
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DTT_UMD_BUILD_EXAMPLES=ON
+cmake --build build -j"$(nproc)"
+```
+
+Binaries land in `build/examples/rdma_dmabuf_p2p/`. If `libibverbs` is not installed the example is
+skipped at configure time rather than failing the build.
+
+## Run
+
+On the target host (owns the exported dma-buf):
+
+```bash
+./build/examples/rdma_dmabuf_p2p/dmabuf_target --port 9999 --chip 0 --size 67108864
+```
+
+It blocks waiting for a TCP connection from the initiator, exchanges QP/rkey info automatically,
+waits for the initiator's "done" signal, then verifies and prints PASS/FAIL.
+
+On the initiator host:
+
+```bash
+./build/examples/rdma_dmabuf_p2p/dmabuf_initiator --host <target-host> --port 9999 \
+    --size 67108864 --iters 200
+```
+
+It times the batch and prints something like:
+
+```
+Wrote 13421772800 bytes in 1.842 s => 7.287 GB/s
+```
+
+### Options
+
+| Flag | Side | Default | Meaning |
+| --- | --- | --- | --- |
+| `--port` | both | — | TCP port for the out-of-band handshake |
+| `--host` | initiator | — | Target hostname |
+| `--chip` | target | 0 | Chip id to export from |
+| `--addr` | target | 0 | DRAM address to export (page-aligned) |
+| `--size` | both | 64 MiB | Bytes per RDMA operation; must match on both sides |
+| `--iters` | initiator | 100 | RDMA operations issued back-to-back before timing |
+| `--ib-port` | both | 1 | HCA port number |
+| `--gid-index` | both | auto | GID index; auto-detects a RoCEv2 IPv4-mapped GID |
+| `--op` | both | `write` | `write` (host → device) or `read` (device → host); must match |
+
+`--op read` reverses the direction: the target seeds the pattern via `write_to_device()` before the
+handshake, the initiator RDMA-READs it into a sentinel-filled buffer, and the **initiator** prints
+PASS/FAIL since that is where the data lands.
+
+Expect read to be markedly slower than write, for a reason unrelated to link width: PCIe writes are
+*posted* (fire-and-forget, they pipeline), while reads are *non-posted* — the NIC must issue read
+requests against the card's BAR and wait for each completion, so throughput is governed by
+read-completion concurrency and latency rather than raw link bandwidth.
+
+## Notes
+
+- `addr + size` must stay within a single DRAM bank. On Blackhole the usable bank space ends short
+  of the nominal `DRAM_BANK_SIZE` — keep clear of the tail when picking large `--size`/`--addr`.
+- The underlying TLB window size is chosen by `tt_tlb_alloc()`, which accepts only specific size
+  classes (1/2/16 MiB on Wormhole, 2 MiB or 4 GiB on Blackhole). `export_dmabuf()` rounds `--size`
+  up to the smallest class that fits, so no manual adjustment is needed.
+- GID selection matters and is easy to get wrong. On some NICs GID index 0 is RoCE *v1* with a
+  link-local address; RoCEv1 is non-routable, and connecting with it produces traffic the peer never
+  ACKs — the symptom is a first operation failing with "transport retry counter exceeded", which
+  looks nothing like a fabric-config problem. The auto-detection in `rdma_common.hpp` prefers a
+  RoCEv2 IPv4-mapped GID for this reason.
+- Large `--size` raises the initiator's pinned host memory; if `ibv_reg_mr` fails, raise `ulimit -l`.

--- a/examples/rdma_dmabuf_p2p/README.md
+++ b/examples/rdma_dmabuf_p2p/README.md
@@ -15,8 +15,14 @@ the target side.
 - `rdma_common.hpp` — the out-of-band TCP handshake and RoCEv2 GID selection shared by the two.
 
 For a single-host smoke test that needs no peer and no network config, see
-`TestClusterExportDmabufLoopback` in `tests/unified/test_tlb.cpp` instead — it exercises the same
-export path over an RDMA loopback QP pair on one NIC port.
+`TestDmabufRdmaLoopback.ExportedDmabufIsRdmaReadable` in `tests/rdma/test_dmabuf_loopback.cpp`
+instead — it exercises the same export path over an RDMA loopback QP pair on one NIC port. It lives
+in the `rdma_tests` target, which is excluded from the default build and requires libibverbs:
+
+```bash
+cmake --build build --target rdma_tests
+./build/test/umd/rdma/rdma_tests
+```
 
 ## Prerequisites (both hosts)
 

--- a/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RDMA initiator for the two-host dma-buf bandwidth test. Registers a normal host-memory MR filled
+// with a known test pattern, brings up an RC QP against the target, and issues repeated RDMA WRITEs
+// into the target's dma-buf-backed MR (see dmabuf_target.cpp) to measure sustained write bandwidth.
+// No UMD dependency here at all.
+#include <infiniband/verbs.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rdma_common.hpp"
+
+namespace {
+
+struct Args {
+    std::string host;
+    uint16_t port = 9999;
+    // 64 MiB: must match dmabuf_target's --size (Blackhole DRAM_BANK_SIZE is 4 GiB, so there's
+    // plenty of headroom vs the old Tensix-L1-backed 1.5 MiB ceiling).
+    uint64_t size = 64ull << 20;
+    uint64_t iters = 100;  // number of RDMA ops of --size bytes to issue, timed as one batch
+    int ib_port = 1;
+    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";  // "write" = host -> device NOC; "read" = device NOC -> host
+};
+
+Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto next = [&]() { return std::string(argv[++i]); };
+        if (arg == "--host") {
+            a.host = next();
+        } else if (arg == "--port") {
+            a.port = static_cast<uint16_t>(std::stoi(next()));
+        } else if (arg == "--size") {
+            a.size = std::stoull(next());
+        } else if (arg == "--iters") {
+            a.iters = std::stoull(next());
+        } else if (arg == "--ib-port") {
+            a.ib_port = std::stoi(next());
+        } else if (arg == "--gid-index") {
+            a.gid_index = std::stoi(next());
+        } else if (arg == "--op") {
+            a.op = next();
+        }
+    }
+    return a;
+}
+
+// Number of in-flight, unsignaled RDMA_WRITEs between each polled completion. RC QPs complete
+// WQEs in order, so polling one CQE every SIGNAL_INTERVAL writes still confirms all of them landed.
+// Kept at 1 (fully synchronous, one WRITE in flight at a time): at the default 64 MiB --size,
+// ibv_poll_cq overhead is negligible next to per-message transfer time, so there's nothing to gain
+// from batching completions — and batching here is actively dangerous, since going over 32 previously
+// left ~2 GiB of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget
+// ("transport retry counter exceeded") on a real fabric. Only raise this if you've confirmed the
+// fabric tolerates more bytes in flight for your chosen --size.
+constexpr uint64_t SIGNAL_INTERVAL = 1;
+
+}  // namespace
+
+int run(int argc, char** argv) {
+    Args args = parse_args(argc, argv);
+    if (args.host.empty()) {
+        std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]"
+                  << " [--op write|read] [--gid-index N]" << std::endl;
+        return 1;
+    }
+    if (args.op != "write" && args.op != "read") {
+        std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        return 1;
+    }
+    const bool is_read = (args.op == "read");
+
+    std::vector<uint8_t> local_buf(args.size);
+    if (is_read) {
+        // RDMA_READ pulls device memory into this buffer, so prefill with a sentinel that is NOT the
+        // expected pattern — otherwise a read that silently moved nothing would still "verify".
+        // The target seeds the real pattern into device memory via UMD before the handshake.
+        std::fill(local_buf.begin(), local_buf.end(), 0xAA);
+    } else {
+        // Test pattern: byte i = i & 0xFF, so the target can verify without needing to share the
+        // buffer contents out of band.
+        for (size_t i = 0; i < args.size; ++i) {
+            local_buf[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+    }
+
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        std::cerr << "No RDMA devices found" << std::endl;
+        return 1;
+    }
+    ibv_context* ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!ctx) {
+        std::cerr << "ibv_open_device failed" << std::endl;
+        return 1;
+    }
+
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
+        std::cerr << "ibv_query_port failed" << std::endl;
+        return 1;
+    }
+    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
+    if (is_roce) {
+        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
+    }
+
+    ibv_pd* pd = ibv_alloc_pd(ctx);
+    ibv_mr* mr = ibv_reg_mr(pd, local_buf.data(), local_buf.size(), IBV_ACCESS_LOCAL_WRITE);
+    if (!mr) {
+        perror("ibv_reg_mr failed");
+        return 1;
+    }
+
+    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
+    ibv_qp_init_attr qp_init_attr{};
+    qp_init_attr.send_cq = cq;
+    qp_init_attr.recv_cq = cq;
+    qp_init_attr.qp_type = IBV_QPT_RC;
+    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
+    // between polls.
+    qp_init_attr.cap.max_send_wr = static_cast<uint32_t>(SIGNAL_INTERVAL);
+    qp_init_attr.cap.max_recv_wr = 1;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
+    if (!qp) {
+        std::cerr << "ibv_create_qp failed" << std::endl;
+        return 1;
+    }
+
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_INIT;
+        attr.pkey_index = 0;
+        attr.port_num = args.ib_port;
+        attr.qp_access_flags = 0;
+        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to INIT" << std::endl;
+            return 1;
+        }
+    }
+
+    QpExchangeInfo local{};
+    local.qpn = qp->qp_num;
+    local.psn = 0x5678;
+    if (is_roce) {
+        ibv_gid gid{};
+        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
+            std::cerr << "ibv_query_gid failed" << std::endl;
+            return 1;
+        }
+        std::memcpy(local.gid, gid.raw, 16);
+    } else {
+        local.lid = port_attr.lid;
+    }
+
+    std::cout << "Connecting to " << args.host << ":" << args.port << "..." << std::endl;
+    int conn = tcp_connect(args.host, args.port);
+    QpExchangeInfo remote{};
+    recv_all(conn, &remote, sizeof(remote));
+    send_all(conn, &local, sizeof(local));
+    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << std::endl;
+
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTR;
+        attr.path_mtu = IBV_MTU_1024;
+        attr.dest_qp_num = remote.qpn;
+        attr.rq_psn = remote.psn;
+        attr.max_dest_rd_atomic = 1;
+        attr.min_rnr_timer = 12;
+        attr.ah_attr.port_num = args.ib_port;
+        if (is_roce) {
+            attr.ah_attr.is_global = 1;
+            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
+            attr.ah_attr.grh.sgid_index = args.gid_index;
+            attr.ah_attr.grh.hop_limit = 1;
+        } else {
+            attr.ah_attr.is_global = 0;
+            attr.ah_attr.dlid = remote.lid;
+        }
+        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTR" << std::endl;
+            return 1;
+        }
+    }
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTS;
+        attr.timeout = 14;
+        attr.retry_cnt = 7;
+        attr.rnr_retry = 7;
+        attr.sq_psn = local.psn;
+        attr.max_rd_atomic = 1;
+        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                    IBV_QP_MAX_QP_RD_ATOMIC;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTS" << std::endl;
+            return 1;
+        }
+    }
+
+    // Repeatedly move --size bytes between local_buf and the target's dma-buf MR at iova 0 (see
+    // dmabuf_target.cpp; the dma-buf MR was registered with iova=0, so remote_addr here must also be
+    // 0). Every iteration touches the same remote window, which is fine for a bandwidth measurement:
+    // in write mode each iteration reproduces the identical pattern, and in read mode the source
+    // device memory is never modified.
+    //
+    // Direction note: WRITE pushes host -> device NOC and is "posted" on the target's PCIe link
+    // (fire-and-forget, pipelines well). READ pulls device NOC -> host, which makes the target NIC
+    // issue *non-posted* PCIe reads against the card's BAR — each needs a completion to come back, so
+    // throughput is bounded by read-completion concurrency and latency rather than raw link
+    // bandwidth. Expect READ to be substantially slower than WRITE on the same link.
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<uint64_t>(local_buf.data());
+    sge.length = static_cast<uint32_t>(local_buf.size());
+    sge.lkey = mr->lkey;
+
+    ibv_send_wr wr{};
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = is_read ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
+    wr.wr.rdma.remote_addr = remote.remote_addr;
+    wr.wr.rdma.rkey = remote.rkey;
+
+    const char* op_name = is_read ? "READ" : "WRITE";
+    std::cout << "Issuing " << args.iters << " x " << args.size << " byte RDMA " << op_name << "s..." << std::endl;
+    auto t_start = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < args.iters; ++i) {
+        bool signal = ((i + 1) % SIGNAL_INTERVAL == 0) || (i + 1 == args.iters);
+        wr.wr_id = i;
+        wr.send_flags = signal ? IBV_SEND_SIGNALED : 0;
+
+        ibv_send_wr* bad_wr = nullptr;
+        if (ibv_post_send(qp, &wr, &bad_wr)) {
+            std::cerr << "ibv_post_send failed at iter " << i << std::endl;
+            return 1;
+        }
+
+        if (signal) {
+            ibv_wc wc{};
+            int n = 0;
+            while (n == 0) {
+                n = ibv_poll_cq(cq, 1, &wc);
+                if (n < 0) {
+                    std::cerr << "ibv_poll_cq failed" << std::endl;
+                    return 1;
+                }
+            }
+            if (wc.status != IBV_WC_SUCCESS) {
+                // wc.wr_id, not the loop counter i: once a fatal transport error hits, the QP flushes
+                // all outstanding WQEs, so the CQE we get back may belong to an earlier, still-unsignaled
+                // op rather than the one posted this iteration.
+                std::cerr << "RDMA " << op_name << " failed, wr_id=" << wc.wr_id << ": " << ibv_wc_status_str(wc.status)
+                          << std::endl;
+                return 1;
+            }
+        }
+    }
+    auto t_end = std::chrono::steady_clock::now();
+
+    double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
+    double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
+    double gbps = total_bytes / elapsed_s / 1e9;
+    std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
+              << " s => " << gbps << " GB/s" << std::endl;
+
+    // In read mode the data landed on *this* side, so verification happens here rather than on the
+    // target: check that the pattern the target seeded into device memory actually arrived, and that
+    // we're not just looking at the 0xAA sentinel.
+    bool all_match = true;
+    if (is_read) {
+        for (size_t i = 0; i < args.size && i < 4096; ++i) {
+            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
+            if (local_buf[i] != expected) {
+                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
+                          << static_cast<int>(local_buf[i]) << std::endl;
+                all_match = false;
+                break;
+            }
+        }
+        std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
+    }
+
+    // Signal the target that the batch is done (a real hardware ACK from the CQE above, not just
+    // "posted") so it can verify (write mode) or tear down (read mode).
+    char done = 1;
+    send_all(conn, &done, 1);
+
+    close(conn);
+    ibv_destroy_qp(qp);
+    ibv_destroy_cq(cq);
+    ibv_dereg_mr(mr);
+    ibv_dealloc_pd(pd);
+    ibv_close_device(ctx);
+    return all_match ? 0 : 1;
+}
+
+int main(int argc, char** argv) {
+    // tcp_connect()/send_all()/recv_all() and resolve_gid_index() throw; catch here so a
+    // handshake or config failure prints a clean error instead of an uncaught-exception core dump.
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
@@ -24,34 +24,46 @@ namespace {
 struct Args {
     std::string host;
     uint16_t port = 9999;
-    // 64 MiB: must match dmabuf_target's --size (Blackhole DRAM_BANK_SIZE is 4 GiB, so there's
-    // plenty of headroom vs the old Tensix-L1-backed 1.5 MiB ceiling).
-    uint64_t size = 64ull << 20;
-    uint64_t iters = 100;  // number of RDMA ops of --size bytes to issue, timed as one batch
-    int ib_port = 1;
+    // Must match dmabuf_target's --size, which defaults to the same value for the arch reasons
+    // documented there (2 MiB is the only size class valid on both Wormhole and Blackhole).
+    uint64_t size = 2ull << 20;
+    uint64_t iters = 100;      // number of RDMA ops of --size bytes to issue, timed as one batch
+    std::string dev;           // empty = first RDMA device with an ACTIVE port
+    int ib_port = -1;          // -1 = first ACTIVE port on that device
     int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
     std::string op = "write";  // "write" = host -> device NOC; "read" = device NOC -> host
 };
+
+void print_usage() {
+    std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]\n"
+              << "                        [--dev NAME] [--ib-port N] [--gid-index N] [--op write|read]" << std::endl;
+}
 
 Args parse_args(int argc, char** argv) {
     Args a;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        auto next = [&]() { return std::string(argv[++i]); };
         if (arg == "--host") {
-            a.host = next();
+            a.host = arg_value(argc, argv, i);
         } else if (arg == "--port") {
-            a.port = static_cast<uint16_t>(std::stoi(next()));
+            a.port = static_cast<uint16_t>(std::stoi(arg_value(argc, argv, i)));
         } else if (arg == "--size") {
-            a.size = std::stoull(next());
+            a.size = std::stoull(arg_value(argc, argv, i));
         } else if (arg == "--iters") {
-            a.iters = std::stoull(next());
+            a.iters = std::stoull(arg_value(argc, argv, i));
+        } else if (arg == "--dev") {
+            a.dev = arg_value(argc, argv, i);
         } else if (arg == "--ib-port") {
-            a.ib_port = std::stoi(next());
+            a.ib_port = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--gid-index") {
-            a.gid_index = std::stoi(next());
+            a.gid_index = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--op") {
-            a.op = next();
+            a.op = arg_value(argc, argv, i);
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage();
+            std::exit(0);
+        } else {
+            throw std::runtime_error("Unknown argument '" + arg + "'");
         }
     }
     return a;
@@ -59,12 +71,12 @@ Args parse_args(int argc, char** argv) {
 
 // Number of in-flight, unsignaled RDMA_WRITEs between each polled completion. RC QPs complete
 // WQEs in order, so polling one CQE every SIGNAL_INTERVAL writes still confirms all of them landed.
-// Kept at 1 (fully synchronous, one WRITE in flight at a time): at the default 64 MiB --size,
-// ibv_poll_cq overhead is negligible next to per-message transfer time, so there's nothing to gain
-// from batching completions — and batching here is actively dangerous, since going over 32 previously
-// left ~2 GiB of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget
-// ("transport retry counter exceeded") on a real fabric. Only raise this if you've confirmed the
-// fabric tolerates more bytes in flight for your chosen --size.
+// Kept at 1 (fully synchronous, one WRITE in flight at a time): at these transfer sizes ibv_poll_cq
+// overhead is negligible next to per-message transfer time, so there's nothing to gain from batching
+// completions — and batching here is actively dangerous, since going over 32 previously left ~2 GiB
+// of unpaced, unacknowledged WRITEs outstanding and blew through the QP's retry budget ("transport
+// retry counter exceeded") on a real fabric. Only raise this if you've confirmed the fabric tolerates
+// more bytes in flight for your chosen --size.
 constexpr uint64_t SIGNAL_INTERVAL = 1;
 
 }  // namespace
@@ -72,8 +84,7 @@ constexpr uint64_t SIGNAL_INTERVAL = 1;
 int run(int argc, char** argv) {
     Args args = parse_args(argc, argv);
     if (args.host.empty()) {
-        std::cerr << "Usage: dmabuf_initiator --host <target-host> [--port N] [--size N] [--iters N]"
-                  << " [--op write|read] [--gid-index N]" << std::endl;
+        print_usage();
         return 1;
     }
     if (args.op != "write" && args.op != "read") {
@@ -82,6 +93,22 @@ int run(int argc, char** argv) {
     }
     const bool is_read = (args.op == "read");
 
+    // Validate --size before allocating anything for it. One work request carries one SGE, whose
+    // length is a uint32_t, while --size is a uint64_t: --size 4294967296 (4 GiB, a natural choice on
+    // Blackhole) truncates sge.length to 0, so every WQE moves nothing, every CQE reports success,
+    // and the bandwidth line below — computed from --size x --iters — reports a fabricated number as
+    // a pass.
+    if (args.size == 0) {
+        std::cerr << "--size must be non-zero" << std::endl;
+        return 1;
+    }
+    if (args.size > UINT32_MAX) {
+        std::cerr << "--size " << args.size << " exceeds the " << UINT32_MAX
+                  << " byte limit of a single RDMA work request; split the transfer or use a smaller --size"
+                  << std::endl;
+        return 1;
+    }
+
     std::vector<uint8_t> local_buf(args.size);
     if (is_read) {
         // RDMA_READ pulls device memory into this buffer, so prefill with a sentinel that is NOT the
@@ -89,134 +116,68 @@ int run(int argc, char** argv) {
         // The target seeds the real pattern into device memory via UMD before the handshake.
         std::fill(local_buf.begin(), local_buf.end(), 0xAA);
     } else {
-        // Test pattern: byte i = i & 0xFF, so the target can verify without needing to share the
-        // buffer contents out of band.
-        for (size_t i = 0; i < args.size; ++i) {
-            local_buf[i] = static_cast<uint8_t>(i & 0xFF);
-        }
+        // Position-dependent pattern, so the target can verify without needing the buffer contents
+        // out of band, and a misaddressed or partial transfer cannot accidentally match.
+        fill_pattern(local_buf.data(), local_buf.size());
     }
 
-    int num_devices = 0;
-    ibv_device** dev_list = ibv_get_device_list(&num_devices);
-    if (!dev_list || num_devices == 0) {
-        std::cerr << "No RDMA devices found" << std::endl;
-        return 1;
+    RdmaPort rdma = open_active_rdma_port(args.dev, args.ib_port);
+    if (rdma.is_roce()) {
+        args.gid_index = resolve_gid_index(rdma.ctx, rdma.ib_port, args.gid_index);
     }
-    ibv_context* ctx = ibv_open_device(dev_list[0]);
-    ibv_free_device_list(dev_list);
-    if (!ctx) {
-        std::cerr << "ibv_open_device failed" << std::endl;
+
+    // port_attr.max_msg_sz is the device's own per-message ceiling (commonly 1 GiB), checked for the
+    // same reason as the uint32_t limit above; it needs an opened port, so it lands here.
+    if (args.size > rdma.port_attr.max_msg_sz) {
+        std::cerr << "--size " << args.size << " exceeds the port's max_msg_sz of " << rdma.port_attr.max_msg_sz
+                  << " bytes" << std::endl;
         return 1;
     }
 
-    ibv_port_attr port_attr{};
-    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
-        std::cerr << "ibv_query_port failed" << std::endl;
+    ibv_pd* pd = ibv_alloc_pd(rdma.ctx);
+    if (!pd) {
+        std::cerr << "ibv_alloc_pd failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
-    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
-    if (is_roce) {
-        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
-    }
 
-    ibv_pd* pd = ibv_alloc_pd(ctx);
     ibv_mr* mr = ibv_reg_mr(pd, local_buf.data(), local_buf.size(), IBV_ACCESS_LOCAL_WRITE);
     if (!mr) {
         perror("ibv_reg_mr failed");
         return 1;
     }
 
-    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
-    ibv_qp_init_attr qp_init_attr{};
-    qp_init_attr.send_cq = cq;
-    qp_init_attr.recv_cq = cq;
-    qp_init_attr.qp_type = IBV_QPT_RC;
-    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
-    // between polls.
-    qp_init_attr.cap.max_send_wr = static_cast<uint32_t>(SIGNAL_INTERVAL);
-    qp_init_attr.cap.max_recv_wr = 1;
-    qp_init_attr.cap.max_send_sge = 1;
-    qp_init_attr.cap.max_recv_sge = 1;
-    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
-    if (!qp) {
-        std::cerr << "ibv_create_qp failed" << std::endl;
+    ibv_cq* cq = ibv_create_cq(rdma.ctx, 1, nullptr, nullptr, 0);
+    if (!cq) {
+        std::cerr << "ibv_create_cq failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_INIT;
-        attr.pkey_index = 0;
-        attr.port_num = args.ib_port;
-        attr.qp_access_flags = 0;
-        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to INIT" << std::endl;
-            return 1;
-        }
-    }
+    // Must hold at least SIGNAL_INTERVAL WQEs, since that many go unsignaled (and thus unretired)
+    // between polls. No remote access is served on this side, so the QP needs no access flags.
+    ibv_qp* qp = create_rc_qp(pd, cq, rdma.ib_port, static_cast<uint32_t>(SIGNAL_INTERVAL), 0);
 
-    QpExchangeInfo local{};
-    local.qpn = qp->qp_num;
-    local.psn = 0x5678;
-    if (is_roce) {
-        ibv_gid gid{};
-        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
-            std::cerr << "ibv_query_gid failed" << std::endl;
-            return 1;
-        }
-        std::memcpy(local.gid, gid.raw, 16);
-    } else {
-        local.lid = port_attr.lid;
-    }
+    QpExchangeInfo local = make_local_exchange_info(rdma, args.gid_index, qp->qp_num, 0x5678);
 
     std::cout << "Connecting to " << args.host << ":" << args.port << "..." << std::endl;
     int conn = tcp_connect(args.host, args.port);
     QpExchangeInfo remote{};
     recv_all(conn, &remote, sizeof(remote));
     send_all(conn, &local, sizeof(local));
-    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << std::endl;
+    check_peer_exchange_info(remote);
+    std::cout << "Target QPN=" << remote.qpn << " rkey=" << remote.rkey << " mr_length=" << remote.mr_length
+              << std::endl;
 
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTR;
-        attr.path_mtu = IBV_MTU_1024;
-        attr.dest_qp_num = remote.qpn;
-        attr.rq_psn = remote.psn;
-        attr.max_dest_rd_atomic = 1;
-        attr.min_rnr_timer = 12;
-        attr.ah_attr.port_num = args.ib_port;
-        if (is_roce) {
-            attr.ah_attr.is_global = 1;
-            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
-            attr.ah_attr.grh.sgid_index = args.gid_index;
-            attr.ah_attr.grh.hop_limit = 1;
-        } else {
-            attr.ah_attr.is_global = 0;
-            attr.ah_attr.dlid = remote.lid;
-        }
-        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
-                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTR" << std::endl;
-            return 1;
-        }
+    // The two binaries are launched independently with their own --size. A larger local size overruns
+    // the target's MR and dies with IBV_WC_REM_ACCESS_ERR at iteration 0, indistinguishable from a
+    // permissions or dma-buf failure; a smaller one succeeds and prints a bandwidth figure for a
+    // window that was never fully written.
+    if (remote.mr_length != args.size) {
+        std::cerr << "Size mismatch: this side has --size " << args.size << " but the target exported "
+                  << remote.mr_length << " bytes. Launch both with the same --size." << std::endl;
+        return 1;
     }
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTS;
-        attr.timeout = 14;
-        attr.retry_cnt = 7;
-        attr.rnr_retry = 7;
-        attr.sq_psn = local.psn;
-        attr.max_rd_atomic = 1;
-        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
-                    IBV_QP_MAX_QP_RD_ATOMIC;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTS" << std::endl;
-            return 1;
-        }
-    }
+
+    connect_rc_qp(qp, rdma, args.gid_index, remote, local.psn);
 
     // Repeatedly move --size bytes between local_buf and the target's dma-buf MR at iova 0 (see
     // dmabuf_target.cpp; the dma-buf MR was registered with iova=0, so remote_addr here must also be
@@ -243,16 +204,19 @@ int run(int argc, char** argv) {
 
     const char* op_name = is_read ? "READ" : "WRITE";
     std::cout << "Issuing " << args.iters << " x " << args.size << " byte RDMA " << op_name << "s..." << std::endl;
+
+    bool batch_ok = true;
     auto t_start = std::chrono::steady_clock::now();
-    for (uint64_t i = 0; i < args.iters; ++i) {
+    for (uint64_t i = 0; i < args.iters && batch_ok; ++i) {
         bool signal = ((i + 1) % SIGNAL_INTERVAL == 0) || (i + 1 == args.iters);
         wr.wr_id = i;
         wr.send_flags = signal ? IBV_SEND_SIGNALED : 0;
 
         ibv_send_wr* bad_wr = nullptr;
         if (ibv_post_send(qp, &wr, &bad_wr)) {
-            std::cerr << "ibv_post_send failed at iter " << i << std::endl;
-            return 1;
+            std::cerr << "ibv_post_send failed at iter " << i << ": " << std::strerror(errno) << std::endl;
+            batch_ok = false;
+            break;
         }
 
         if (signal) {
@@ -262,61 +226,63 @@ int run(int argc, char** argv) {
                 n = ibv_poll_cq(cq, 1, &wc);
                 if (n < 0) {
                     std::cerr << "ibv_poll_cq failed" << std::endl;
-                    return 1;
+                    batch_ok = false;
+                    break;
                 }
             }
-            if (wc.status != IBV_WC_SUCCESS) {
+            if (batch_ok && wc.status != IBV_WC_SUCCESS) {
                 // wc.wr_id, not the loop counter i: once a fatal transport error hits, the QP flushes
                 // all outstanding WQEs, so the CQE we get back may belong to an earlier, still-unsignaled
                 // op rather than the one posted this iteration.
                 std::cerr << "RDMA " << op_name << " failed, wr_id=" << wc.wr_id << ": " << ibv_wc_status_str(wc.status)
                           << std::endl;
-                return 1;
+                batch_ok = false;
             }
         }
     }
     auto t_end = std::chrono::steady_clock::now();
 
-    double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
-    double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
-    double gbps = total_bytes / elapsed_s / 1e9;
-    std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
-              << " s => " << gbps << " GB/s" << std::endl;
+    if (batch_ok) {
+        double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
+        double total_bytes = static_cast<double>(args.size) * static_cast<double>(args.iters);
+        double gbps = total_bytes / elapsed_s / 1e9;
+        std::cout << (is_read ? "Read " : "Wrote ") << static_cast<uint64_t>(total_bytes) << " bytes in " << elapsed_s
+                  << " s => " << gbps << " GB/s" << std::endl;
+    }
 
     // In read mode the data landed on *this* side, so verification happens here rather than on the
     // target: check that the pattern the target seeded into device memory actually arrived, and that
-    // we're not just looking at the 0xAA sentinel.
-    bool all_match = true;
-    if (is_read) {
-        for (size_t i = 0; i < args.size && i < 4096; ++i) {
-            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
-            if (local_buf[i] != expected) {
-                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
-                          << static_cast<int>(local_buf[i]) << std::endl;
-                all_match = false;
-                break;
-            }
+    // we're not just looking at the 0xAA sentinel. The compare covers the whole buffer, since a
+    // prefix-only check passes when only the first page was transferred.
+    bool all_match = batch_ok;
+    if (batch_ok && is_read) {
+        const size_t mismatch = find_pattern_mismatch(local_buf.data(), local_buf.size());
+        if (mismatch != local_buf.size()) {
+            std::cerr << "Mismatch at byte " << mismatch << ": expected " << static_cast<int>(pattern_byte(mismatch))
+                      << " got " << static_cast<int>(local_buf[mismatch]) << std::endl;
+            all_match = false;
         }
         std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
     }
 
-    // Signal the target that the batch is done (a real hardware ACK from the CQE above, not just
-    // "posted") so it can verify (write mode) or tear down (read mode).
-    char done = 1;
-    send_all(conn, &done, 1);
+    // Report the outcome to the target rather than an unconditional "done": it owns the device and is
+    // the natural side for a CI harness to watch, so a failure here has to reach its exit status too.
+    BatchResult result = all_match ? BatchResult::Pass : BatchResult::Fail;
+    send_all(conn, &result, 1);
 
     close(conn);
     ibv_destroy_qp(qp);
     ibv_destroy_cq(cq);
     ibv_dereg_mr(mr);
     ibv_dealloc_pd(pd);
-    ibv_close_device(ctx);
+    ibv_close_device(rdma.ctx);
     return all_match ? 0 : 1;
 }
 
 int main(int argc, char** argv) {
-    // tcp_connect()/send_all()/recv_all() and resolve_gid_index() throw; catch here so a
-    // handshake or config failure prints a clean error instead of an uncaught-exception core dump.
+    // tcp_connect()/send_all()/recv_all(), the RDMA bring-up helpers and resolve_gid_index() all
+    // throw; catch here so a handshake or config failure prints a clean error instead of an
+    // uncaught-exception core dump.
     try {
         return run(argc, argv);
     } catch (const std::exception& e) {

--- a/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_initiator.cpp
@@ -24,8 +24,8 @@ namespace {
 struct Args {
     std::string host;
     uint16_t port = 9999;
-    // Must match dmabuf_target's --size, which defaults to the same value for the arch reasons
-    // documented there (2 MiB is the only size class valid on both Wormhole and Blackhole).
+    // Must match dmabuf_target's --size, which defaults to the same value for the reason documented
+    // there (2 MiB is the smaller of Blackhole's two TLB window size classes).
     uint64_t size = 2ull << 20;
     uint64_t iters = 100;      // number of RDMA ops of --size bytes to issue, timed as one batch
     std::string dev;           // empty = first RDMA device with an ACTIVE port

--- a/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
@@ -13,7 +13,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "rdma_common.hpp"
@@ -21,6 +23,7 @@
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -31,34 +34,65 @@ struct Args {
     uint16_t port = 9999;
     tt::ChipId chip = 0;
     uint64_t addr = 0;
-    // 64 MiB: comfortably under Blackhole DRAM_BANK_SIZE (4 GiB, device/api/umd/device/arch/
-    // blackhole_implementation.hpp) and large enough that per-message RDMA/CQE overhead doesn't
-    // dominate the bandwidth measurement. addr + size must stay within a single DRAM bank.
-    uint64_t size = 64ull << 20;
-    int ib_port = 1;
-    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
-    std::string op = "write";  // must match the initiator's --op: decides who seeds and who verifies
+    // 2 MiB, and it must stay a value that is a valid TLB window size class on every arch: Wormhole
+    // offers {1, 2, 16} MiB and Blackhole {2 MiB, 4 GiB} (get_tlb_sizes() in the *_implementation.hpp
+    // headers). export_dmabuf() rounds up to the next class that can cover the request, so a larger
+    // default throws outright on Wormhole ("No TLB window size can cover ...") and on Blackhole
+    // quietly consumes one of the few 4 GiB windows. Raise it with --size when you know the arch.
+    uint64_t size = 2ull << 20;
+    std::string dev;                   // empty = first RDMA device with an ACTIVE port
+    int ib_port = -1;                  // -1 = first ACTIVE port on that device
+    int gid_index = -1;                // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";          // must match the initiator's --op: decides who seeds and who verifies
+    std::string ordering = "relaxed";  // TLB window ordering mode for the export
 };
+
+void print_usage() {
+    std::cerr << "Usage: dmabuf_target [--port N] [--chip N] [--addr 0xN] [--size N] [--dev NAME]\n"
+              << "                     [--ib-port N] [--gid-index N] [--op write|read]\n"
+              << "                     [--ordering relaxed|posted|strict]" << std::endl;
+}
+
+uint64_t parse_ordering(const std::string& name) {
+    if (name == "relaxed") {
+        return tlb_data::Relaxed;
+    }
+    if (name == "posted") {
+        return tlb_data::Posted;
+    }
+    if (name == "strict") {
+        return tlb_data::Strict;
+    }
+    throw std::runtime_error("--ordering must be relaxed, posted or strict, got '" + name + "'");
+}
 
 Args parse_args(int argc, char** argv) {
     Args a;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        auto next = [&]() { return std::string(argv[++i]); };
         if (arg == "--port") {
-            a.port = static_cast<uint16_t>(std::stoi(next()));
+            a.port = static_cast<uint16_t>(std::stoi(arg_value(argc, argv, i)));
         } else if (arg == "--chip") {
-            a.chip = std::stoi(next());
+            a.chip = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--addr") {
-            a.addr = std::stoull(next(), nullptr, 0);
+            a.addr = std::stoull(arg_value(argc, argv, i), nullptr, 0);
         } else if (arg == "--size") {
-            a.size = std::stoull(next());
+            a.size = std::stoull(arg_value(argc, argv, i));
+        } else if (arg == "--dev") {
+            a.dev = arg_value(argc, argv, i);
         } else if (arg == "--ib-port") {
-            a.ib_port = std::stoi(next());
+            a.ib_port = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--gid-index") {
-            a.gid_index = std::stoi(next());
+            a.gid_index = std::stoi(arg_value(argc, argv, i));
         } else if (arg == "--op") {
-            a.op = next();
+            a.op = arg_value(argc, argv, i);
+        } else if (arg == "--ordering") {
+            a.ordering = arg_value(argc, argv, i);
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage();
+            std::exit(0);
+        } else {
+            throw std::runtime_error("Unknown argument '" + arg + "'");
         }
     }
     return a;
@@ -70,9 +104,11 @@ int run(int argc, char** argv) {
     Args args = parse_args(argc, argv);
     if (args.op != "write" && args.op != "read") {
         std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        print_usage();
         return 1;
     }
     const bool is_read = (args.op == "read");
+    const uint64_t ordering = parse_ordering(args.ordering);
 
     // --- UMD side: export a TLB window as a dma-buf ------------------------------------------
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
@@ -85,38 +121,28 @@ int run(int argc, char** argv) {
     CoreCoord core = dram_cores.front();
 
     std::cout << "Exporting TLB window: chip=" << args.chip << " core=(" << core.x << "," << core.y << ") addr=0x"
-              << std::hex << args.addr << std::dec << " size=" << args.size << std::endl;
+              << std::hex << args.addr << std::dec << " size=" << args.size << " ordering=" << args.ordering
+              << std::endl;
 
     // export_dmabuf() takes the export length directly and rounds the underlying TLB window up to
     // the arch's next valid size class internally, so --size needs no arch-specific adjustment here.
-    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size);
+    // It throws on every failure path (bad alignment, no window large enough, KMD too old), so the
+    // returned fd is always valid; main()'s handler turns a throw into a clean "Fatal: ..." line.
+    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size, ordering);
     std::cout << "Got dma-buf fd " << dmabuf_fd << std::endl;
 
     // --- RDMA side: register the dma-buf as an MR --------------------------------------------
-    int num_devices = 0;
-    ibv_device** dev_list = ibv_get_device_list(&num_devices);
-    if (!dev_list || num_devices == 0) {
-        std::cerr << "No RDMA devices found" << std::endl;
-        return 1;
+    RdmaPort rdma = open_active_rdma_port(args.dev, args.ib_port);
+    if (rdma.is_roce()) {
+        args.gid_index = resolve_gid_index(rdma.ctx, rdma.ib_port, args.gid_index);
     }
-    ibv_context* ctx = ibv_open_device(dev_list[0]);
-    ibv_free_device_list(dev_list);
-    if (!ctx) {
-        std::cerr << "ibv_open_device failed" << std::endl;
+
+    ibv_pd* pd = ibv_alloc_pd(rdma.ctx);
+    if (!pd) {
+        std::cerr << "ibv_alloc_pd failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    ibv_port_attr port_attr{};
-    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
-        std::cerr << "ibv_query_port failed" << std::endl;
-        return 1;
-    }
-    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
-    if (is_roce) {
-        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
-    }
-
-    ibv_pd* pd = ibv_alloc_pd(ctx);
     // offset=0, iova=0: the dma-buf has no CPU-side virtual address, so remote_addr on the
     // initiator's WRITE/READ must also be 0 to match this MR's iova.
     //
@@ -130,61 +156,27 @@ int run(int argc, char** argv) {
         return 1;
     }
 
-    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
-    ibv_qp_init_attr qp_init_attr{};
-    qp_init_attr.send_cq = cq;
-    qp_init_attr.recv_cq = cq;
-    qp_init_attr.qp_type = IBV_QPT_RC;
-    qp_init_attr.cap.max_send_wr = 1;
-    qp_init_attr.cap.max_recv_wr = 1;
-    qp_init_attr.cap.max_send_sge = 1;
-    qp_init_attr.cap.max_recv_sge = 1;
-    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
-    if (!qp) {
-        std::cerr << "ibv_create_qp failed" << std::endl;
+    ibv_cq* cq = ibv_create_cq(rdma.ctx, 1, nullptr, nullptr, 0);
+    if (!cq) {
+        std::cerr << "ibv_create_cq failed: " << std::strerror(errno) << std::endl;
         return 1;
     }
 
-    // INIT
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_INIT;
-        attr.pkey_index = 0;
-        attr.port_num = args.ib_port;
-        // Same reasoning as the MR flags above: the QP must permit remote reads too, or an
-        // RDMA_READ is rejected at the QP level even though the MR allows it.
-        attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
-        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to INIT" << std::endl;
-            return 1;
-        }
-    }
+    // The QP must permit remote reads too, or an RDMA_READ is rejected at the QP level even though
+    // the MR above allows it.
+    ibv_qp* qp = create_rc_qp(pd, cq, rdma.ib_port, 1, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
 
-    QpExchangeInfo local{};
-    local.qpn = qp->qp_num;
-    local.psn = 0x1234;
+    QpExchangeInfo local = make_local_exchange_info(rdma, args.gid_index, qp->qp_num, 0x1234);
     local.rkey = mr->rkey;
     local.remote_addr = 0;
-    if (is_roce) {
-        ibv_gid gid{};
-        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
-            std::cerr << "ibv_query_gid failed" << std::endl;
-            return 1;
-        }
-        std::memcpy(local.gid, gid.raw, 16);
-    } else {
-        local.lid = port_attr.lid;
-    }
+    local.mr_length = args.size;
 
     // In read mode the initiator pulls *from* device memory, so the pattern has to already be there.
     // Seed it via UMD (a path independent of the exported window) before the handshake, so it is in
     // place before the peer can possibly issue a READ.
     if (is_read) {
         std::vector<uint8_t> seed(args.size);
-        for (size_t i = 0; i < args.size; ++i) {
-            seed[i] = static_cast<uint8_t>(i & 0xFF);
-        }
+        fill_pattern(seed.data(), seed.size());
         cluster->write_to_device(seed.data(), seed.size(), args.chip, core, args.addr);
         std::cout << "Seeded " << args.size << " bytes of test pattern into device memory via UMD" << std::endl;
     }
@@ -195,79 +187,45 @@ int run(int argc, char** argv) {
     QpExchangeInfo remote{};
     send_all(conn, &local, sizeof(local));
     recv_all(conn, &remote, sizeof(remote));
+    check_peer_exchange_info(remote);
     std::cout << "Peer QPN=" << remote.qpn << std::endl;
 
-    // RTR
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTR;
-        attr.path_mtu = IBV_MTU_1024;
-        attr.dest_qp_num = remote.qpn;
-        attr.rq_psn = remote.psn;
-        attr.max_dest_rd_atomic = 1;
-        attr.min_rnr_timer = 12;
-        attr.ah_attr.port_num = args.ib_port;
-        if (is_roce) {
-            attr.ah_attr.is_global = 1;
-            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
-            attr.ah_attr.grh.sgid_index = args.gid_index;
-            attr.ah_attr.grh.hop_limit = 1;
-        } else {
-            attr.ah_attr.is_global = 0;
-            attr.ah_attr.dlid = remote.lid;
-        }
-        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
-                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTR" << std::endl;
-            return 1;
-        }
-    }
-    // RTS
-    {
-        ibv_qp_attr attr{};
-        attr.qp_state = IBV_QPS_RTS;
-        attr.timeout = 14;
-        attr.retry_cnt = 7;
-        attr.rnr_retry = 7;
-        attr.sq_psn = local.psn;
-        attr.max_rd_atomic = 1;
-        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
-                    IBV_QP_MAX_QP_RD_ATOMIC;
-        if (ibv_modify_qp(qp, &attr, flags)) {
-            std::cerr << "Failed to move QP to RTS" << std::endl;
-            return 1;
-        }
+    connect_rc_qp(qp, rdma, args.gid_index, remote, local.psn);
+
+    // Wait for the initiator to report the outcome of its RDMA batch (a real hardware ACK, not just
+    // "posted"), so a failure on its side becomes a failure here too.
+    BatchResult peer_result = BatchResult::Fail;
+    recv_all(conn, &peer_result, 1);
+    if (peer_result != BatchResult::Pass) {
+        std::cerr << "Initiator reported FAIL for its RDMA batch" << std::endl;
     }
 
-    // Wait for the initiator to signal its RDMA batch has completed (a real hardware ACK, not just
-    // "posted").
-    char done = 0;
-    recv_all(conn, &done, 1);
-
-    bool all_match = true;
+    bool all_match = (peer_result == BatchResult::Pass);
     if (is_read) {
         // The data moved device -> host, so the initiator holds it and verifies on its side; there is
         // nothing to check here. Device memory should be unchanged from what we seeded.
         std::cout << "Initiator signaled read complete; it verifies the pattern on its side." << std::endl;
-    } else {
+    } else if (all_match) {
         std::cout << "Initiator signaled write complete; verifying via UMD readback..." << std::endl;
+
+        // The initiator's CQE only proves its NIC got a RoCE-level ACK; it says nothing about the
+        // resulting PCIe -> TLB -> NOC -> DRAM writes having landed. The readback below goes through a
+        // *different* TLB window, and the exported window's default Relaxed ordering imposes nothing
+        // against it, so without a barrier this races the tail of the RDMA batch and shows up as an
+        // intermittent, unreproducible "Mismatch at byte N" that reads as a dma-buf bug.
+        cluster->dram_membar(args.chip, std::unordered_set<CoreCoord>{core});
 
         std::vector<uint8_t> readback(args.size);
         cluster->read_from_device(readback.data(), args.chip, core, args.addr, args.size);
 
-        for (size_t i = 0; i < args.size && i < 4096; ++i) {
-            // Initiator fills its buffer with pattern byte = (i & 0xFF); check the first 4KiB, enough
-            // to catch a wrong-address / wrong-fd / stale-data class of bug without a slow full compare.
-            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
-            if (readback[i] != expected) {
-                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
-                          << static_cast<int>(readback[i]) << std::endl;
-                all_match = false;
-                break;
-            }
+        // Full compare against a position-dependent pattern: a prefix-only check passes when just the
+        // first page landed, and a byte-periodic pattern cannot detect a wrong-address bug at all.
+        const size_t mismatch = find_pattern_mismatch(readback.data(), readback.size());
+        if (mismatch != readback.size()) {
+            std::cerr << "Mismatch at byte " << mismatch << ": expected " << static_cast<int>(pattern_byte(mismatch))
+                      << " got " << static_cast<int>(readback[mismatch]) << std::endl;
+            all_match = false;
         }
-
         std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
     }
 
@@ -277,13 +235,13 @@ int run(int argc, char** argv) {
     ibv_destroy_cq(cq);
     ibv_dereg_mr(mr);
     ibv_dealloc_pd(pd);
-    ibv_close_device(ctx);
+    ibv_close_device(rdma.ctx);
     return all_match ? 0 : 1;
 }
 
 int main(int argc, char** argv) {
-    // recv_all()/send_all() throw on a dropped connection (e.g. the initiator dying mid-run); catch
-    // here so a peer failure prints a clean error instead of an uncaught-exception core dump.
+    // recv_all()/send_all(), the RDMA bring-up helpers and export_dmabuf() all throw; catch here so a
+    // peer or config failure prints a clean error instead of an uncaught-exception core dump.
     try {
         return run(argc, argv);
     } catch (const std::exception& e) {

--- a/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
@@ -34,11 +34,10 @@ struct Args {
     uint16_t port = 9999;
     tt::ChipId chip = 0;
     uint64_t addr = 0;
-    // 2 MiB, and it must stay a value that is a valid TLB window size class on every arch: Wormhole
-    // offers {1, 2, 16} MiB and Blackhole {2 MiB, 4 GiB} (get_tlb_sizes() in the *_implementation.hpp
-    // headers). export_dmabuf() rounds up to the next class that can cover the request, so a larger
-    // default throws outright on Wormhole ("No TLB window size can cover ...") and on Blackhole
-    // quietly consumes one of the few 4 GiB windows. Raise it with --size when you know the arch.
+    // 2 MiB: this example targets Blackhole, whose only TLB window size classes are 2 MiB and 4 GiB
+    // (see the size class tables in device/arch/architecture_tlbs.cpp). export_dmabuf() rounds up to
+    // the next class that can cover the request, so any larger default quietly consumes one of the
+    // few 4 GiB windows. Raise it with --size only when that trade is what you want.
     uint64_t size = 2ull << 20;
     std::string dev;                   // empty = first RDMA device with an ACTIVE port
     int ib_port = -1;                  // -1 = first ACTIVE port on that device

--- a/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
+++ b/examples/rdma_dmabuf_p2p/dmabuf_target.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RDMA target for the two-host dma-buf bandwidth test. Exports a TLB window via UMD's
+// Cluster::export_dmabuf(), registers the resulting fd as an RDMA MR with ibv_reg_dmabuf_mr(), and
+// waits for a peer NIC to RDMA-WRITE into it (repeatedly, to measure sustained bandwidth). Verifies
+// the final write landed by reading the same NOC address back through UMD (a path independent of
+// the exported window).
+#include <infiniband/verbs.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rdma_common.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+namespace {
+
+struct Args {
+    uint16_t port = 9999;
+    tt::ChipId chip = 0;
+    uint64_t addr = 0;
+    // 64 MiB: comfortably under Blackhole DRAM_BANK_SIZE (4 GiB, device/api/umd/device/arch/
+    // blackhole_implementation.hpp) and large enough that per-message RDMA/CQE overhead doesn't
+    // dominate the bandwidth measurement. addr + size must stay within a single DRAM bank.
+    uint64_t size = 64ull << 20;
+    int ib_port = 1;
+    int gid_index = -1;        // -1 = auto-detect a RoCEv2 GID (see resolve_gid_index in rdma_common.hpp)
+    std::string op = "write";  // must match the initiator's --op: decides who seeds and who verifies
+};
+
+Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto next = [&]() { return std::string(argv[++i]); };
+        if (arg == "--port") {
+            a.port = static_cast<uint16_t>(std::stoi(next()));
+        } else if (arg == "--chip") {
+            a.chip = std::stoi(next());
+        } else if (arg == "--addr") {
+            a.addr = std::stoull(next(), nullptr, 0);
+        } else if (arg == "--size") {
+            a.size = std::stoull(next());
+        } else if (arg == "--ib-port") {
+            a.ib_port = std::stoi(next());
+        } else if (arg == "--gid-index") {
+            a.gid_index = std::stoi(next());
+        } else if (arg == "--op") {
+            a.op = next();
+        }
+    }
+    return a;
+}
+
+}  // namespace
+
+int run(int argc, char** argv) {
+    Args args = parse_args(argc, argv);
+    if (args.op != "write" && args.op != "read") {
+        std::cerr << "--op must be 'write' or 'read', got '" << args.op << "'" << std::endl;
+        return 1;
+    }
+    const bool is_read = (args.op == "read");
+
+    // --- UMD side: export a TLB window as a dma-buf ------------------------------------------
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    const SocDescriptor& soc_desc = cluster->get_soc_descriptor(args.chip);
+    std::vector<CoreCoord> dram_cores = soc_desc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    if (dram_cores.empty()) {
+        std::cerr << "No DRAM cores found on chip " << args.chip << std::endl;
+        return 1;
+    }
+    CoreCoord core = dram_cores.front();
+
+    std::cout << "Exporting TLB window: chip=" << args.chip << " core=(" << core.x << "," << core.y << ") addr=0x"
+              << std::hex << args.addr << std::dec << " size=" << args.size << std::endl;
+
+    // export_dmabuf() takes the export length directly and rounds the underlying TLB window up to
+    // the arch's next valid size class internally, so --size needs no arch-specific adjustment here.
+    int dmabuf_fd = cluster->export_dmabuf(args.chip, core, args.addr, args.size);
+    std::cout << "Got dma-buf fd " << dmabuf_fd << std::endl;
+
+    // --- RDMA side: register the dma-buf as an MR --------------------------------------------
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        std::cerr << "No RDMA devices found" << std::endl;
+        return 1;
+    }
+    ibv_context* ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!ctx) {
+        std::cerr << "ibv_open_device failed" << std::endl;
+        return 1;
+    }
+
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, args.ib_port, &port_attr)) {
+        std::cerr << "ibv_query_port failed" << std::endl;
+        return 1;
+    }
+    bool is_roce = (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET);
+    if (is_roce) {
+        args.gid_index = resolve_gid_index(ctx, args.ib_port, args.gid_index);
+    }
+
+    ibv_pd* pd = ibv_alloc_pd(ctx);
+    // offset=0, iova=0: the dma-buf has no CPU-side virtual address, so remote_addr on the
+    // initiator's WRITE/READ must also be 0 to match this MR's iova.
+    //
+    // REMOTE_READ is granted unconditionally alongside REMOTE_WRITE so one target invocation serves
+    // either direction. Omitting it is the classic way an RDMA_READ dies with
+    // IBV_WC_REM_ACCESS_ERR on the initiator while the write path looks perfectly healthy.
+    ibv_mr* mr = ibv_reg_dmabuf_mr(
+        pd, 0, args.size, 0, dmabuf_fd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
+    if (!mr) {
+        perror("ibv_reg_dmabuf_mr failed");
+        return 1;
+    }
+
+    ibv_cq* cq = ibv_create_cq(ctx, 1, nullptr, nullptr, 0);
+    ibv_qp_init_attr qp_init_attr{};
+    qp_init_attr.send_cq = cq;
+    qp_init_attr.recv_cq = cq;
+    qp_init_attr.qp_type = IBV_QPT_RC;
+    qp_init_attr.cap.max_send_wr = 1;
+    qp_init_attr.cap.max_recv_wr = 1;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+    ibv_qp* qp = ibv_create_qp(pd, &qp_init_attr);
+    if (!qp) {
+        std::cerr << "ibv_create_qp failed" << std::endl;
+        return 1;
+    }
+
+    // INIT
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_INIT;
+        attr.pkey_index = 0;
+        attr.port_num = args.ib_port;
+        // Same reasoning as the MR flags above: the QP must permit remote reads too, or an
+        // RDMA_READ is rejected at the QP level even though the MR allows it.
+        attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
+        int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to INIT" << std::endl;
+            return 1;
+        }
+    }
+
+    QpExchangeInfo local{};
+    local.qpn = qp->qp_num;
+    local.psn = 0x1234;
+    local.rkey = mr->rkey;
+    local.remote_addr = 0;
+    if (is_roce) {
+        ibv_gid gid{};
+        if (ibv_query_gid(ctx, args.ib_port, args.gid_index, &gid)) {
+            std::cerr << "ibv_query_gid failed" << std::endl;
+            return 1;
+        }
+        std::memcpy(local.gid, gid.raw, 16);
+    } else {
+        local.lid = port_attr.lid;
+    }
+
+    // In read mode the initiator pulls *from* device memory, so the pattern has to already be there.
+    // Seed it via UMD (a path independent of the exported window) before the handshake, so it is in
+    // place before the peer can possibly issue a READ.
+    if (is_read) {
+        std::vector<uint8_t> seed(args.size);
+        for (size_t i = 0; i < args.size; ++i) {
+            seed[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+        cluster->write_to_device(seed.data(), seed.size(), args.chip, core, args.addr);
+        std::cout << "Seeded " << args.size << " bytes of test pattern into device memory via UMD" << std::endl;
+    }
+
+    // --- OOB handshake -------------------------------------------------------------------------
+    std::cout << "Waiting for initiator on port " << args.port << "..." << std::endl;
+    int conn = tcp_listen_accept(args.port);
+    QpExchangeInfo remote{};
+    send_all(conn, &local, sizeof(local));
+    recv_all(conn, &remote, sizeof(remote));
+    std::cout << "Peer QPN=" << remote.qpn << std::endl;
+
+    // RTR
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTR;
+        attr.path_mtu = IBV_MTU_1024;
+        attr.dest_qp_num = remote.qpn;
+        attr.rq_psn = remote.psn;
+        attr.max_dest_rd_atomic = 1;
+        attr.min_rnr_timer = 12;
+        attr.ah_attr.port_num = args.ib_port;
+        if (is_roce) {
+            attr.ah_attr.is_global = 1;
+            std::memcpy(attr.ah_attr.grh.dgid.raw, remote.gid, 16);
+            attr.ah_attr.grh.sgid_index = args.gid_index;
+            attr.ah_attr.grh.hop_limit = 1;
+        } else {
+            attr.ah_attr.is_global = 0;
+            attr.ah_attr.dlid = remote.lid;
+        }
+        int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTR" << std::endl;
+            return 1;
+        }
+    }
+    // RTS
+    {
+        ibv_qp_attr attr{};
+        attr.qp_state = IBV_QPS_RTS;
+        attr.timeout = 14;
+        attr.retry_cnt = 7;
+        attr.rnr_retry = 7;
+        attr.sq_psn = local.psn;
+        attr.max_rd_atomic = 1;
+        int flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                    IBV_QP_MAX_QP_RD_ATOMIC;
+        if (ibv_modify_qp(qp, &attr, flags)) {
+            std::cerr << "Failed to move QP to RTS" << std::endl;
+            return 1;
+        }
+    }
+
+    // Wait for the initiator to signal its RDMA batch has completed (a real hardware ACK, not just
+    // "posted").
+    char done = 0;
+    recv_all(conn, &done, 1);
+
+    bool all_match = true;
+    if (is_read) {
+        // The data moved device -> host, so the initiator holds it and verifies on its side; there is
+        // nothing to check here. Device memory should be unchanged from what we seeded.
+        std::cout << "Initiator signaled read complete; it verifies the pattern on its side." << std::endl;
+    } else {
+        std::cout << "Initiator signaled write complete; verifying via UMD readback..." << std::endl;
+
+        std::vector<uint8_t> readback(args.size);
+        cluster->read_from_device(readback.data(), args.chip, core, args.addr, args.size);
+
+        for (size_t i = 0; i < args.size && i < 4096; ++i) {
+            // Initiator fills its buffer with pattern byte = (i & 0xFF); check the first 4KiB, enough
+            // to catch a wrong-address / wrong-fd / stale-data class of bug without a slow full compare.
+            uint8_t expected = static_cast<uint8_t>(i & 0xFF);
+            if (readback[i] != expected) {
+                std::cerr << "Mismatch at byte " << i << ": expected " << static_cast<int>(expected) << " got "
+                          << static_cast<int>(readback[i]) << std::endl;
+                all_match = false;
+                break;
+            }
+        }
+
+        std::cout << (all_match ? "PASS" : "FAIL") << std::endl;
+    }
+
+    close(conn);
+    close(dmabuf_fd);
+    ibv_destroy_qp(qp);
+    ibv_destroy_cq(cq);
+    ibv_dereg_mr(mr);
+    ibv_dealloc_pd(pd);
+    ibv_close_device(ctx);
+    return all_match ? 0 : 1;
+}
+
+int main(int argc, char** argv) {
+    // recv_all()/send_all() throw on a dropped connection (e.g. the initiator dying mid-run); catch
+    // here so a peer failure prints a clean error instead of an uncaught-exception core dump.
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/examples/rdma_dmabuf_p2p/rdma_common.hpp
+++ b/examples/rdma_dmabuf_p2p/rdma_common.hpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared helpers for the two-host dma-buf RDMA example: the out-of-band TCP handshake used to
-// exchange QP/rkey info, and RoCEv2 GID selection.
+// Shared helpers for the two-host dma-buf RDMA example: command-line parsing, the out-of-band TCP
+// handshake used to exchange QP/rkey info, RDMA device/GID selection, RC QP bring-up, and the
+// verification pattern. Both binaries use these, so the bring-up exists once rather than twice.
 #pragma once
 
 #include <arpa/inet.h>
@@ -13,6 +14,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -20,16 +23,171 @@
 #include <string>
 
 // Out-of-band info exchanged between the two hosts to bring up the RC QP.
-// Sent as a flat, fixed-size struct over a plain TCP socket (no serialization library needed).
+//
+// Sent as a flat struct over a plain TCP socket (no serialization library needed). The field order
+// is chosen so every member is naturally aligned with no implicit padding, and the static_assert
+// below pins the resulting size: a silent layout change between the initiator's and the target's
+// build would otherwise corrupt the handshake in a way that surfaces as an unrelated RDMA error.
+// `magic` catches the mismatched-build case at runtime. Both hosts are assumed to be the same
+// endianness (x86 <-> x86); this is an example, not a portable wire protocol.
 struct QpExchangeInfo {
+    uint32_t magic = 0;  // MAGIC below; guards against a mismatched or stale peer build
     uint32_t qpn = 0;
     uint32_t psn = 0;
-    uint16_t lid = 0;          // valid only if the port's link layer is InfiniBand
-    uint8_t gid[16] = {0};     // valid only if the port's link layer is Ethernet (RoCE)
-    uint32_t rkey = 0;         // target's dma-buf MR rkey; unused/zero from the initiator
-    uint64_t remote_addr = 0;  // target's dma-buf MR iova (we register with iova=0, so this is 0);
-                               // kept explicit so the initiator doesn't have to hardcode it
+    uint32_t rkey = 0;           // target's dma-buf MR rkey; unused/zero from the initiator
+    uint64_t remote_addr = 0;    // target's dma-buf MR iova (we register with iova=0, so this is 0);
+                                 // kept explicit so the initiator doesn't have to hardcode it
+    uint64_t mr_length = 0;      // target's MR length in bytes. The two binaries are launched
+                                 // independently with their own --size; the initiator compares this
+                                 // against its own and refuses a mismatch, which would otherwise be
+                                 // either IBV_WC_REM_ACCESS_ERR at iter 0 (initiator larger) or a
+                                 // bandwidth figure for a partly-written window (initiator smaller).
+    uint16_t lid = 0;            // valid only if the port's link layer is InfiniBand
+    uint16_t reserved = 0;       // explicit, so the 16-byte gid below stays aligned with no padding
+    uint8_t gid[16] = {0};       // valid only if the port's link layer is Ethernet (RoCE)
+    uint8_t reserved2[4] = {0};  // explicit tail padding to the struct's 8-byte alignment, so the
+                                 // wire size is stated here rather than chosen by the compiler
+
+    static constexpr uint32_t MAGIC = 0x54544442;  // "TTDB"
 };
+
+static_assert(sizeof(QpExchangeInfo) == 56, "QpExchangeInfo must stay padding-free; the peer parses it byte-for-byte");
+
+// Sent by the initiator after its RDMA batch, in place of the old unconditional 1 byte. The target
+// propagates a FAIL into its own exit status: without this the initiator can print FAIL and return 1
+// while the target returns 0, and a CI harness watching the target (the side that owns the device)
+// records a clean pass on a data-corruption run.
+enum class BatchResult : uint8_t {
+    Pass = 1,
+    Fail = 2,
+};
+
+// Position-dependent verification pattern: a golden-ratio multiplier per 64-bit word, so the value
+// at a given offset is unique across any realistic window. A byte-periodic pattern (e.g. i & 0xFF)
+// cannot detect a wrong-address bug at all, since any offset that is a multiple of the period
+// verifies clean.
+constexpr uint64_t PATTERN_MULT = 0x9E3779B97F4A7C15ULL;
+
+inline uint8_t pattern_byte(size_t offset) {
+    const uint64_t word = static_cast<uint64_t>(offset / sizeof(uint64_t)) * PATTERN_MULT;
+    return static_cast<uint8_t>(word >> (8 * (offset % sizeof(uint64_t))));
+}
+
+inline void fill_pattern(uint8_t* buf, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        buf[i] = pattern_byte(i);
+    }
+}
+
+// Returns the offset of the first mismatching byte, or `size` if the whole buffer matches. The
+// compare covers the entire buffer: checking only a prefix lets a transfer where just the first page
+// landed pass.
+inline size_t find_pattern_mismatch(const uint8_t* buf, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        if (buf[i] != pattern_byte(i)) {
+            return i;
+        }
+    }
+    return size;
+}
+
+// --- command line ----------------------------------------------------------------------------
+
+// Value of the argument following `argv[i]`, advancing `i`. Throws when the flag is trailing:
+// `argv[++i]` at i == argc - 1 reads argv[argc], the guaranteed NULL terminator, and constructing a
+// std::string from it is UB (in practice a segfault inside strlen, before any usage message).
+inline std::string arg_value(int argc, char** argv, int& i) {
+    const std::string flag = argv[i];
+    if (i + 1 >= argc) {
+        throw std::runtime_error(flag + " requires a value");
+    }
+    return std::string(argv[++i]);
+}
+
+// --- RDMA device / port selection ------------------------------------------------------------
+
+// An opened RDMA device plus the port to use on it. The caller owns `ctx` and must ibv_close_device()
+// it.
+struct RdmaPort {
+    ibv_context* ctx = nullptr;
+    std::string dev_name;
+    int ib_port = 1;
+    ibv_port_attr port_attr{};
+
+    bool is_roce() const { return port_attr.link_layer == IBV_LINK_LAYER_ETHERNET; }
+};
+
+// Opens an RDMA device and picks a port that is actually usable.
+//
+// With no --dev/--ib-port override, scans every device and every port 1..phys_port_cnt and takes the
+// first in state IBV_PORT_ACTIVE. Taking dev_list[0]/port 1 blindly picks a DOWN NIC on a multi-NIC
+// host, which then either reports "no RoCEv2 GID" or brings the QP up on a dead port and times out —
+// while UMD's own has_any_active_rdma_port() check has already passed on a *different* device.
+//
+// An explicit device or port is honoured, but a non-ACTIVE choice is rejected rather than used.
+inline RdmaPort open_active_rdma_port(const std::string& requested_dev, int requested_port) {
+    int num_devices = 0;
+    ibv_device** dev_list = ibv_get_device_list(&num_devices);
+    if (!dev_list || num_devices == 0) {
+        if (dev_list) {
+            ibv_free_device_list(dev_list);
+        }
+        throw std::runtime_error("No RDMA devices found under /sys/class/infiniband");
+    }
+
+    RdmaPort result;
+    std::string tried;
+    for (int d = 0; d < num_devices && !result.ctx; ++d) {
+        const std::string name = ibv_get_device_name(dev_list[d]);
+        if (!requested_dev.empty() && name != requested_dev) {
+            continue;
+        }
+
+        ibv_context* ctx = ibv_open_device(dev_list[d]);
+        if (!ctx) {
+            tried += " " + name + "(open failed)";
+            continue;
+        }
+
+        ibv_device_attr dev_attr{};
+        if (ibv_query_device(ctx, &dev_attr)) {
+            ibv_close_device(ctx);
+            tried += " " + name + "(query failed)";
+            continue;
+        }
+
+        const int first_port = requested_port > 0 ? requested_port : 1;
+        const int last_port = requested_port > 0 ? requested_port : dev_attr.phys_port_cnt;
+        for (int p = first_port; p <= last_port; ++p) {
+            ibv_port_attr port_attr{};
+            if (ibv_query_port(ctx, p, &port_attr)) {
+                tried += " " + name + ":" + std::to_string(p) + "(query failed)";
+                continue;
+            }
+            if (port_attr.state != IBV_PORT_ACTIVE) {
+                tried += " " + name + ":" + std::to_string(p) + "(" + ibv_port_state_str(port_attr.state) + ")";
+                continue;
+            }
+            result.ctx = ctx;
+            result.dev_name = name;
+            result.ib_port = p;
+            result.port_attr = port_attr;
+            break;
+        }
+        if (!result.ctx) {
+            ibv_close_device(ctx);
+        }
+    }
+    ibv_free_device_list(dev_list);
+
+    if (!result.ctx) {
+        throw std::runtime_error("No RDMA port in the ACTIVE state found; tried:" + (tried.empty() ? " none" : tried));
+    }
+    std::cout << "Using RDMA device " << result.dev_name << " port " << result.ib_port << " ("
+              << ibv_port_state_str(result.port_attr.state) << ", active_mtu=" << (128 << result.port_attr.active_mtu)
+              << " B)" << std::endl;
+    return result;
+}
 
 // Format a GID for logging, matching the ipv4-mapped-aware style of `show_gids`.
 inline std::string gid_to_string(const ibv_gid& gid) {
@@ -110,13 +268,133 @@ inline int resolve_gid_index(ibv_context* ctx, int ib_port, int requested) {
     return idx;
 }
 
+// --- RC QP bring-up --------------------------------------------------------------------------
+
+// Creates an RC QP in the INIT state. `access_flags` is the QP-level permission set: a QP serving
+// RDMA_READ needs IBV_ACCESS_REMOTE_READ here even when its MR already grants it, or the read is
+// rejected at the QP level.
+inline ibv_qp* create_rc_qp(ibv_pd* pd, ibv_cq* cq, int ib_port, uint32_t max_send_wr, int access_flags) {
+    ibv_qp_init_attr init_attr{};
+    init_attr.send_cq = cq;
+    init_attr.recv_cq = cq;
+    init_attr.qp_type = IBV_QPT_RC;
+    init_attr.cap.max_send_wr = max_send_wr;
+    init_attr.cap.max_recv_wr = 1;
+    init_attr.cap.max_send_sge = 1;
+    init_attr.cap.max_recv_sge = 1;
+
+    ibv_qp* qp = ibv_create_qp(pd, &init_attr);
+    if (!qp) {
+        throw std::runtime_error(std::string("ibv_create_qp failed: ") + std::strerror(errno));
+    }
+
+    ibv_qp_attr attr{};
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = static_cast<uint8_t>(ib_port);
+    attr.qp_access_flags = access_flags;
+    const int flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+    if (ibv_modify_qp(qp, &attr, flags)) {
+        const std::string err = std::strerror(errno);
+        ibv_destroy_qp(qp);
+        throw std::runtime_error("ibv_modify_qp to INIT failed: " + err);
+    }
+    return qp;
+}
+
+// Moves `qp` INIT -> RTR (pointed at the peer described by `remote`) -> RTS.
+//
+// path_mtu is negotiated down from the port's active_mtu rather than hardcoded: pinning a
+// jumbo-frame fabric (active_mtu 4096) to 1 KiB inflates per-packet header overhead ~4x, so the very
+// bandwidth number this example exists to produce comes out silently low — and on a port whose
+// active_mtu is below the hardcoded value the RTR transition simply fails.
+//
+// hop_limit is 64, not 1. This is a cross-host example and the GID selection above deliberately
+// prefers the routable IPv4-mapped RoCEv2 GID, so a hop limit of 1 makes every packet die at the
+// first router the moment the hosts aren't on one L2 segment — surfacing as "transport retry counter
+// exceeded", which is exactly the symptom this file attributes to a RoCEv1 GID above.
+inline void connect_rc_qp(
+    ibv_qp* qp, const RdmaPort& port, int gid_index, const QpExchangeInfo& remote, uint32_t local_psn) {
+    const ibv_mtu mtu = std::min(port.port_attr.active_mtu, IBV_MTU_4096);
+
+    ibv_qp_attr rtr{};
+    rtr.qp_state = IBV_QPS_RTR;
+    rtr.path_mtu = mtu;
+    rtr.dest_qp_num = remote.qpn;
+    rtr.rq_psn = remote.psn;
+    rtr.max_dest_rd_atomic = 1;
+    rtr.min_rnr_timer = 12;
+    rtr.ah_attr.port_num = static_cast<uint8_t>(port.ib_port);
+    if (port.is_roce()) {
+        rtr.ah_attr.is_global = 1;
+        std::memcpy(rtr.ah_attr.grh.dgid.raw, remote.gid, 16);
+        rtr.ah_attr.grh.sgid_index = static_cast<uint8_t>(gid_index);
+        rtr.ah_attr.grh.hop_limit = 64;
+    } else {
+        rtr.ah_attr.is_global = 0;
+        rtr.ah_attr.dlid = remote.lid;
+    }
+    int flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+    if (ibv_modify_qp(qp, &rtr, flags)) {
+        throw std::runtime_error(std::string("ibv_modify_qp to RTR failed: ") + std::strerror(errno));
+    }
+
+    ibv_qp_attr rts{};
+    rts.qp_state = IBV_QPS_RTS;
+    rts.timeout = 14;
+    rts.retry_cnt = 7;
+    rts.rnr_retry = 7;
+    rts.sq_psn = local_psn;
+    rts.max_rd_atomic = 1;
+    flags =
+        IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC;
+    if (ibv_modify_qp(qp, &rts, flags)) {
+        throw std::runtime_error(std::string("ibv_modify_qp to RTS failed: ") + std::strerror(errno));
+    }
+}
+
+// Fills in the local half of the handshake for `port`.
+inline QpExchangeInfo make_local_exchange_info(const RdmaPort& port, int gid_index, uint32_t qpn, uint32_t psn) {
+    QpExchangeInfo info{};
+    info.magic = QpExchangeInfo::MAGIC;
+    info.qpn = qpn;
+    info.psn = psn;
+    if (port.is_roce()) {
+        ibv_gid gid{};
+        if (ibv_query_gid(port.ctx, port.ib_port, gid_index, &gid)) {
+            throw std::runtime_error("ibv_query_gid failed");
+        }
+        std::memcpy(info.gid, gid.raw, 16);
+    } else {
+        info.lid = port.port_attr.lid;
+    }
+    return info;
+}
+
+inline void check_peer_exchange_info(const QpExchangeInfo& remote) {
+    if (remote.magic != QpExchangeInfo::MAGIC) {
+        throw std::runtime_error(
+            "Handshake magic mismatch (got " + std::to_string(remote.magic) +
+            "): the peer is running a different or stale build of this example");
+    }
+}
+
+// --- out-of-band TCP -------------------------------------------------------------------------
+
+// MSG_NOSIGNAL: without it, a send() to a socket whose peer has died (Ctrl-C, or a failed WQE) kills
+// this process with SIGPIPE — no exception, no error message, and no chance to close the exported
+// dma-buf and release the TLB window. EINTR is retried rather than treated as a connection error.
 inline void send_all(int fd, const void* buf, size_t len) {
     const char* p = static_cast<const char*>(buf);
     size_t sent = 0;
     while (sent < len) {
-        ssize_t n = send(fd, p + sent, len - sent, 0);
+        ssize_t n = send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
         if (n <= 0) {
-            throw std::runtime_error("send_all: connection error");
+            throw std::runtime_error(std::string("send_all: connection error: ") + std::strerror(errno));
         }
         sent += static_cast<size_t>(n);
     }
@@ -127,8 +405,14 @@ inline void recv_all(int fd, void* buf, size_t len) {
     size_t got = 0;
     while (got < len) {
         ssize_t n = recv(fd, p + got, len - got, 0);
-        if (n <= 0) {
-            throw std::runtime_error("recv_all: connection error");
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        if (n == 0) {
+            throw std::runtime_error("recv_all: peer closed the connection");
+        }
+        if (n < 0) {
+            throw std::runtime_error(std::string("recv_all: connection error: ") + std::strerror(errno));
         }
         got += static_cast<size_t>(n);
     }
@@ -148,13 +432,16 @@ inline int tcp_listen_accept(uint16_t port) {
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);
     if (bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        close(listen_fd);
         throw std::runtime_error("bind() failed");
     }
     if (listen(listen_fd, 1) < 0) {
+        close(listen_fd);
         throw std::runtime_error("listen() failed");
     }
     int conn_fd = accept(listen_fd, nullptr, nullptr);
     if (conn_fd < 0) {
+        close(listen_fd);
         throw std::runtime_error("accept() failed");
     }
     close(listen_fd);

--- a/examples/rdma_dmabuf_p2p/rdma_common.hpp
+++ b/examples/rdma_dmabuf_p2p/rdma_common.hpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared helpers for the two-host dma-buf RDMA example: the out-of-band TCP handshake used to
+// exchange QP/rkey info, and RoCEv2 GID selection.
+#pragma once
+
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+// Out-of-band info exchanged between the two hosts to bring up the RC QP.
+// Sent as a flat, fixed-size struct over a plain TCP socket (no serialization library needed).
+struct QpExchangeInfo {
+    uint32_t qpn = 0;
+    uint32_t psn = 0;
+    uint16_t lid = 0;          // valid only if the port's link layer is InfiniBand
+    uint8_t gid[16] = {0};     // valid only if the port's link layer is Ethernet (RoCE)
+    uint32_t rkey = 0;         // target's dma-buf MR rkey; unused/zero from the initiator
+    uint64_t remote_addr = 0;  // target's dma-buf MR iova (we register with iova=0, so this is 0);
+                               // kept explicit so the initiator doesn't have to hardcode it
+};
+
+// Format a GID for logging, matching the ipv4-mapped-aware style of `show_gids`.
+inline std::string gid_to_string(const ibv_gid& gid) {
+    char buf[INET6_ADDRSTRLEN] = {0};
+    if (!inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf))) {
+        return "<unprintable>";
+    }
+    return buf;
+}
+
+// Pick the GID index to use for a RoCE port.
+//
+// This matters a lot and is easy to get wrong: on these Broadcom BCM957608 NICs, GID index 0 is
+// RoCE *v1* with a link-local fe80:: address. RoCEv1 is a non-routable L2 protocol, and connecting
+// with it (even between hosts on the same subnet) produces no traffic the peer ever ACKs — the
+// symptom is the initiator failing its very first WRITE with "transport retry counter exceeded",
+// which is indistinguishable at a glance from a hardware/dma-buf problem. `ib_write_bw -x 0`
+// reproduces the same stall, so it's a fabric-config issue, not anything to do with UMD.
+//
+// Prefer a RoCEv2 GID with an IPv4-mapped address (::ffff:a.b.c.d), which is the routable,
+// switch-friendly choice; fall back to any non-link-local RoCEv2 GID. Returns -1 if none is found.
+inline int find_roce_v2_gid_index(ibv_context* ctx, int ib_port) {
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, ib_port, &port_attr)) {
+        return -1;
+    }
+
+    int fallback = -1;
+    for (int i = 0; i < port_attr.gid_tbl_len; ++i) {
+        ibv_gid_entry entry{};
+        if (ibv_query_gid_ex(ctx, static_cast<uint32_t>(ib_port), static_cast<uint32_t>(i), &entry, 0)) {
+            continue;  // ENODATA for empty table slots
+        }
+        if (entry.gid_type != IBV_GID_TYPE_ROCE_V2) {
+            continue;
+        }
+
+        const uint8_t* r = entry.gid.raw;
+        bool ipv4_mapped = (r[10] == 0xff && r[11] == 0xff);
+        for (int b = 0; b < 10 && ipv4_mapped; ++b) {
+            ipv4_mapped = (r[b] == 0x00);
+        }
+        if (ipv4_mapped) {
+            return i;
+        }
+        bool link_local = (r[0] == 0xfe && r[1] == 0x80);
+        if (!link_local && fallback < 0) {
+            fallback = i;
+        }
+    }
+    return fallback;
+}
+
+// Resolve the GID index to use: honor an explicit override if given (>= 0), otherwise auto-detect.
+// Throws if neither yields a usable RoCEv2 GID, since silently falling back to index 0 is exactly
+// the failure mode described above.
+inline int resolve_gid_index(ibv_context* ctx, int ib_port, int requested) {
+    if (requested >= 0) {
+        ibv_gid_entry entry{};
+        if (!ibv_query_gid_ex(ctx, static_cast<uint32_t>(ib_port), static_cast<uint32_t>(requested), &entry, 0) &&
+            entry.gid_type != IBV_GID_TYPE_ROCE_V2) {
+            std::cerr << "Warning: --gid-index " << requested << " is not a RoCEv2 GID; "
+                      << "expect 'transport retry counter exceeded' if the fabric is routed." << std::endl;
+        }
+        return requested;
+    }
+
+    int idx = find_roce_v2_gid_index(ctx, ib_port);
+    if (idx < 0) {
+        throw std::runtime_error(
+            "No RoCEv2 GID found on this port; pass --gid-index explicitly (see the GID table under "
+            "/sys/class/infiniband/<dev>/ports/<port>/gid_attrs/types/)");
+    }
+
+    ibv_gid gid{};
+    ibv_query_gid(ctx, ib_port, idx, &gid);
+    std::cout << "Auto-selected RoCEv2 GID index " << idx << " (" << gid_to_string(gid) << ")" << std::endl;
+    return idx;
+}
+
+inline void send_all(int fd, const void* buf, size_t len) {
+    const char* p = static_cast<const char*>(buf);
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = send(fd, p + sent, len - sent, 0);
+        if (n <= 0) {
+            throw std::runtime_error("send_all: connection error");
+        }
+        sent += static_cast<size_t>(n);
+    }
+}
+
+inline void recv_all(int fd, void* buf, size_t len) {
+    char* p = static_cast<char*>(buf);
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = recv(fd, p + got, len - got, 0);
+        if (n <= 0) {
+            throw std::runtime_error("recv_all: connection error");
+        }
+        got += static_cast<size_t>(n);
+    }
+}
+
+// Target side: listen on `port`, accept exactly one connection, return its fd.
+inline int tcp_listen_accept(uint16_t port) {
+    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        throw std::runtime_error("socket() failed");
+    }
+    int one = 1;
+    setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(port);
+    if (bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        throw std::runtime_error("bind() failed");
+    }
+    if (listen(listen_fd, 1) < 0) {
+        throw std::runtime_error("listen() failed");
+    }
+    int conn_fd = accept(listen_fd, nullptr, nullptr);
+    if (conn_fd < 0) {
+        throw std::runtime_error("accept() failed");
+    }
+    close(listen_fd);
+    return conn_fd;
+}
+
+// Initiator side: connect to host:port, return the connected fd.
+inline int tcp_connect(const std::string& host, uint16_t port) {
+    addrinfo hints{};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* res = nullptr;
+    std::string port_str = std::to_string(port);
+    if (getaddrinfo(host.c_str(), port_str.c_str(), &hints, &res) != 0) {
+        throw std::runtime_error("getaddrinfo() failed for host " + host);
+    }
+    int fd = -1;
+    for (addrinfo* rp = res; rp != nullptr; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
+            break;
+        }
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0) {
+        throw std::runtime_error("connect() failed to " + host + ":" + port_str);
+    }
+    return fd;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,8 +33,11 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/hang_detection)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/blackhole)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/misc)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pcie)
-# rdma_tests is EXCLUDE_FROM_ALL and requires libibverbs; it is intentionally left out of umd_tests.
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/rdma)
+# Opt-in via TT_UMD_BUILD_RDMA: needs libibverbs to build and an RDMA NIC to run. Deliberately left
+# out of the umd_tests aggregate target, which CI runs, for the same reason.
+if(TT_UMD_BUILD_RDMA)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/rdma)
+endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unified)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wormhole)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/galaxy)

--- a/tests/rdma/CMakeLists.txt
+++ b/tests/rdma/CMakeLists.txt
@@ -1,19 +1,7 @@
-# RDMA dma-buf loopback test.
-#
-# Deliberately not part of the default build, of the umd_tests aggregate target, or of CI: it needs
-# libibverbs at build time and an ACTIVE RoCEv2 NIC at run time. Build it explicitly with
-# `cmake --build <dir> --target rdma_tests` on a machine that has libibverbs-dev installed.
-find_library(IBVERBS_LIBRARY NAMES ibverbs)
-find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
-
-if(NOT (IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR))
-    message(STATUS "libibverbs not found; skipping the rdma_tests target")
-    return()
-endif()
-
+# RDMA dma-buf loopback test. Reached only when TT_UMD_BUILD_RDMA is ON; libibverbs is located and
+# version-checked once in cmake/ibverbs.cmake.
 add_executable(
     rdma_tests
-    EXCLUDE_FROM_ALL
     rdma_loopback.cpp
     test_dmabuf_loopback.cpp
 )
@@ -21,9 +9,8 @@ target_link_libraries(
     rdma_tests
     PRIVATE
         test_common
-        ${IBVERBS_LIBRARY}
+        ibverbs::ibverbs
 )
-target_include_directories(rdma_tests PRIVATE ${IBVERBS_INCLUDE_DIR})
 
 set_target_properties(
     rdma_tests

--- a/tests/rdma/test_dmabuf_loopback.cpp
+++ b/tests/rdma/test_dmabuf_loopback.cpp
@@ -43,9 +43,13 @@ using namespace tt::umd;
 // different TLB window. A self-consistent "write and read back through the same window" check could
 // not distinguish that from a misprogrammed or bogus export.
 //
-// This target is not part of the default build or of any automatically run test suite: it needs
-// libibverbs at build time and an ACTIVE RoCEv2 NIC plus a KMD with dma-buf export support at run
-// time. Run it explicitly on a machine that has them.
+// Scope: the dma-buf export path is currently intended for Blackhole Galaxy systems and is only
+// exercised there. Nothing in this test is arch-specific and the size below is valid on Wormhole too,
+// so it is not gated to one arch, but a Wormhole run is unverified.
+//
+// This target is opt-in and not part of any automatically run test suite: it needs libibverbs at
+// build time (-DTT_UMD_BUILD_RDMA=ON) and an ACTIVE RoCEv2 NIC plus a KMD with dma-buf export support
+// at run time. Run it explicitly on a machine that has them.
 // The pattern write below is a single 2 MiB MMIO transfer through a TLB window, which carries no
 // hang-detector veto: on a contended host it can outlast the tight default per-op budget and throw
 // DeviceTimeoutError. Widen the budget for the test and restore the default afterwards.
@@ -67,7 +71,9 @@ TEST_F(TestDmabufRdmaLoopback, ExportedDmabufIsRdmaReadable) {
     }
 
     const ChipId chip = 0;
-    const uint64_t size = 1 << 21;  // 2 MiB: a valid tt_tlb_alloc size class on both Wormhole and Blackhole.
+    // 2 MiB: a valid tt_tlb_alloc size class on both Wormhole and Blackhole, so the test needs no
+    // arch-specific adjustment (see the size class tables in device/arch/architecture_tlbs.cpp).
+    const uint64_t size = 1 << 21;
     const size_t nwords = size / sizeof(uint64_t);
     const size_t chunk_size = 512 * 1024;
     const int max_outstanding_reads = 8;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3283

### Description
Documents how to run the two RDMA dma-buf tests added in the preceding PRs in this stack: the single-host loopback gtest and the two-host peer-to-peer example. Also makes both of them opt-in at configure time, which came out of the review discussion on this PR.

### List of the changes
 - Added examples/rdma_dmabuf_p2p/README.md: scope, prerequisites split into distro packages, NIC driver and fabric configuration, build steps, run instructions for both sides, a table of the available flags, and notes on DRAM bank limits, TLB window size classes, RoCEv2 GID selection and pinned memory limits. Cross-references the loopback gtest for the single-host case.
 - Listed the new example in examples/README.md.
 - Added the TT_UMD_BUILD_RDMA option, OFF by default, gating both tests/rdma and examples/rdma_dmabuf_p2p. With it ON, missing or too-old libibverbs is a configure error naming what to install rather than a silent skip, so the host environment no longer decides what gets built.
 - Added cmake/ibverbs.cmake, which locates libibverbs, checks that rdma-core is new enough for ibv_reg_dmabuf_mr and ibv_query_gid_ex, and defines an imported ibverbs::ibverbs target. Both consumers previously carried the same lookup separately.
 - Stated that this is currently intended for Blackhole Galaxy and only exercised there, and dropped the Wormhole size class guidance from the example.

### Testing
Configured with the option off (no RDMA targets and no libibverbs lookup), with it on (all three targets build warning free), and with it on and libibverbs hidden (a single configure error pointing at the fix).

### API Changes
This PR has no API changes.
