### PR TITLE
[Base API] Delegate get_firmware_noc_coord to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -58,7 +58,6 @@ protected:
     // Number of retrain attempts is chosen based on syseng team testing.
     uint32_t get_max_dram_retrain_attempts() const override { return 3; }
 
-    void set_arc_coordinate() override;
 
     void probe_arc() override;
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -56,7 +56,6 @@ protected:
     // Number of retrain attempts is chosen based on syseng team testing.
     uint32_t get_max_dram_retrain_attempts() const override { return 3; }
 
-
     void probe_arc() override;
 
 private:

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -559,10 +559,8 @@ protected:
 
     void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
 
-
     void construct_soc_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     void set_soc_descriptor(const SocDescriptor &soc_descriptor);
-
 
     // TODO: temporary. The register to probe is architecture specific, so only the concrete devices
     // can implement it. Goes away once DeviceFirmware::init_firmware owns ARC startup.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -110,7 +110,7 @@ public:
     RemoteCommunication *get_remote_communication();
 
     DeviceProtocol *get_device_protocol();
-    DeviceFirmware *get_device_firmware();
+    DeviceFirmware *get_device_firmware() const;
     PcieInterface *get_pcie_interface();
     JtagInterface *get_jtag_interface();
     RemoteInterface *get_remote_interface();
@@ -533,13 +533,10 @@ protected:
 
     void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
 
-    xy_pair arc_core_noc0;
-    xy_pair arc_core_noc1;
 
     void construct_soc_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     void set_soc_descriptor(const SocDescriptor &soc_descriptor);
 
-    virtual void set_arc_coordinate() {}
 
     // TODO: temporary. The register to probe is architecture specific, so only the concrete devices
     // can implement it. Goes away once DeviceFirmware::init_firmware owns ARC startup.

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -52,7 +52,6 @@ protected:
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 
-    void set_arc_coordinate() override;
 
     void probe_arc() override;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -50,7 +50,6 @@ protected:
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 
-
     void probe_arc() override;
 
 private:

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -44,7 +44,6 @@ namespace tt::umd {
 BlackholeTTDevice::BlackholeTTDevice(
     std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     TTDevice(std::move(model), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
-    BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));
 }
@@ -231,11 +230,6 @@ void BlackholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
             error::RuntimeError,
             fmt::format("Failed to retrain DRAM core {} with exit code {}.", dram_channel, ret_code));
     }
-}
-
-void BlackholeTTDevice::set_arc_coordinate() {
-    arc_core_noc0 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/false);
-    arc_core_noc1 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/true);
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -116,7 +116,7 @@ std::unique_ptr<DeviceFirmware> TTDevice::create_device_firmware() {
     }
 }
 
-DeviceFirmware *TTDevice::get_device_firmware() {
+DeviceFirmware *TTDevice::get_device_firmware() const {
     if (device_firmware_ == nullptr) {
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
@@ -608,10 +608,10 @@ void TTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs
     set_risc_reset_state(core, soft_reset_new_with_staggered_start);
 }
 
-tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
+tt_xy_pair TTDevice::get_arc_core() const { return get_arc_core(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0); }
 
 tt_xy_pair TTDevice::get_arc_core(const NocId noc_id) const {
-    return noc_id == NocId::NOC1 ? arc_core_noc1 : arc_core_noc0;
+    return get_device_firmware()->get_firmware_noc_coord(noc_id);
 }
 
 void TTDevice::noc_multicast_write(

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -43,7 +43,6 @@ namespace tt::umd {
 WormholeTTDevice::WormholeTTDevice(
     std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     TTDevice(std::move(model), std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
-    WormholeTTDevice::set_arc_coordinate();
     // A remote device has no protocol of its own to probe; its liveness is that of the local device
     // it is reached through.
     DeviceProtocol *hang_check_protocol =
@@ -254,13 +253,6 @@ void WormholeTTDevice::probe_arc() {
 
 void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported on WormholeTTDevice.");
-}
-
-void WormholeTTDevice::set_arc_coordinate() {
-    arc_core_noc0 = wormhole::ARC_CORES_NOC0[0];
-    arc_core_noc1 = tt_xy_pair(
-        wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
-        wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
## Issue

`TTDevice` cached the ARC core coordinate in `arc_core_noc0`/`arc_core_noc1`, filled by a `set_arc_coordinate()` hook each architecture overrode — duplicating what the firmware already computes.

## Description

The cache and the hook go; `get_arc_core()` forwards to `get_firmware_noc_coord()`, which is the same selection over the firmware's own members.

The coordinates themselves are computed the same way, just in the firmware's constructor: Blackhole calls `blackhole::get_arc_core(...)` exactly as `set_arc_coordinate()` did, Wormhole uses the same fixed constants.

Scoped as hard because of ~20 callers, but most were other classes' own `get_arc_core()` — `ArcTelemetryReader` and `BlackholeArcMessageQueue` each compute their own.

## List of the changes

- Both `get_arc_core()` overloads delegate.
- Deleted: `arc_core_noc0`/`arc_core_noc1`, virtual `set_arc_coordinate()` and both overrides.
- `get_device_firmware()` is now `const`.

## Testing

Simulation on and off; `baremetal_tests` 254/254.

## API Changes

`TTDevice::set_arc_coordinate()` removed. `get_device_firmware()` is now `const`.
