### PR TITLE
[base API] Answer arch and communication id from TTDeviceModel components

### DIFF
--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -33,10 +33,6 @@ public:
 
     ~BlackholeTTDeviceModel() override;
 
-    tt::ARCH get_arch() const override;
-
-    int get_communication_device_id() const override;
-
     DeviceProtocol *get_device_protocol() override;
 
     DeviceFirmware *get_device_firmware() override;
@@ -64,7 +60,6 @@ public:
     PCIDevice *get_pci_device() override;
 
 private:
-    int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "umd/device/tt_device_model/tt_device_model.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 class SimulationDeviceFirmware;
@@ -22,10 +23,6 @@ public:
 
     ~SimulationTTDeviceModel() override;
 
-    tt::ARCH get_arch() const override;
-
-    int get_communication_device_id() const override;
-
     DeviceProtocol *get_device_protocol() override;
 
     DeviceFirmware *get_device_firmware() override;
@@ -37,7 +34,6 @@ public:
     std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
 
 private:
-    tt::ARCH arch_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
     std::unique_ptr<SimulationDeviceFirmware> device_firmware_;
 };

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
-#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 class DeviceFirmware;
@@ -43,16 +42,6 @@ class SocArchDescriptor;
 class TTDeviceModel {
 public:
     virtual ~TTDeviceModel() = default;
-
-    // TODO: temporary - not part of the Base API. Answered by
-    // get_architecture_impl()->get_architecture() once ArchitectureImplementation moves here.
-    virtual tt::ARCH get_arch() const = 0;
-
-    // Identifies the device within its transport: the PCI device number for PCIe, the JLink id for
-    // JTAG. A remote device reports the identity of the local device it is reached through.
-    // TODO: temporary - not part of the Base API. Answered by get_device_protocol()->get_mmio_id()
-    // once DeviceProtocol moves here.
-    virtual int get_communication_device_id() const = 0;
 
     // Required components.
     virtual DeviceProtocol *get_device_protocol() = 0;

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -36,10 +36,6 @@ public:
 
     ~WormholeTTDeviceModel() override;
 
-    tt::ARCH get_arch() const override;
-
-    int get_communication_device_id() const override;
-
     DeviceProtocol *get_device_protocol() override;
 
     DeviceFirmware *get_device_firmware() override;
@@ -67,7 +63,6 @@ public:
     PCIDevice *get_pci_device() override;
 
 private:
-    int communication_device_id_;
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -83,9 +83,10 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         is_pcie_hung();
     }
     // The hang detector is an optional component, so a model that provides none simply skips the check.
-    HangDetector *hang_detector = model_->get_hang_detector();
+    // Going through is_noc_hung() rather than the detector directly picks up its warning for a
+    // protocol that cannot run the check at all.
     const NocId hang_check_noc = is_selected_noc1() ? NocId::NOC1 : NocId::NOC0;
