### PR TITLE
[Base API] Delegate set_clock_state to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -33,8 +33,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
-
     bool get_noc_translation_enabled() override;
 
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -17,6 +17,7 @@
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
@@ -54,6 +55,8 @@ public:
         std::chrono::milliseconds timeout,
         NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    void set_clock_state(ClockState state, NocId noc_id = NocId::DEFAULT_NOC) override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *
@@ -90,6 +93,10 @@ private:
     void wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id);
 
     IODeviceType get_io_device_type() const;
+
+    // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
+    // settle, rather than throwing.
+    void wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
 
     // Whether NOC address translation is active. Private for now: the constructor needs it to
     // resolve the ARC coordinates, while TTDevice::get_noc_translation_enabled stays the public

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -94,6 +94,12 @@ private:
 
     IODeviceType get_io_device_type() const;
 
+    // Full diagnostics for an unsettled AICLK, matching what TTDevice::log_aiclk_timeout_warning
+    // reported: observed vs expected, ASIC temperature, the max-arbiter clamp, and a staleness hint
+    // when the timeout is within the telemetry update interval.
+    void log_aiclk_timeout_warning(
+        uint32_t target_aiclk, uint32_t observed_aiclk, std::chrono::milliseconds timeout_ms);
+
     // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
     // settle, rather than throwing.
     void wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -24,6 +24,14 @@ struct DeviceCommandResult {
 };
 
 /**
+ * @brief Requested clock state for a device.
+ */
+enum class ClockState {
+    BUSY,  ///< Maximum AICLK frequency.
+    IDLE,  ///< Minimum AICLK frequency.
+};
+
+/**
  * @brief Interface to the device's management firmware.
  *
  * Owns the interaction with the firmware running on the device's management processor: waiting for
@@ -65,6 +73,17 @@ public:
         const std::vector<uint32_t> &args,
         std::chrono::milliseconds timeout,
         [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+
+    /**
+     * @brief Sets the device clock frequency.
+     *
+     * Distinct from a power-state change: this drives AICLK through the firmware, then waits for
+     * the clock to settle near the target before returning.
+     *
+     * @param state The target clock state.
+     * @param noc_id NOC to route through.
+     */
+    virtual void set_clock_state(ClockState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
@@ -31,6 +31,10 @@ public:
         [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override {
         return DeviceCommandResult{};
     }
+
+    // Simulated devices have no controllable clock.
+    void set_clock_state(
+        [[maybe_unused]] ClockState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override {}
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -95,6 +95,12 @@ private:
 
     IODeviceType get_io_device_type() const;
 
+    // Full diagnostics for an unsettled AICLK, matching what TTDevice::log_aiclk_timeout_warning
+    // reported: observed vs expected, ASIC temperature, the max-arbiter clamp, and a staleness hint
+    // when the timeout is within the telemetry update interval.
+    void log_aiclk_timeout_warning(
+        uint32_t target_aiclk, uint32_t observed_aiclk, std::chrono::milliseconds timeout_ms);
+
     // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
     // settle, rather than throwing.
     void wait_for_aiclk_value(

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -16,6 +16,7 @@
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
@@ -55,6 +56,8 @@ public:
         std::chrono::milliseconds timeout,
         NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    void set_clock_state(ClockState state, NocId noc_id = NocId::DEFAULT_NOC) override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *
@@ -91,6 +94,11 @@ private:
     void wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id);
 
     IODeviceType get_io_device_type() const;
+
+    // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
+    // settle, rather than throwing.
+    void wait_for_aiclk_value(
+        uint32_t target_aiclk, NocId noc_id, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
 
     // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
     // API it replaces moves here.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -26,6 +26,7 @@
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
@@ -391,12 +392,12 @@ public:
     /**
      * @brief Sets the device clock frequency.
      *
-     * Controls the AICLK frequency the device runs at. Distinct from
-     * set_power_state(), which manages hardware power domains.
+     * Controls the AICLK frequency the device runs at. Distinct from set_power_state(), which
+     * manages hardware power domains.
      *
      * @param state The target clock state (BUSY = max frequency, IDLE = min frequency).
      */
-    virtual void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC);
+    void set_clock_state(ClockState state, NocId noc_id = NocId::DEFAULT_NOC);
 
     virtual uint32_t get_clock() = 0;
 
@@ -532,11 +533,6 @@ protected:
         uint64_t addr,
         NocId noc_id = NocId::DEFAULT_NOC);
 
-    // Polls AICLK until it reaches the frequency expected for `power_state`, or logs a warning and
-    // returns on timeout.
-    void wait_for_aiclk_value(
-        PowerState power_state, const std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
-
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
     xy_pair arc_core_noc0;
@@ -548,8 +544,6 @@ protected:
     virtual void set_arc_coordinate() {}
 
 private:
-    void log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms);
-
     // Wires the model's hang detector to this device: routes a timed-out MMIO op to a NOC liveness
     // check, and gives the detector a separately-locked window to probe through.
     void wire_hang_detector();

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -30,8 +30,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
-
     bool get_noc_translation_enabled() override;
 
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
@@ -58,7 +56,6 @@ private:
     const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::WORMHOLE_B0);
 
     // Builds the ARC message (with the common prefix) that requests the given clock state.
-    uint32_t get_power_state_arc_msg(PowerState state);
 
     friend std::unique_ptr<TTDevice> TTDevice::create(
         int device_number,

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -152,8 +152,7 @@ void Chip::advance_device_execution() {
 
 void Chip::set_clock_state(DevicePowerState state) {
     if (auto* tt_device = get_tt_device()) {
-        tt_device->set_clock_state(
-            state == DevicePowerState::BUSY ? TTDevice::PowerState::BUSY : TTDevice::PowerState::IDLE);
+        tt_device->set_clock_state(state == DevicePowerState::BUSY ? ClockState::BUSY : ClockState::IDLE);
     }
 }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -184,38 +184,6 @@ uint32_t BlackholeTTDevice::get_clock() {
 
 uint32_t BlackholeTTDevice::get_min_clock_freq() { return get_architecture_implementation()->get_min_clock_freq(); }
 
-void BlackholeTTDevice::set_clock_state(TTDevice::PowerState state, NocId /*noc_id*/) {
-    ZoneScoped;
-    uint32_t exit_code = 0;
-    switch (state) {
-        case TTDevice::PowerState::BUSY:
-            exit_code = get_device_firmware()
-                            ->send_device_command(
-                                (uint32_t)blackhole::ArcMessageType::AICLK_GO_BUSY,
-                                {},
-                                timeout::ARC_MESSAGE_TIMEOUT,
-                                get_selected_noc_id())
-                            .exit_code;
-            break;
-        case TTDevice::PowerState::IDLE:
-            exit_code = get_device_firmware()
-                            ->send_device_command(
-                                (uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE,
-                                {},
-                                timeout::ARC_MESSAGE_TIMEOUT,
-                                get_selected_noc_id())
-                            .exit_code;
-            break;
-        default:
-            UMD_THROW(error::RuntimeError, "Unrecognized power state.");
-    }
-    UMD_ASSERT(
-        exit_code == 0,
-        error::RuntimeError,
-        fmt::format("Failed to set clock state to {} with exit code: {}", (int)state, exit_code));
-    wait_for_aiclk_value(state);
-}
-
 void BlackholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
     if (arc_addr_offset > blackhole::ARC_XBAR_ADDRESS_END) {
         UMD_THROW(error::RuntimeError, "Address is out of ARC XBAR address range.");

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -4,19 +4,24 @@
 
 #include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
 
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
+#include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
+#include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
 #include "utils.hpp"
 
@@ -134,6 +139,60 @@ DeviceCommandResult BlackholeDeviceFirmware::send_device_command(
         fmt::join(return_values, ", "));
 
     return DeviceCommandResult{exit_code, std::move(return_values)};
+}
+
+void BlackholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
+    uint32_t msg_code = 0;
+    uint32_t target_aiclk = 0;
+    switch (state) {
+        case ClockState::BUSY:
+            msg_code = static_cast<uint32_t>(blackhole::ArcMessageType::AICLK_GO_BUSY);
+            target_aiclk = firmware_info_provider_->get_max_clock_freq().value_or(0);
+            break;
+        case ClockState::IDLE:
+            msg_code = static_cast<uint32_t>(blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
+            target_aiclk = blackhole::AICLK_IDLE_VAL;
+            break;
+        default:
+            UMD_THROW(error::RuntimeError, "Unrecognized clock state.");
+    }
+
+    DeviceCommandResult result = send_device_command(msg_code, {}, timeout::ARC_MESSAGE_TIMEOUT, noc_id);
+    UMD_ASSERT(
+        result.exit_code == 0,
+        error::RuntimeError,
+        fmt::format("Failed to set clock state to {} with exit code: {}", (int)state, result.exit_code));
+
+    wait_for_aiclk_value(target_aiclk);
+}
+
+void BlackholeDeviceFirmware::wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms) {
+    constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
+
+    uint32_t aiclk = 0;
+    const bool settled = utils::poll_until(
+        [&] {
+            aiclk = firmware_telemetry_reader_->read_entry(TelemetryTag::AICLK);
+            return is_within_percentage(aiclk, target_aiclk, AICLK_TOLERANCE_PERCENT);
+        },
+        timeout_ms,
+        std::chrono::microseconds(500),
+        std::chrono::microseconds(100));
+
+    if (!settled) {
+        log_warning(
+            LogUMD, "AICLK did not reach {} MHz within {} ms. Proceeding anyway.", target_aiclk, timeout_ms.count());
+        return;
+    }
+
+    if (aiclk != target_aiclk) {
+        log_warning(
+            LogUMD,
+            "AICLK settled at {} MHz, within {}% of the requested {} MHz but not an exact match. Proceeding.",
+            aiclk,
+            AICLK_TOLERANCE_PERCENT,
+            target_aiclk);
+    }
 }
 
 void BlackholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -142,6 +142,12 @@ DeviceCommandResult BlackholeDeviceFirmware::send_device_command(
 }
 
 void BlackholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
+    // The BUSY branch reads the info provider before send_device_command can run its own pre-init
+    // check, so refuse here with the same error the deleted TTDevice path produced.
+    if (firmware_info_provider_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, get_io_device_type(), device_id_, tt::ARCH::BLACKHOLE);
+    }
+
     uint32_t msg_code = 0;
     uint32_t target_aiclk = 0;
     switch (state) {
@@ -166,6 +172,37 @@ void BlackholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
     wait_for_aiclk_value(target_aiclk);
 }
 
+void BlackholeDeviceFirmware::log_aiclk_timeout_warning(
+    uint32_t target_aiclk, uint32_t observed_aiclk, std::chrono::milliseconds timeout_ms) {
+    std::string arb_max_info;
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
+        const uint32_t arb_max = firmware_telemetry_reader_->read_entry(TelemetryTag::AICLK_ARB_MAX);
+        arb_max_info = fmt::format(
+            ", AICLK clamped by max-arbiter index {} at {} MHz", (arb_max >> 16) & 0xFFFF, arb_max & 0xFFFF);
+    }
+
+    log_warning(
+        LogUMD,
+        "AICLK failed to settle after {} ms. Expected {}, observed {}. ASIC temperature: {}{}",
+        timeout_ms.count(),
+        target_aiclk,
+        observed_aiclk,
+        firmware_info_provider_->get_asic_temperature().value_or(0.0),
+        arb_max_info);
+
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
+        const uint32_t update_telem_speed_ms = firmware_telemetry_reader_->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
+        if (timeout_ms.count() <= update_telem_speed_ms) {
+            log_warning(
+                LogUMD,
+                "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the observed "
+                "AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
+                timeout_ms.count(),
+                update_telem_speed_ms);
+        }
+    }
+}
+
 void BlackholeDeviceFirmware::wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms) {
     constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
 
@@ -180,8 +217,7 @@ void BlackholeDeviceFirmware::wait_for_aiclk_value(uint32_t target_aiclk, std::c
         std::chrono::microseconds(100));
 
     if (!settled) {
-        log_warning(
-            LogUMD, "AICLK did not reach {} MHz within {} ms. Proceeding anyway.", target_aiclk, timeout_ms.count());
+        log_aiclk_timeout_warning(target_aiclk, aiclk, timeout_ms);
         return;
     }
 

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -10,14 +10,17 @@
 #include <utility>
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
@@ -345,6 +348,67 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
     }
 
     return DeviceCommandResult{exit_code, std::move(return_values)};
