### PR TITLE
Disable bh loudbox on merge queue

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -154,6 +154,7 @@ jobs:
         # - P300-viommu is a shared pool of 3 P300 machines.
         # - bh-loudbox is a single machine in CIv2. It also has an additional problem where
         #   it actually has a ~20min startup time for viommu variant, so this one can be really slow.
+        #   It recently became congested, so it is blacklisted from merge queue for now, but will still run on main.
         # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.
         # - 6u is a single machine and the main merge queue bottleneck, so in the merge queue it
         #   runs on one build type only. Release is dropped because the PR gate already covers it,
@@ -168,9 +169,7 @@ jobs:
         run: |
           ENTRIES=$(jq -cn '$ARGS.positional' --args \
             'pull_request|*|tt-ubuntu-2204-bh-loudbox-*' \
-            'merge_group|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
-            'merge_group|ASan|tt-ubuntu-2204-bh-loudbox-stable' \
-            'merge_group|TSan|tt-ubuntu-2204-bh-loudbox-stable' \
+            'merge_group|*|tt-ubuntu-2204-bh-loudbox-*' \
             'pull_request|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'merge_group|Release|6u' \


### PR DESCRIPTION
### Issue
No issue

### Description
BH- Loudbox resources are in a bad state, and this is bottlenecking our development.
Note that this will still run on main, so we can still have a signal if it fails but on main branch, give we triage all our failures. 

### List of the changes
- Blacklist bh-loudbox for merge-queue

### Testing
No testing

### API Changes
This PR has no API changes.
