### PR TITLE
[Base API] Move firmware component ownership into DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 #include "umd/device/tt_device/firmware/blackhole_arc_apb.hpp"
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
@@ -18,6 +19,8 @@ namespace tt::umd {
 
 class ArchitectureImplementation;
 class DeviceProtocol;
+class FirmwareInfoProvider;
+class FirmwareTelemetryReader;
 class JtagInterface;
 class PcieInterface;
 
@@ -37,15 +40,39 @@ public:
         JtagInterface* jtag_interface,
         ArchitectureImplementation* architecture_impl);
 
+    // Defined in the .cpp, where the owned components' types are complete.
+    ~BlackholeDeviceFirmware() override;
+
     void init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id = NocId::DEFAULT_NOC) override;
+
+    /**
+     * @brief Telemetry published by the management firmware.
+     *
+     * Owned here: it reads state the firmware publishes, so it cannot exist until init_firmware()
+     * has brought the firmware up. Deliberately a concrete-class getter rather than part of
+     * DeviceFirmware: the concrete model lends it onward, and the facade turns a null into
+     * UninitializedDeviceError carrying the device's identity.
+     *
+     * @return The reader, or nullptr until init_firmware() has run.
+     */
+    FirmwareTelemetryReader* get_firmware_telemetry_reader() const;
+
+    /**
+     * @brief Firmware-reported device information. Owned and lent the same way as the telemetry
+     * reader.
+     *
+     * @return The provider, or nullptr until init_firmware() has run.
+     */
+    FirmwareInfoProvider* get_firmware_info_provider() const;
 
 private:
     /**
      * @brief Blocks until the management firmware reports it has booted.
      *
-     * Kept as its own step because init_firmware() has a second job arriving: building the
-     * components that read what the firmware publishes, which lands next to this call rather than
-     * around it.
+     * Kept as its own step because init_firmware() has a second job - building the components
+     * that read what the firmware publishes - and callers such as warm reset only want this first
+     * one. Once the two become separate API calls, init_firmware()'s idempotence guard goes away
+     * with them.
      *
      * @param timeout_ms How long to wait for the firmware to report ready.
      * @param noc_id NOC to route the status reads over.
@@ -83,6 +110,12 @@ private:
     tt_xy_pair arc_core_noc1_;
 
     BlackholeArcApb arc_apb_;
+
+    // Created by init_firmware(), not the constructor: they read state the firmware publishes, so
+    // this is the earliest they can exist. The info provider holds a raw pointer to the telemetry
+    // reader, so it is declared after it and destroyed first.
+    std::unique_ptr<FirmwareTelemetryReader> firmware_telemetry_reader_;
+    std::unique_ptr<FirmwareInfoProvider> firmware_info_provider_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
@@ -18,6 +19,8 @@ namespace tt::umd {
 
 class ArchitectureImplementation;
 class DeviceProtocol;
+class FirmwareInfoProvider;
+class FirmwareTelemetryReader;
 class JtagInterface;
 class PcieInterface;
 class RemoteInterface;
@@ -39,15 +42,39 @@ public:
         RemoteInterface* remote_interface,
         ArchitectureImplementation* architecture_impl);
 
+    // Defined in the .cpp, where the owned components' types are complete.
+    ~WormholeDeviceFirmware() override;
+
     void init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id = NocId::DEFAULT_NOC) override;
+
+    /**
+     * @brief Telemetry published by the management firmware.
+     *
+     * Owned here: it reads state the firmware publishes, so it cannot exist until init_firmware()
+     * has brought the firmware up. Deliberately a concrete-class getter rather than part of
+     * DeviceFirmware: the concrete model lends it onward, and the facade turns a null into
+     * UninitializedDeviceError carrying the device's identity.
+     *
+     * @return The reader, or nullptr until init_firmware() has run.
+     */
+    FirmwareTelemetryReader* get_firmware_telemetry_reader() const;
+
+    /**
+     * @brief Firmware-reported device information. Owned and lent the same way as the telemetry
+     * reader.
+     *
+     * @return The provider, or nullptr until init_firmware() has run.
+     */
+    FirmwareInfoProvider* get_firmware_info_provider() const;
 
 private:
     /**
      * @brief Blocks until the management firmware reports it has booted.
      *
-     * Kept as its own step because init_firmware() has a second job arriving: building the
-     * components that read what the firmware publishes, which lands next to this call rather than
-     * around it.
+     * Kept as its own step because init_firmware() has a second job - building the components
+     * that read what the firmware publishes - and callers such as warm reset only want this first
+     * one. Once the two become separate API calls, init_firmware()'s idempotence guard goes away
+     * with them.
      *
      * @param timeout_ms How long to wait for the firmware to report ready.
      * @param noc_id NOC to route the status reads over.
@@ -83,6 +110,12 @@ private:
 
     WormholeArcWindow arc_apb_;
     WormholeArcWindow arc_csm_;
+
+    // Created by init_firmware(), not the constructor: they read state the firmware publishes, so
+    // this is the earliest they can exist. The info provider holds a raw pointer to the telemetry
+    // reader, so it is declared after it and destroyed first.
+    std::unique_ptr<FirmwareTelemetryReader> firmware_telemetry_reader_;
+    std::unique_ptr<FirmwareInfoProvider> firmware_info_provider_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -565,8 +565,6 @@ private:
     std::unique_ptr<TTDeviceModel> model_;
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
-    std::unique_ptr<FirmwareTelemetryReader> telemetry = nullptr;
-    std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -41,6 +41,10 @@ public:
 
     DeviceFirmware *get_device_firmware() override;
 
+    FirmwareTelemetryReader *get_firmware_telemetry_reader() override;
+
+    FirmwareInfoProvider *get_firmware_info_provider() override;
+
     ArchitectureImplementation *get_architecture_impl() override;
 
     HangDetector *get_hang_detector() override;

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -14,6 +14,7 @@ class DeviceFirmware;
 
 class ArchitectureImplementation;
 class DmaInterface;
+class FirmwareInfoProvider;
 class FirmwareTelemetryReader;
 class HangDetector;
 class JtagInterface;
@@ -72,7 +73,12 @@ public:
     // Optional components.
     virtual HangDetector *get_hang_detector() { return nullptr; }
 
+    // Lent from the firmware component, which owns them because they read state the firmware
+    // publishes: null until DeviceFirmware::init_firmware() has run. Simulation models keep the
+    // default - a simulated device has no firmware-published state to read.
     virtual FirmwareTelemetryReader *get_firmware_telemetry_reader() { return nullptr; }
+
+    virtual FirmwareInfoProvider *get_firmware_info_provider() { return nullptr; }
 
     // Optional transport interfaces.
     virtual PcieInterface *get_pcie_interface() { return nullptr; }

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -44,6 +44,10 @@ public:
 
     DeviceFirmware *get_device_firmware() override;
 
+    FirmwareTelemetryReader *get_firmware_telemetry_reader() override;
+
+    FirmwareInfoProvider *get_firmware_info_provider() override;
+
     ArchitectureImplementation *get_architecture_impl() override;
 
     HangDetector *get_hang_detector() override;

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -4,7 +4,9 @@
 
 #include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
 
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
@@ -50,12 +52,42 @@ BlackholeDeviceFirmware::BlackholeDeviceFirmware(
     arc_core_noc1_ = blackhole::get_arc_core(noc_translation_enabled, /*use_noc1=*/true);
 }
 