+}
+
+void WormholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
+    uint32_t msg_code = wormhole::ARC_MSG_COMMON_PREFIX;
+    uint32_t target_aiclk = 0;
+    switch (state) {
+        case ClockState::BUSY:
+            msg_code |= architecture_impl_->get_firmware_message_go_busy();
+            target_aiclk = firmware_info_provider_->get_max_clock_freq().value_or(0);
+            break;
+        case ClockState::IDLE:
+            msg_code |= architecture_impl_->get_firmware_message_go_idle();
+            target_aiclk = wormhole::AICLK_IDLE_VAL;
+            break;
+        default:
+            UMD_THROW(error::RuntimeError, "Unrecognized clock state.");
+    }
+
+    DeviceCommandResult result = send_device_command(msg_code, {0, 0}, timeout::ARC_MESSAGE_TIMEOUT, noc_id);
+    UMD_ASSERT(
+        result.exit_code == 0,
+        error::RuntimeError,
+        fmt::format("Failed to set clock state to {} with exit code: {}", (int)state, result.exit_code));
+
+    wait_for_aiclk_value(target_aiclk, noc_id);
+}
+
+void WormholeDeviceFirmware::wait_for_aiclk_value(
+    uint32_t target_aiclk, NocId noc_id, std::chrono::milliseconds timeout_ms) {
+    constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
+
+    uint32_t aiclk = 0;
+    const bool settled = utils::poll_until(
+        [&] {
+            // Wormhole reads AICLK through an ARC message rather than telemetry.
+            DeviceCommandResult result = send_device_command(
+                wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::GET_AICLK),
+                {0, 0},
+                timeout::ARC_MESSAGE_TIMEOUT,
+                noc_id);
+            aiclk = result.return_values.at(0);
+            return is_within_percentage(aiclk, target_aiclk, AICLK_TOLERANCE_PERCENT);
+        },
+        timeout_ms,
+        std::chrono::microseconds(500),
+        std::chrono::microseconds(100));
+
+    if (!settled) {
+        log_warning(
+            LogUMD, "AICLK did not reach {} MHz within {} ms. Proceeding anyway.", target_aiclk, timeout_ms.count());
+        return;
+    }
+
+    if (aiclk != target_aiclk) {
+        log_warning(
+            LogUMD,
+            "AICLK settled at {} MHz, within {}% of the requested {} MHz but not an exact match. Proceeding.",
+            aiclk,
+            AICLK_TOLERANCE_PERCENT,
+            target_aiclk);
+    }
 }
 
 tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
