### PR TITLE
[Base API] Delegate get_noc_translation_enabled to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -33,8 +33,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    bool get_noc_translation_enabled() override;
-
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -70,7 +70,6 @@ public:
     void write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     uint32_t get_clock() override;
     uint32_t get_min_clock_freq() override;
-    bool get_noc_translation_enabled() override;
     void dma_multicast_write(
         void* src,
         size_t size,

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -408,7 +408,7 @@ public:
 
     BoardType get_board_type();
 
-    virtual bool get_noc_translation_enabled() = 0;
+    bool get_noc_translation_enabled();
 
     double get_asic_temperature();
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -30,8 +30,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    bool get_noc_translation_enabled() override;
-
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -121,19 +121,6 @@ void BlackholeTTDevice::configure_iatu_region(size_t region, uint64_t target, si
         target);
 }
 
-bool BlackholeTTDevice::get_noc_translation_enabled() {
-    uint32_t niu_cfg;
-    const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + 0x100;
-
-    if (get_communication_device_type() == IODeviceType::JTAG) {
-        // Target arc core.
-        niu_cfg = get_jtag_interface()->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);
-    } else {
-        niu_cfg = bar_read32(addr);
-    }
-    return ((niu_cfg >> 14) & 0x1) != 0;
-}
-
 ChipInfo BlackholeTTDevice::get_chip_info() {
     ChipInfo chip_info = TTDevice::get_chip_info();
     chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -310,12 +310,6 @@ std::unique_ptr<TlbWindow> SimulationTTDevice::get_io_window(tlb_data config, Tl
     return create_tlb_window(tlb_index, actual_size, mapping, config);
 }
 
-bool SimulationTTDevice::get_noc_translation_enabled() {
-    // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is never
-    // applied.
-    return false;
-}
-
 void SimulationTTDevice::noc_multicast_write(
     const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -276,6 +276,8 @@ void TTDevice::set_power_state(TTDevice::PowerState state, NocId noc_id) {
         state == TTDevice::PowerState::BUSY ? tt::umd::PowerState::HIGH : tt::umd::PowerState::LOW, noc_id);
 }
 
+bool TTDevice::get_noc_translation_enabled() { return get_device_firmware()->get_noc_translation_enabled(); }
+
 DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }
 
 PcieInterface *TTDevice::get_pcie_interface() {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -53,14 +53,6 @@ WormholeTTDevice::WormholeTTDevice(
     set_hang_detector(std::make_unique<WormholeHangDetector>(hang_check_protocol));
 }
 
-bool WormholeTTDevice::get_noc_translation_enabled() {
-    uint32_t niu_cfg = 0x0;
-    constexpr uint32_t ARC_APB_NIU_0_OFFSET = 0x50000;
-    constexpr uint32_t NIU_CFG_0_OFFSET = 0x100;
-    read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof niu_cfg);
-    return (niu_cfg & (1 << 14)) != 0;
-}
-
 ChipInfo WormholeTTDevice::get_chip_info() {
     ChipInfo chip_info = TTDevice::get_chip_info();
 


### PR DESCRIPTION
## Issue

`TTDevice::get_noc_translation_enabled` was pure virtual with three overrides, each duplicating a register read the firmware already does.

## Description

The pure virtual becomes a forwarder; the Blackhole, Wormhole and simulation overrides are deleted. Removed Wormhole body against its replacement ([`wormhole_device_firmware.cpp#L313-L320`](https://github.com/tenstorrent/tt-umd/blob/8d55c9d9e0de36bdb37c19ff301a3aebabe515d2/device/tt_device/firmware/wormhole_device_firmware.cpp#L313-L320)):

```diff
--- TTDevice
+++ DeviceFirmware
@@ -1,7 +1,8 @@
-bool get_noc_translation_enabled() {
-    uint32_t niu_cfg = 0x0;
+bool get_noc_translation_enabled(NocId noc_id) {
     constexpr uint32_t ARC_APB_NIU_0_OFFSET = 0x50000;
     constexpr uint32_t NIU_CFG_0_OFFSET = 0x100;
-    read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof niu_cfg);
+
+    uint32_t niu_cfg = 0x0;
+    read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof(niu_cfg), noc_id);
     return (niu_cfg & (1 << 14)) != 0;
 }
```

Same register, same bit. The only change is that the firmware holds the interfaces directly and takes the NOC per call.

This was scoped as blocked by constructor ordering. It isn't: the firmware is built at the top of `BlackholeTTDevice`'s constructor and computes its own answer, so it never needs `TTDevice` to have answered first.

## List of the changes

- `TTDevice::get_noc_translation_enabled()` delegates instead of being pure virtual.
- Three overrides deleted.

## Testing

Simulation on and off; `baremetal_tests` 254/254.

## API Changes

`TTDevice::get_noc_translation_enabled()` is no longer virtual. Behaviour unchanged.