+BlackholeDeviceFirmware::~BlackholeDeviceFirmware() = default;
+
 IODeviceType BlackholeDeviceFirmware::get_io_device_type() const {
     return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
 }
 
 void BlackholeDeviceFirmware::init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // TODO: temporary. init_firmware() does two jobs - waiting for the firmware and building what
+    // depends on it - so callers that only need the first (warm reset, for one) still run the
+    // second, and a rebuild here would discard a live set and pay the telemetry table's readiness
+    // wait again. The intended fix is to split the two into separate API calls, at which point
+    // this guard goes away.
+    //
+    // Safe today only because every caller creates the TTDevice after a reset rather than reusing
+    // one across it, so there is never pre-reset state to preserve.
+    if (firmware_info_provider_ != nullptr) {
+        return;
+    }
+
     wait_firmware_ready(timeout_ms, noc_id);
+
+    // The telemetry reader and info provider read state the firmware publishes, so this is the
+    // earliest point they can exist.
+    firmware_telemetry_reader_ = ArcTelemetryReader::create_arc_telemetry_reader(
+        device_protocol_, tt::ARCH::BLACKHOLE, arc_core_noc0_, arc_core_noc1_);
+
+    firmware_info_provider_ = FirmwareInfoProviderImplementation::create_firmware_info_provider(
+        tt::ARCH::BLACKHOLE, device_protocol_, arc_core_noc0_, arc_core_noc1_, firmware_telemetry_reader_.get());
+}
+
+FirmwareTelemetryReader* BlackholeDeviceFirmware::get_firmware_telemetry_reader() const {
+    return firmware_telemetry_reader_.get();
+}
+
+FirmwareInfoProvider* BlackholeDeviceFirmware::get_firmware_info_provider() const {
+    return firmware_info_provider_.get();
 }
 
 void BlackholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -4,7 +4,9 @@
 
 #include "umd/device/tt_device/firmware/wormhole_device_firmware.hpp"
 
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
@@ -58,12 +60,41 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
         wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
 }
 