-    if (hang_detector != nullptr && hang_detector->is_noc_hung(hang_check_noc).value_or(false)) {
+    if (model_->get_hang_detector() != nullptr && is_noc_hung(hang_check_noc, HangAction::RETURN)) {
         UMD_THROW(error::NocHangError, *this, hang_check_noc);
     }
     // Waits for the firmware and builds the components that read what it publishes; the model's

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -22,6 +22,7 @@
 #include "tracy.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -33,6 +34,7 @@
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/dma_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
@@ -254,7 +256,7 @@ RemoteInterface *TTDevice::get_remote_interface() {
     return remote_interface;
 }
 
-tt::ARCH TTDevice::get_arch() const { return model_->get_arch(); }
+tt::ARCH TTDevice::get_arch() const { return model_->get_architecture_impl()->get_architecture(); }
 
 bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action) {
     HangDetector *hang_detector = model_->get_hang_detector();
@@ -494,7 +496,12 @@ void TTDevice::wait_for_non_mmio_flush() {
 
 bool TTDevice::is_remote() { return model_->get_remote_interface() != nullptr; }
 
-int TTDevice::get_communication_device_id() const { return model_->get_communication_device_id(); }
+// A simulation model reaches its device in-process, so it has no protocol and no communication
+// device to be addressed within.
+int TTDevice::get_communication_device_id() const {
+    DeviceProtocol *device_protocol = model_->get_device_protocol();
+    return device_protocol != nullptr ? device_protocol->get_mmio_id() : -1;
+}
 
 // Derived from the transport the device actually has, rather than stored: exactly one of these
 // interfaces is present, and a remote device reports the transport of the local device it is

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -37,7 +37,6 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    communication_device_id_(pci_device->get_device_num()),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
     architecture_impl_(std::make_unique<BlackholeImplementation>()),
     pci_device_(pci_device.get()) {
@@ -59,7 +58,6 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     std::unique_ptr<JtagDevice> jtag_device,
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    communication_device_id_(jlink_id),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
     architecture_impl_(std::make_unique<BlackholeImplementation>()) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
@@ -75,10 +73,6 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.
 BlackholeTTDeviceModel::~BlackholeTTDeviceModel() = default;
-
-tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; }
-
-int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
 

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -10,19 +10,12 @@
 namespace tt::umd {
 
 SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
-    arch_(arch),
     architecture_impl_(ArchitectureImplementation::create(arch)),
     device_firmware_(std::make_unique<SimulationDeviceFirmware>(arch)) {}
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.
 SimulationTTDeviceModel::~SimulationTTDeviceModel() = default;
-
-tt::ARCH SimulationTTDeviceModel::get_arch() const { return arch_; }
-
-// A simulation backend has no host transport to be addressed within, so it reports no communication
-// device at all.
-int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 
 // A simulation backend reaches its device directly rather than over a transport protocol; the
 // simulation TTDevice overrides the read/write paths instead of routing them through one.

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -25,7 +25,6 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    communication_device_id_(pci_device->get_device_num()),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
     architecture_impl_(std::make_unique<WormholeImplementation>()),
     pci_device_(pci_device.get()) {
@@ -46,7 +45,6 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<JtagDevice> jtag_device,
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    communication_device_id_(jlink_id),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
     architecture_impl_(std::make_unique<WormholeImplementation>()) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
@@ -58,11 +56,9 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
         protocol_.get(), pcie_interface_, jtag_interface_, remote_interface_, architecture_impl_.get());
 }
 
-// A remote device is reached through a local one, so it takes the local device's identity.
 WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<RemoteCommunication> remote_communication,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
     soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
     architecture_impl_(std::make_unique<WormholeImplementation>()) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
@@ -78,10 +74,6 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.
 WormholeTTDeviceModel::~WormholeTTDeviceModel() = default;
-
-tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0; }
-
-int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
 


### PR DESCRIPTION
### Issue
Related to #2864

### Description
TTDeviceModel carried get_arch() and get_communication_device_id() as temporary getters,
each with a TODO saying it would be answered by a real component once that component moved
into the model. Both components are now there, so the getters go away and TTDevice asks the
components directly.

Note that get_communication_device_id() changes when it resolves, not what it returns. The
models captured the id at construction; RemoteProtocol::get_mmio_id() reaches through to the
local device on every call instead. That is the same reach-through that caused the teardown
segfault on #3236: the local device now has to outlive every remote device routed through it.
Taken deliberately, to keep identity in one place rather than copied into each model.

### List of the changes
- Drop get_arch() and get_communication_device_id() from TTDeviceModel and its three models,
  along with the now-unused communication_device_id_ and arch_ members.
- TTDevice::get_arch() delegates to get_architecture_impl()->get_architecture().
- TTDevice::get_communication_device_id() delegates to get_device_protocol()->get_mmio_id(),
  guarding the null protocol a simulation model reports.

### Testing
Existing CI. No behavioural change for PCIe and JTAG: PcieProtocol::get_mmio_id() returns the
same PCI device number the models captured, and JtagProtocol::get_mmio_id() the same JLink id.

### API Changes
This PR has API changes: two getters are removed from the TTDeviceModel interface. They were
never part of the Base API spec.