+#include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
@@ -20,6 +21,7 @@
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/types/telemetry.hpp"
 #include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -351,6 +353,12 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
 }
 
 void WormholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
+    // The BUSY branch reads the info provider before send_device_command can run its own pre-init
+    // check, so refuse here with the same error the deleted TTDevice path produced.
+    if (firmware_info_provider_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, get_io_device_type(), device_id_, tt::ARCH::WORMHOLE_B0);
+    }
+
     uint32_t msg_code = wormhole::ARC_MSG_COMMON_PREFIX;
     uint32_t target_aiclk = 0;
     switch (state) {
@@ -375,6 +383,37 @@ void WormholeDeviceFirmware::set_clock_state(ClockState state, NocId noc_id) {
     wait_for_aiclk_value(target_aiclk, noc_id);
 }
 
+void WormholeDeviceFirmware::log_aiclk_timeout_warning(
+    uint32_t target_aiclk, uint32_t observed_aiclk, std::chrono::milliseconds timeout_ms) {
+    std::string arb_max_info;
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
+        const uint32_t arb_max = firmware_telemetry_reader_->read_entry(TelemetryTag::AICLK_ARB_MAX);
+        arb_max_info = fmt::format(
+            ", AICLK clamped by max-arbiter index {} at {} MHz", (arb_max >> 16) & 0xFFFF, arb_max & 0xFFFF);
+    }
+
+    log_warning(
+        LogUMD,
+        "AICLK failed to settle after {} ms. Expected {}, observed {}. ASIC temperature: {}{}",
+        timeout_ms.count(),
+        target_aiclk,
+        observed_aiclk,
+        firmware_info_provider_->get_asic_temperature().value_or(0.0),
+        arb_max_info);
+
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
+        const uint32_t update_telem_speed_ms = firmware_telemetry_reader_->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
+        if (timeout_ms.count() <= update_telem_speed_ms) {
+            log_warning(
+                LogUMD,
+                "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the observed "
+                "AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
+                timeout_ms.count(),
+                update_telem_speed_ms);
+        }
+    }
+}
+
 void WormholeDeviceFirmware::wait_for_aiclk_value(
     uint32_t target_aiclk, NocId noc_id, std::chrono::milliseconds timeout_ms) {
     constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
@@ -382,12 +421,18 @@ void WormholeDeviceFirmware::wait_for_aiclk_value(
     uint32_t aiclk = 0;
     const bool settled = utils::poll_until(
         [&] {
-            // Wormhole reads AICLK through an ARC message rather than telemetry.
+            // Wormhole reads AICLK through an ARC message rather than telemetry. The 0xFFFF pair
+            // packs to the firmware's no-argument sentinel, exactly as TTDevice::get_clock sends it;
+            // a failed read throws rather than settling on garbage, as the deleted path did.
             DeviceCommandResult result = send_device_command(
                 wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::GET_AICLK),
-                {0, 0},
+                {0xFFFF, 0xFFFF},
                 timeout::ARC_MESSAGE_TIMEOUT,
                 noc_id);
+            if (result.exit_code != 0) {
+                UMD_THROW(
+                    error::RuntimeError, fmt::format("Failed to get AICLK value with exit code: {}", result.exit_code));
+            }
             aiclk = result.return_values.at(0);
             return is_within_percentage(aiclk, target_aiclk, AICLK_TOLERANCE_PERCENT);
         },
@@ -396,8 +441,7 @@ void WormholeDeviceFirmware::wait_for_aiclk_value(
         std::chrono::microseconds(100));
 
     if (!settled) {
-        log_warning(
-            LogUMD, "AICLK did not reach {} MHz within {} ms. Proceeding anyway.", target_aiclk, timeout_ms.count());
+        log_aiclk_timeout_warning(target_aiclk, aiclk, timeout_ms);
         return;
     }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -207,8 +207,10 @@ void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
 }
 
-void TTDevice::set_clock_state(ClockState state, NocId noc_id) {
-    get_device_firmware()->set_clock_state(state, noc_id);
+void TTDevice::set_clock_state(ClockState state, NocId /*noc_id*/) {
+    // The per-arch overrides this replaces ignored the parameter and let ArcMessenger route on the
+    // thread-selected NOC; keep that until the parameter is honored end-to-end.
+    get_device_firmware()->set_clock_state(state, get_selected_noc_id());
 }
 
 DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -60,9 +60,6 @@
 namespace tt::umd {
 enum class RiscType : std::uint64_t;
 
-// AICLK rarely settles on the exact target; accept any value within this percentage of the target.
-constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
-
 /* static */ void TTDevice::set_sigbus_safe_handler(bool set_safe_handler) {
     SiliconTlbWindow::set_sigbus_safe_handler(set_safe_handler);
 }
@@ -210,80 +207,8 @@ void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
 }
 
-void TTDevice::set_clock_state(TTDevice::PowerState /*state*/, NocId /*noc_id*/) {
-    // No-op by default. Backends with a controllable clock (Wormhole, Blackhole) override this to
-    // drive AICLK via ARC; backends without one (e.g. simulation) keep the no-op.
-}
-
-void TTDevice::wait_for_aiclk_value(TTDevice::PowerState power_state, const std::chrono::milliseconds timeout_ms) {
-    uint32_t target_aiclk = 0;
-    switch (power_state) {
-        case TTDevice::PowerState::BUSY:
-            target_aiclk = get_max_clock_freq();
-            break;
-        case TTDevice::PowerState::IDLE:
-            target_aiclk = get_min_clock_freq();
-            break;
-        default:
-            UMD_THROW(error::RuntimeError, "Invalid power state specified for AICLK wait.");
-    }
-
-    uint32_t aiclk = 0;
-    const bool settled = utils::poll_until(
-        [&] {
-            aiclk = get_clock();
-            return is_within_percentage(aiclk, target_aiclk, AICLK_TOLERANCE_PERCENT);
-        },
-        timeout_ms,
-        std::chrono::microseconds(500),
-        std::chrono::microseconds(100));
-
-    if (!settled) {
-        log_aiclk_timeout_warning(target_aiclk, timeout_ms);
-        return;
-    }
-
-    if (aiclk != target_aiclk) {
-        log_warning(
-            LogUMD,
-            "AICLK settled at {} MHz, within {}% of the requested {} MHz but not an exact match. Proceeding.",
-            aiclk,
-            AICLK_TOLERANCE_PERCENT,
-            target_aiclk);
-    }
-}
-
-void TTDevice::log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms) {
-    const uint32_t aiclk = get_clock();
-
-    auto *telemetry = get_firmware_telemetry_reader();
-    std::string arb_max_info;
-    if (telemetry != nullptr && telemetry->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
-        const uint32_t arb_max = telemetry->read_entry(TelemetryTag::AICLK_ARB_MAX);
-        arb_max_info = fmt::format(
-            ", AICLK clamped by max-arbiter index {} at {} MHz", (arb_max >> 16) & 0xFFFF, arb_max & 0xFFFF);
-    }
-
-    log_warning(
-        LogUMD,
-        "AICLK failed to settle after {} ms. Expected {}, observed {}. ASIC temperature: {}{}",
-        timeout_ms.count(),
-        target_aiclk,
-        aiclk,
-        get_asic_temperature(),
-        arb_max_info);
-
-    if (telemetry != nullptr && telemetry->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
-        const uint32_t update_telem_speed_ms = telemetry->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
-        if (timeout_ms.count() <= update_telem_speed_ms) {
-            log_warning(
-                LogUMD,
-                "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the observed "
-                "AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
-                timeout_ms.count(),
-                update_telem_speed_ms);
-        }
-    }
+void TTDevice::set_clock_state(ClockState state, NocId noc_id) {
+    get_device_firmware()->set_clock_state(state, noc_id);
 }
 
 DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -87,35 +87,6 @@ uint32_t WormholeTTDevice::get_clock() {
 
 uint32_t WormholeTTDevice::get_min_clock_freq() { return get_architecture_implementation()->get_min_clock_freq(); }
 
-uint32_t WormholeTTDevice::get_power_state_arc_msg(TTDevice::PowerState state) {
-    uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
-    switch (state) {
-        case TTDevice::PowerState::BUSY: {
-            msg |= get_architecture_implementation()->get_firmware_message_go_busy();
-            break;
-        }
-        case TTDevice::PowerState::IDLE: {
-            msg |= get_architecture_implementation()->get_firmware_message_go_idle();
-            break;
-        }
-        default:
-            UMD_THROW(error::RuntimeError, "Unrecognized power state.");
-    }
-    return msg;
-}
-
-void WormholeTTDevice::set_clock_state(TTDevice::PowerState state, NocId /*noc_id*/) {
-    ZoneScoped;
-    uint32_t msg = get_power_state_arc_msg(state);
-    DeviceCommandResult result =
-        get_device_firmware()->send_device_command(msg, {0, 0}, timeout::ARC_MESSAGE_TIMEOUT, get_selected_noc_id());
-    UMD_ASSERT(
-        result.exit_code == 0,
-        error::RuntimeError,
-        fmt::format("Failed to set clock state to {} with exit code: {}", (int)state, result.exit_code));
-    wait_for_aiclk_value(state);
-}
-
 void WormholeTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
     uint32_t dest_bar_lo = target & 0xffffffff;
     uint32_t dest_bar_hi = (target >> 32) & 0xffffffff;


### PR DESCRIPTION
## Issue


#2872
Delegate `set_clock_state` to `DeviceFirmware`.

## Description

The AICLK control moves into the firmware implementations, built on `send_device_command` (#3322): Wormhole reads AICLK back through the `GET_AICLK` ARC message, Blackhole through telemetry, both settling within the same 5% tolerance with the same warnings as before.

On the facade, `TTDevice::set_clock_state` becomes a **non-virtual** forwarder taking the firmware's `ClockState` — the per-arch overrides die, along with the TTDevice-side AICLK wait and its timeout-warning helper (the firmware implementations carry that logic now). `Chip::set_clock_state` maps `DevicePowerState` to `ClockState` at the boundary. Simulation keeps its no-op, now expressed by `SimulationDeviceFirmware`.

This is distinct from `set_power_state` (power domains), which is the next PR.

## List of the changes

- `ClockState` + `DeviceFirmware::set_clock_state()`; implemented in WH (ARC message + `GET_AICLK` settle), BH (ARC message + telemetry settle), simulation (no-op).
- `TTDevice::set_clock_state(ClockState, NocId)` non-virtual forwarder; WH/BH overrides deleted; `wait_for_aiclk_value`/`log_aiclk_timeout_warning` deleted from `TTDevice`.
- `Chip::set_clock_state` maps to `ClockState`.

## Testing

`baremetal_tests` 254/254, simulation on and off, no undefined symbols.

## API Changes

- `TTDevice::set_clock_state` now takes `ClockState` instead of `TTDevice::PowerState` and is non-virtual (no users of the old signature in tt-metal/tt-exalens/tests).

Stacked on #3322.

## Adversarial review round

A follow-up commit restores the deleted path's exact semantics where the first cut drifted:

- `set_clock_state(BUSY)` on an uninitialized device dereferenced the null info provider where the old path threw `UninitializedDeviceError`; guarded on both architectures.
- The Wormhole AICLK settle poll sent `{0,0}` (a real zero argument) instead of the `{0xFFFF,0xFFFF}` no-argument sentinel `get_clock()` uses, and ignored the exit code (a hung read spun out the timeout as "AICLK=0"); both match `get_clock()` again.
- The full `log_aiclk_timeout_warning` diagnostics (observed AICLK, ASIC temperature, max-arbiter clamp decode, telemetry staleness hint) are reimplemented in both firmwares.
- The facade keeps the thread-selected NOC the deleted overrides used.