+WormholeDeviceFirmware::~WormholeDeviceFirmware() = default;
+
 IODeviceType WormholeDeviceFirmware::get_io_device_type() const {
     return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
 }
 
 void WormholeDeviceFirmware::init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // TODO: temporary. init_firmware() does two jobs - waiting for the firmware and building what
+    // depends on it - so callers that only need the first (warm reset, for one) still run the
+    // second, and a rebuild here would discard a live set. The intended fix is to split the two
+    // into separate API calls, at which point this guard goes away.
+    //
+    // Safe today only because every caller creates the TTDevice after a reset rather than reusing
+    // one across it, so there is never pre-reset state to preserve.
+    if (firmware_info_provider_ != nullptr) {
+        return;
+    }
+
     wait_firmware_ready(timeout_ms, noc_id);
+
+    // The telemetry reader and info provider read state the firmware publishes, so this is the
+    // earliest point they can exist.
+    firmware_telemetry_reader_ = ArcTelemetryReader::create_arc_telemetry_reader(
+        device_protocol_, tt::ARCH::WORMHOLE_B0, arc_core_noc0_, arc_core_noc1_);
+
+    firmware_info_provider_ = FirmwareInfoProviderImplementation::create_firmware_info_provider(
+        tt::ARCH::WORMHOLE_B0, device_protocol_, arc_core_noc0_, arc_core_noc1_, firmware_telemetry_reader_.get());
+}
+
+FirmwareTelemetryReader* WormholeDeviceFirmware::get_firmware_telemetry_reader() const {
+    return firmware_telemetry_reader_.get();
+}
+
+FirmwareInfoProvider* WormholeDeviceFirmware::get_firmware_info_provider() const {
+    return firmware_info_provider_.get();
 }
 
 void WormholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -25,7 +25,6 @@
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/driver_atomics.hpp"
-#include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
@@ -91,16 +90,10 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     if (hang_detector != nullptr && hang_detector->is_noc_hung(hang_check_noc).value_or(false)) {
         UMD_THROW(error::NocHangError, *this, hang_check_noc);
     }
+    // Waits for the firmware and builds the components that read what it publishes; the model's
+    // firmware owns them, and the accessors below lend them onward.
     get_device_firmware()->init_firmware(timeout_ms, get_selected_noc_id());
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
-    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(
-        get_device_protocol(), get_arch(), arc_core_noc0, arc_core_noc1);
-    firmware_info_provider = FirmwareInfoProviderImplementation::create_firmware_info_provider(
-        get_arch(),
-        get_device_protocol(),
-        get_arc_core(NocId::NOC0),
-        get_arc_core(NocId::NOC1),
-        get_firmware_telemetry_reader());
     construct_soc_descriptor(model_->get_shared_soc_arch_descriptor());
 }
 
