### PR TITLE
[Base API] Add the DeviceFirmware seam

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -103,6 +103,8 @@ target_sources(
         tt_device/hang_detection/wormhole_hang_detector.cpp
         tt_device/hang_detection/blackhole_hang_detector.cpp
         tt_device/firmware/blackhole_arc_apb.cpp
+        tt_device/firmware/blackhole_device_firmware.cpp
+        tt_device/firmware/wormhole_device_firmware.cpp
         tt_device/protocol/pcie_protocol.cpp
         tt_device/protocol/jtag_protocol.cpp
         tt_device/protocol/remote_protocol.cpp
@@ -263,6 +265,10 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
                 api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
                 api/umd/device/tt_device/firmware/blackhole_arc_apb.hpp
+                api/umd/device/tt_device/firmware/device_firmware.hpp
+                api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+                api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+                api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
                 api/umd/device/tt_device/remote_communication.hpp
                 api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
                 api/umd/device/tt_device/ethernet_broadcast.hpp

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
+
+namespace tt::umd {
+
+class ArchitectureImplementation;
+class DeviceProtocol;
+class JtagInterface;
+class PcieInterface;
+
+/**
+ * @brief Blackhole implementation of DeviceFirmware.
+ *
+ * Built from protocol interfaces: the device protocol it issues NOC accesses through, exactly one of
+ * the optional PCIe/JTAG transports (which one is present is how routes are picked), and the
+ * architecture implementation for register layout. All non-owning; they belong to the object that
+ * owns this one and must outlive it.
+ */
+class BlackholeDeviceFirmware : public DeviceFirmware {
+public:
+    BlackholeDeviceFirmware(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        ArchitectureImplementation* architecture_impl);
+
+private:
+    DeviceProtocol* device_protocol_ = nullptr;
+    PcieInterface* pcie_interface_ = nullptr;
+    JtagInterface* jtag_interface_ = nullptr;
+    ArchitectureImplementation* architecture_impl_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::umd {
+
+/**
+ * @brief Interface to the device's management firmware.
+ *
+ * Owns the interaction with the firmware running on the device's management processor: waiting for
+ * it to boot, issuing commands, and reading the state it publishes. TTDevice holds one and forwards
+ * the firmware-backed parts of its API here; the implementations are built from protocol interfaces
+ * rather than a TTDevice, so they carry no dependency on the facade.
+ *
+ * The interface starts empty on purpose. Each capability is added together with the TTDevice code
+ * it replaces, so every addition is reviewable as a move.
+ */
+class DeviceFirmware {
+public:
+    virtual ~DeviceFirmware() = default;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief Simulation implementation of DeviceFirmware.
+ *
+ * Simulators run no management firmware, so as the interface grows this implements each operation
+ * as the appropriate no-op. Backends that need to differ get their own subclass when that need
+ * arrives, not before.
+ */
+class SimulationDeviceFirmware : public DeviceFirmware {};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
+
+namespace tt::umd {
+
+class ArchitectureImplementation;
+class DeviceProtocol;
+class JtagInterface;
+class PcieInterface;
+class RemoteInterface;
+
+/**
+ * @brief Wormhole implementation of DeviceFirmware.
+ *
+ * Built from protocol interfaces: the device protocol it issues NOC accesses through, exactly one of
+ * the optional PCIe/JTAG/remote transports (which one is present is how routes are picked), and the
+ * architecture implementation for register layout. All non-owning; they belong to the object that
+ * owns this one and must outlive it.
+ */
+class WormholeDeviceFirmware : public DeviceFirmware {
+public:
+    WormholeDeviceFirmware(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface,
+        ArchitectureImplementation* architecture_impl);
+
+private:
+    DeviceProtocol* device_protocol_ = nullptr;
+    PcieInterface* pcie_interface_ = nullptr;
+    JtagInterface* jtag_interface_ = nullptr;
+    RemoteInterface* remote_interface_ = nullptr;
+    ArchitectureImplementation* architecture_impl_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -9,6 +9,7 @@
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
+class BlackholeDeviceFirmware;
 
 class ArchitectureImplementation;
 class HangDetector;
@@ -37,6 +38,8 @@ public:
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    DeviceFirmware *get_device_firmware() override;
 
     ArchitectureImplementation *get_architecture_impl() override;
 
@@ -72,6 +75,9 @@ private:
     // Must come after pci_device_: the detector holds a TLB window wired in by TTDevice, which needs
     // the protocol's PCIDevice alive when it is released.
     std::unique_ptr<HangDetector> hang_detector_;
+
+    // Declared after the transports: it borrows them, so it must be destroyed first.
+    std::unique_ptr<BlackholeDeviceFirmware> device_firmware_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -9,6 +9,7 @@
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
+class SimulationDeviceFirmware;
 
 // Model for a simulated device. A simulation backend is reached in-process rather than over a host
 // transport, and takes its architecture from the SoC descriptor it is built with rather than from a
@@ -27,6 +28,8 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    DeviceFirmware *get_device_firmware() override;
+
     ArchitectureImplementation *get_architecture_impl() override;
 
     SocArchDescriptor *get_soc_arch_descriptor() override;
@@ -36,6 +39,7 @@ public:
 private:
     tt::ARCH arch_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
+    std::unique_ptr<SimulationDeviceFirmware> device_firmware_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -10,6 +10,7 @@
 #include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
+class DeviceFirmware;
 
 class ArchitectureImplementation;
 class DmaInterface;
@@ -54,6 +55,14 @@ public:
 
     // Required components.
     virtual DeviceProtocol *get_device_protocol() = 0;
+
+    /**
+     * @brief The device's management firmware component.
+     *
+     * Created and owned by the concrete model, like every other component: the model knows its
+     * architecture and backend statically, so no dispatch is involved in picking the implementation.
+     */
+    virtual DeviceFirmware *get_device_firmware() = 0;
 
     virtual ArchitectureImplementation *get_architecture_impl() = 0;
 

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -9,6 +9,7 @@
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
+class WormholeDeviceFirmware;
 
 class ArchitectureImplementation;
 class HangDetector;
@@ -40,6 +41,8 @@ public:
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    DeviceFirmware *get_device_firmware() override;
 
     ArchitectureImplementation *get_architecture_impl() override;
 
@@ -75,6 +78,9 @@ private:
     // Must come after pci_device_: the detector holds a TLB window wired in by TTDevice, which needs
     // the protocol's PCIDevice alive when it is released.
     std::unique_ptr<HangDetector> hang_detector_;
+
+    // Declared after the transports: it borrows them, so it must be destroyed first.
+    std::unique_ptr<WormholeDeviceFirmware> device_firmware_;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
+
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
+#include "umd/device/tt_device/protocol/jtag_interface.hpp"
+#include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+BlackholeDeviceFirmware::BlackholeDeviceFirmware(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    ArchitectureImplementation* architecture_impl) :
+    device_protocol_(device_protocol),
+    pcie_interface_(pcie_interface),
+    jtag_interface_(jtag_interface),
+    architecture_impl_(architecture_impl) {
+    UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "BlackholeDeviceFirmware requires a DeviceProtocol.");
+    UMD_ASSERT(
+        architecture_impl_ != nullptr,
+        error::RuntimeError,
+        "BlackholeDeviceFirmware requires an ArchitectureImplementation.");
+    UMD_ASSERT(
+        (pcie_interface_ != nullptr) != (jtag_interface_ != nullptr),
+        error::RuntimeError,
+        "BlackholeDeviceFirmware requires exactly one of a PcieInterface or a JtagInterface, since which one is "
+        "present is how it picks the route for an access.");
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/firmware/wormhole_device_firmware.hpp"
+
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
+#include "umd/device/tt_device/protocol/jtag_interface.hpp"
+#include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+WormholeDeviceFirmware::WormholeDeviceFirmware(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface,
+    ArchitectureImplementation* architecture_impl) :
+    device_protocol_(device_protocol),
+    pcie_interface_(pcie_interface),
+    jtag_interface_(jtag_interface),
+    remote_interface_(remote_interface),
+    architecture_impl_(architecture_impl) {
+    UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "WormholeDeviceFirmware requires a DeviceProtocol.");
+    UMD_ASSERT(
+        architecture_impl_ != nullptr,
+        error::RuntimeError,
+        "WormholeDeviceFirmware requires an ArchitectureImplementation.");
+    const int transports = (pcie_interface_ != nullptr) + (jtag_interface_ != nullptr) + (remote_interface_ != nullptr);
+    UMD_ASSERT(
+        transports == 1,
+        error::RuntimeError,
+        "WormholeDeviceFirmware requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
+        "which one is present is how it picks the route for an access.");
+}
+
+}  // namespace tt::umd

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -11,6 +11,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
@@ -49,6 +50,9 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     if (use_safe_api) {
         SiliconTlbWindow::set_sigbus_safe_handler(true);
     }
+
+    device_firmware_ = std::make_unique<BlackholeDeviceFirmware>(
+        protocol_.get(), pcie_interface_, jtag_interface_, architecture_impl_.get());
 }
 
 BlackholeTTDeviceModel::BlackholeTTDeviceModel(
@@ -63,6 +67,9 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     protocol_ = std::move(jtag_protocol);
     hang_detector_ = std::make_unique<BlackholeHangDetector>(
         protocol_.get(), read_noc_translation_enabled(/*pcie_interface=*/nullptr, jtag_interface_));
+
+    device_firmware_ = std::make_unique<BlackholeDeviceFirmware>(
+        protocol_.get(), pcie_interface_, jtag_interface_, architecture_impl_.get());
 }
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
@@ -74,6 +81,8 @@ tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; 
 int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+DeviceFirmware *BlackholeTTDeviceModel::get_device_firmware() { return device_firmware_.get(); }
 
 SocArchDescriptor *BlackholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
 

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -5,11 +5,14 @@
 #include "umd/device/tt_device_model/simulation_tt_device_model.hpp"
 
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/tt_device/firmware/simulation_device_firmware.hpp"
 
 namespace tt::umd {
 
 SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
-    arch_(arch), architecture_impl_(ArchitectureImplementation::create(arch)) {}
+    arch_(arch),
+    architecture_impl_(ArchitectureImplementation::create(arch)),
+    device_firmware_(std::make_unique<SimulationDeviceFirmware>()) {}
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.
@@ -24,6 +27,8 @@ int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 // A simulation backend reaches its device directly rather than over a transport protocol; the
 // simulation TTDevice overrides the read/write paths instead of routing them through one.
 DeviceProtocol *SimulationTTDeviceModel::get_device_protocol() { return nullptr; }
+
+DeviceFirmware *SimulationTTDeviceModel::get_device_firmware() { return device_firmware_.get(); }
 
 ArchitectureImplementation *SimulationTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }
 

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -11,6 +11,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/firmware/wormhole_device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
@@ -36,6 +37,9 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     if (use_safe_api) {
         SiliconTlbWindow::set_sigbus_safe_handler(true);
     }
+
+    device_firmware_ = std::make_unique<WormholeDeviceFirmware>(
+        protocol_.get(), pcie_interface_, jtag_interface_, remote_interface_, architecture_impl_.get());
 }
 
 WormholeTTDeviceModel::WormholeTTDeviceModel(
@@ -49,6 +53,9 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
     hang_detector_ = std::make_unique<WormholeHangDetector>(protocol_.get());
+
+    device_firmware_ = std::make_unique<WormholeDeviceFirmware>(
+        protocol_.get(), pcie_interface_, jtag_interface_, remote_interface_, architecture_impl_.get());
 }
 
 // A remote device is reached through a local one, so it takes the local device's identity.
@@ -63,6 +70,9 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     protocol_ = std::move(remote_protocol);
     hang_detector_ = std::make_unique<WormholeHangDetector>(
         remote_interface_->get_remote_communication()->get_local_device()->get_device_protocol());
+
+    device_firmware_ = std::make_unique<WormholeDeviceFirmware>(
+        protocol_.get(), pcie_interface_, jtag_interface_, remote_interface_, architecture_impl_.get());
 }
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
@@ -74,6 +84,8 @@ tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0;
 int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+DeviceFirmware *WormholeTTDeviceModel::get_device_firmware() { return device_firmware_.get(); }
 
 SocArchDescriptor *WormholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
 


### PR DESCRIPTION
## Issue


#2872
The `DeviceFirmware` implementations were removed in #3317 to be re-landed one function at a time. Something has to exist for the first function to land into.

## Description

The seam, and nothing else: an interface with no methods, concrete classes that hold and validate their dependencies, and ownership in the right place.

Per the spec, the firmware is a component of `TTDeviceModel` — each concrete model creates and owns its own implementation, exactly like the protocol and the architecture implementation. The model knows its architecture and backend statically, so no dispatch picks the implementation, which rules out the virtual-call-in-constructor trap by construction (the bug that segfaulted ttsim in the previous attempt).

Every subsequent PR adds one method here together with the `TTDevice` code it deletes, so each is reviewable as a move.

## List of the changes

- `DeviceFirmware` (empty interface), `BlackholeDeviceFirmware`, `WormholeDeviceFirmware`, `SimulationDeviceFirmware` (shared by all sim backends until one needs to differ).
- `TTDeviceModel::get_device_firmware()`; each concrete model constructs and owns its firmware.
- Constructors validate every dependency before use.

## Testing

Simulation on and off; `baremetal_tests` 238/238; no undefined symbols. Behaviour cannot change — nothing calls any of it yet.

## API Changes

- `TTDeviceModel::get_device_firmware()` added (pure virtual).

Stacked on #3317.

