### PR TITLE
Add an opt-in unity build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,22 @@ endif()
 
 add_subdirectory(third_party)
 
+# Unity builds batch several sources into one translation unit, so the cost of parsing
+# our headers is paid once per batch instead of once per source. Set AFTER third_party
+# so dependencies keep building one source at a time.
+#
+# Opt-in and off by default, so this commit changes nothing on its own. Turning it on also
+# needs the tests to be batching-safe, which is a follow-up; and it changes how the library
+# is compiled (static-initialisation order within a batch, inlining across what used to be
+# separate translation units), which is not something to hand a release build or a
+# developer's incremental loop without asking.
+option(TT_UMD_ENABLE_UNITY_BUILD "Batch UMD sources into unity translation units" OFF)
+set(TT_UMD_UNITY_BUILD_BATCH_SIZE "8" CACHE STRING "Number of sources per unity translation unit")
+if(TT_UMD_ENABLE_UNITY_BUILD)
+    set(CMAKE_UNITY_BUILD ON)
+    set(CMAKE_UNITY_BUILD_BATCH_SIZE "${TT_UMD_UNITY_BUILD_BATCH_SIZE}")
+endif()
+
 # Create a target that aggregates all generated files needed for code analysis.
 # Subdirectories can add dependencies to this target as needed.
 add_custom_target(umd_all_generated_files)
@@ -211,6 +227,8 @@ set(_umd_summary_vars
     TT_UMD_ENABLE_CLANG_TIDY
     TT_UMD_ENABLE_LOGGING
     TT_UMD_ENABLE_TRACY
+    TT_UMD_ENABLE_UNITY_BUILD
+    TT_UMD_UNITY_BUILD_BATCH_SIZE
 )
 message(STATUS "")
 message(STATUS "==================== UMD configuration summary ====================")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,10 @@ add_subdirectory(third_party)
 # separate translation units), which is not something to hand a release build or a
 # developer's incremental loop without asking.
 option(TT_UMD_ENABLE_UNITY_BUILD "Batch UMD sources into unity translation units" OFF)
-set(TT_UMD_UNITY_BUILD_BATCH_SIZE "8" CACHE STRING "Number of sources per unity translation unit")
+# 16 from a sweep of 1..24 at -j4, the parallelism a CI runner actually has. The curve is
+# almost spent by 8 (2.56x of an available 3.01x) and 16 captures 97% of it; 24 buys 3% more
+# while leaving libtt-umd only 5 units, so the tail idles cores on a 4-core runner.
+set(TT_UMD_UNITY_BUILD_BATCH_SIZE "16" CACHE STRING "Number of sources per unity translation unit")
 if(TT_UMD_ENABLE_UNITY_BUILD)
     set(CMAKE_UNITY_BUILD ON)
     set(CMAKE_UNITY_BUILD_BATCH_SIZE "${TT_UMD_UNITY_BUILD_BATCH_SIZE}")


### PR DESCRIPTION
## Issue

Compile time dominates our CI. `device` has 156 headers against 105 sources, 144 of them public API, and every source re-parses a large slice of that surface. On the merge queue the `build-device` matrix runs 26 to 33 minutes per entry.

## Description

Adds the option, nothing more. `TT_UMD_ENABLE_UNITY_BUILD` defaults to OFF, so **this PR changes no build anywhere** — it only makes batching available to turn on.

Unity builds concatenate several sources into one translation unit, so header parsing is paid once per batch instead of once per source. `CMAKE_UNITY_BUILD` is set *after* `add_subdirectory(third_party)`, so dependencies keep building one source at a time either way.

Split out of the original PR at review request: the test changes that batching requires, and the CI switch that turns it on, are in the follow-up. This PR is deliberately just the mechanism so it can be reviewed on its own.

Measured effect of turning it on, for context (cold `Build All` on real runners, full matrix): 1.35x to 3.74x, median ~2.4x, worst entry 21m27s -> 8m50s. Numbers and the batch-size sweep are in the follow-up.

## List of the changes

- `TT_UMD_ENABLE_UNITY_BUILD` (default OFF) and `TT_UMD_UNITY_BUILD_BATCH_SIZE` (default 8), set after `third_party`.
- Both added to the configuration summary.

## Testing

Configured and built both ways on this branch, clang-20, Release, `TT_UMD_BUILD_ALL=ON`: default (OFF) is byte-for-byte the same build as before, 463 edges green; explicit `-DTT_UMD_ENABLE_UNITY_BUILD=ON` configures 44 unity blobs and builds green.

## API Changes

This PR has no API changes, and with the default off it does not change how the shipped library is compiled.