@@ -529,17 +522,19 @@ ArcMessenger *TTDevice::get_arc_messenger() const {
 }
 
 FirmwareTelemetryReader *TTDevice::get_firmware_telemetry_reader() const {
-    if (telemetry == nullptr) {
+    FirmwareTelemetryReader *telemetry_reader = model_->get_firmware_telemetry_reader();
+    if (telemetry_reader == nullptr) {
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
-    return telemetry.get();
+    return telemetry_reader;
 }
 
 FirmwareInfoProvider *TTDevice::get_firmware_info_provider() const {
-    if (firmware_info_provider == nullptr) {
+    FirmwareInfoProvider *info_provider = model_->get_firmware_info_provider();
+    if (info_provider == nullptr) {
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
-    return firmware_info_provider.get();
+    return info_provider;
 }
 
 FirmwareBundleVersion TTDevice::get_firmware_version() { return get_firmware_info_provider()->get_firmware_version(); }
@@ -598,7 +593,7 @@ double TTDevice::get_asic_temperature() { return get_firmware_info_provider()->g
 uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get_asic_location().value_or(0); }
 
 ChipInfo TTDevice::get_chip_info() {
-    if (firmware_info_provider == nullptr) {
+    if (model_->get_firmware_info_provider() == nullptr) {
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
     ChipInfo chip_info;

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -84,6 +84,14 @@ DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_
 
 DeviceFirmware *BlackholeTTDeviceModel::get_device_firmware() { return device_firmware_.get(); }
 
+FirmwareTelemetryReader *BlackholeTTDeviceModel::get_firmware_telemetry_reader() {
+    return device_firmware_->get_firmware_telemetry_reader();
+}
+
+FirmwareInfoProvider *BlackholeTTDeviceModel::get_firmware_info_provider() {
+    return device_firmware_->get_firmware_info_provider();
+}
+
 SocArchDescriptor *BlackholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
 
 ArchitectureImplementation *BlackholeTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -87,6 +87,14 @@ DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.
 
 DeviceFirmware *WormholeTTDeviceModel::get_device_firmware() { return device_firmware_.get(); }
 
+FirmwareTelemetryReader *WormholeTTDeviceModel::get_firmware_telemetry_reader() {
+    return device_firmware_->get_firmware_telemetry_reader();
+}
+
+FirmwareInfoProvider *WormholeTTDeviceModel::get_firmware_info_provider() {
+    return device_firmware_->get_firmware_info_provider();
+}
+
 SocArchDescriptor *WormholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
 
 ArchitectureImplementation *WormholeTTDeviceModel::get_architecture_impl() { return architecture_impl_.get(); }


### PR DESCRIPTION
## Issue


#2872
Second move onto the `DeviceFirmware` seam: ownership of the firmware-published components.

## Description

The telemetry reader and firmware info provider read state the firmware publishes, so `init_firmware()` is where they get built — and the concrete firmware now owns them, in the same diff that deletes `TTDevice`'s `telemetry`/`firmware_info_provider` members and their construction in `init_tt_device()`.

Ownership is transitive, per the spec's "model owns the components": the concrete model owns the firmware, the firmware owns the readers. The getters are deliberately **concrete-class** getters, not part of the `DeviceFirmware` interface — the concrete model lends them onward through `TTDeviceModel::get_firmware_telemetry_reader()` (which existed, unwired, since the decoupling) and the new `get_firmware_info_provider()`.

The facade keeps the throw: `TTDevice::get_firmware_telemetry_reader()`/`get_firmware_info_provider()` turn a null from the model into `UninitializedDeviceError` carrying the device's identity, exactly as before — including for simulation, where the model keeps the interface's nullptr default because a simulated device has no firmware-published state to read.

`init_firmware()` gets the idempotence guard: it now does two jobs (wait + build), and warm reset only wants the first. The guard carries a TODO — it goes away when the two become separate API calls.

## List of the changes

- `WormholeDeviceFirmware`/`BlackholeDeviceFirmware`: own `firmware_telemetry_reader_`/`firmware_info_provider_`, built in `init_firmware()` after the wait; concrete getters; out-of-line destructors.
- `TTDeviceModel::get_firmware_info_provider()` added beside the existing telemetry accessor; both overridden in the WH/BH models to lend from the firmware.
- `TTDevice`: `telemetry` and `firmware_info_provider` members deleted; accessors forward to the model and keep the `UninitializedDeviceError` throw.

## Testing

`baremetal_tests` 254/254, simulation on and off, no undefined symbols. Card behavior is preserved by construction: same components, built at the same point in `init_tt_device()`, reached through the same two accessors.

## API Changes

None externally — `TTDevice::get_firmware_telemetry_reader()`/`get_firmware_info_provider()` keep their signatures and error behavior. `TTDeviceModel` gains `get_firmware_info_provider()`.

Stacked on #3319.

