### PR TITLE
Enable TestDmaMulticastWrite on Blackhole

### DIFF
--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -244,15 +244,11 @@ TEST_P(TestDeviceIOFixture, DynamicTLB_RW) {
 TEST_F(TestDeviceIOFixture, TestDmaMulticastWrite) {
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "DMA multicast write is not supported on Blackhole architecture.";
-    }
-
     if (is_simulation_test()) {
         GTEST_SKIP() << "DMA multicast write is not supported in simulation.";
     }
 
-    const tt_xy_pair grid_size = {8, 8};
+    const tt_xy_pair grid_size = cluster->get_soc_descriptor(0).get_grid_size(CoreType::TENSIX);
 
     const CoreCoord start_tensix = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
     const CoreCoord end_tensix = CoreCoord(grid_size.x - 1, grid_size.y - 1, CoreType::TENSIX, CoordSystem::LOGICAL);


### PR DESCRIPTION
### Issue
N/A

### Description
`TestDeviceIOFixture.TestDmaMulticastWrite` has been skipped on Blackhole since it was added, with no reason recorded. It is the only test that calls `dma_multicast_write`, so `PcieProtocol::dma_multicast_write` and the `mcast = true` TLB config it builds have never been executed on Blackhole by any test.

Nothing architecture-specific is blocking that path: `create_dma_strategy` returns `BlackholeDmaTransfer`, `blackhole_implementation.hpp` defines the TLB `mcast` bit, and unicast DMA is already exercised on Blackhole by `TestDeviceIO.DMA1`. The skip is removed.

The hardcoded 8x8 multicast rectangle was Wormhole's harvested tensix grid; on Blackhole it would have covered only a corner of the grid. It now comes from the SoC descriptor, so the test spans the full tensix grid of whichever chip it runs on.

### List of the changes
- Removed the Blackhole `GTEST_SKIP` from `TestDeviceIOFixture.TestDmaMulticastWrite`.
- Derived the multicast rectangle from `get_soc_descriptor(0).get_grid_size(CoreType::TENSIX)` instead of a hardcoded 8x8.

### Testing
CI

### API Changes
This PR has no API changes.