### PR TITLE
[CI] Bump build-device job timeout 30 -> 45 min

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -9,7 +9,7 @@ on:
         required: true
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 45
       use-sccache:
         required: false
         description: >-
@@ -121,7 +121,8 @@ jobs:
   build:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
+    # 45, not 30: the heaviest matrix entries build the tree twice and land around 35 min.
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '45') }}
     needs:
       - pr-gate
       - ensure-ubuntu-2204-image
@@ -442,7 +443,7 @@ jobs:
   build-manylinux-wheels:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '45') }}
     needs: [pr-gate, ensure-manylinux-image, ensure-manylinux-aarch64-image]
     strategy:
       fail-fast: false
@@ -498,7 +499,7 @@ jobs:
 
   test-packages:
     needs: [pr-gate, build, ensure-ubuntu-2204-image, ensure-ubuntu-2404-image, ensure-fedora-39-image]
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '45') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Issue

`Build Device` jobs are being cancelled, not failed. [Run 33057193934 / job 98466916102](https://github.com/tenstorrent/tt-umd/actions/runs/33057193934/job/98466916102) (`Build device (release flags) on ubuntu-24.04 with clang-20`) was killed at exactly 30:04, part way through `Rebuild package for python without wheel` at target 53 of 82. There is no failure to look at, just a truncated log.

## Description

The heaviest matrix entries build the tree twice. `Build All` took 21m27s for 451 targets with clang-tidy on, the three standalone client builds another 1m58s, and then `Rebuild package for python without wheel` reconfigures and rebuilds 82 targets. On a 4-core runner with sccache disabled (it is read-only off `main` and skipped entirely on `pull_request` and `merge_group`) that lands around 35 min, so a 30 min ceiling leaves nothing.

45 rather than 60 because these jobs are not expected to grow much further and a genuinely hung one should still be reaped in a reasonable time.

Worth noting separately, because it is why the job is this heavy: the `use_release_flags` branch in `Build All` never fires on the Ubuntu images. GitHub runs container `run:` steps under `shell: sh -e {0}` unless the step overrides it, and dash has no `[[`, so the log carries `/__w/_temp/....sh: 3: [[: not found` and the false condition sends the job down the `else` branch. The configuration summary in the same log confirms it: `TT_UMD_BUILD_ALL = ON`, `TT_UMD_BUILD_TESTS = ON`, `TT_UMD_BUILD_SIMULATION = ON`, `TT_UMD_ENABLE_TRACY = ON`, none of which the release-flags branch sets. So those two entries have never mirrored `release.yml`, and the later reconfigure to `TT_UMD_BUILD_PIP=OFF` is what invalidates a large part of the tree. Fixing it (`shell: bash` on the step) will change what those jobs compile and is likely to surface clang-tidy findings that have been hidden since the entries were added, so it is left out of this PR.

## List of the changes

- `timeout-minutes` default 30 -> 45 in `build`, `build-manylinux-wheels` and `test-packages`.
- `workflow_dispatch` `timeout` input default 30 -> 45, so a manual dispatch matches the automatic runs.

## Testing

CI on this PR. The `build` matrix is skipped on `pull_request` by the `pr-gate` job, so the real check is the merge queue run.

## API Changes

This PR has no API changes.
