### PR TITLE
[Base API] Allow UninitializedDeviceError without a TTDevice

### DIFF
--- a/device/api/umd/device/tt_device/tt_device_error.hpp
+++ b/device/api/umd/device/tt_device/tt_device_error.hpp
@@ -25,6 +25,9 @@ struct TTDeviceData {
     TTDeviceData() = default;
     TTDeviceData(const TTDevice& tt_device, std::optional<uint64_t> discovery_unique_id = std::nullopt);
 
+    // For components that report a device-scoped error without holding a TTDevice.
+    TTDeviceData(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch);
+
     IODeviceType io_device_type = IODeviceType::UNDEFINED;
     ChipId chip_id = 0;
     tt::ARCH arch = tt::ARCH::Invalid;
@@ -101,6 +104,10 @@ struct PcieHangError : UmdError<PcieHangData> {
 
 struct UninitializedDeviceError : UmdError<TTDeviceData> {
     UninitializedDeviceError(const TTDevice& tt_device);
+
+    // For components that report the same condition without holding a TTDevice -- DeviceFirmware
+    // takes protocol interfaces, not a device, so it supplies the identity fields itself.
+    UninitializedDeviceError(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch);
 };
 
 struct UnresolvableCoordinateError : UmdError<DeviceCoreData> {

--- a/device/api/umd/device/tt_device/tt_device_error.hpp
+++ b/device/api/umd/device/tt_device/tt_device_error.hpp
@@ -100,6 +100,9 @@ struct PcieHangData : TTDeviceData {
 
 struct PcieHangError : UmdError<PcieHangData> {
     PcieHangError(const TTDevice& tt_device, uint32_t data_read);
+
+    // For components that report the same condition without holding a TTDevice.
+    PcieHangError(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch, uint32_t data_read);
 };
 
 struct UninitializedDeviceError : UmdError<TTDeviceData> {

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -113,12 +113,20 @@ FirmwareStartupError::FirmwareStartupError(
     message().append(fmt::format(" (Timed out after {} ms)", timeout.count()));
 }
 
+TTDeviceData::TTDeviceData(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch) :
+    io_device_type(io_device_type), chip_id(chip_id), arch(arch) {}
+
 UninitializedDeviceError::UninitializedDeviceError(const TTDevice& tt_device) :
     UmdError<TTDeviceData>(
         fmt::format(
             "This method cannot be called before initializing TTDevice. Device ID: {}",
             tt_device.get_communication_device_id()),
         tt_device) {}
+
+UninitializedDeviceError::UninitializedDeviceError(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch) :
+    UmdError<TTDeviceData>(
+        fmt::format("This method cannot be called before initializing TTDevice. Device ID: {}", chip_id),
+        TTDeviceData(io_device_type, chip_id, arch)) {}
 
 UnresolvableCoordinateError::UnresolvableCoordinateError(const TTDevice& tt_device, CoreCoord core, NocId noc) :
     UmdError<DeviceCoreData>(

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -116,6 +116,11 @@ FirmwareStartupError::FirmwareStartupError(
 TTDeviceData::TTDeviceData(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch) :
     io_device_type(io_device_type), chip_id(chip_id), arch(arch) {}
 
+PcieHangError::PcieHangError(IODeviceType io_device_type, ChipId chip_id, tt::ARCH arch, uint32_t data_read) :
+    UmdError<PcieHangData>(
+        fmt::format("Read {:#x} over PCIe ID {}: the board should be reset.", data_read, chip_id),
+        {TTDeviceData(io_device_type, chip_id, arch), data_read}) {}
+
 UninitializedDeviceError::UninitializedDeviceError(const TTDevice& tt_device) :
     UmdError<TTDeviceData>(
         fmt::format(


### PR DESCRIPTION
## Issue


#2872
`UninitializedDeviceError` can only be constructed from a `const TTDevice&`. Components that take protocol interfaces rather than a device — `DeviceFirmware` and anything following it — cannot report the condition they are best placed to detect, so they throw a plain `RuntimeError` and callers see a different error type than the API promises.

## Description

`TTDeviceData` gains a constructor taking the three fields it actually uses, and `UninitializedDeviceError` an overload built from them. Existing callers are untouched.

Split out of the delegation stack because it is a change to the error API, not to any one device method.

## List of the changes

- `TTDeviceData(IODeviceType, ChipId, tt::ARCH)`.
- `UninitializedDeviceError(IODeviceType, ChipId, tt::ARCH)`.

## Testing

Simulation on and off; `baremetal_tests` 254/254. No behaviour change — nothing calls the new overload yet.

## API Changes

Two added constructors. Nothing removed or altered.

Stacked on #3291.

