### PR TITLE
[Base API] Delegate get_noc_translation_enabled to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -33,8 +33,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    bool get_noc_translation_enabled() override;
-
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -60,6 +60,14 @@ public:
     void set_power_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
 
     /**
+     * @brief Queries whether NOC address translation is active.
+     *
+     * The state is fixed for the device's lifetime and read over BAR/JTAG, never over a NOC, so
+     * noc_id is unused. The constructor also uses it to resolve the ARC coordinates.
+     */
+    bool get_noc_translation_enabled(NocId noc_id = NocId::DEFAULT_NOC) override;
+
+    /**
      * @brief Telemetry published by the management firmware.
      *
      * Owned here: it reads state the firmware publishes, so it cannot exist until init_firmware()
@@ -105,11 +113,6 @@ private:
     // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
     // settle, rather than throwing.
     void wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
-
-    // Whether NOC address translation is active. Private for now: the constructor needs it to
-    // resolve the ARC coordinates, while TTDevice::get_noc_translation_enabled stays the public
-    // entry until that API moves here. Read over BAR/JTAG, so it does not need the firmware up.
-    bool get_noc_translation_enabled() const;
 
     // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
     // API it replaces moves here.

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -95,6 +95,13 @@ public:
      * @param noc_id NOC to route through.
      */
     virtual void set_power_state(PowerState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+
+    /**
+     * @brief Queries whether NOC address translation is active on this chip.
+     * @param noc_id NOC to route through.
+     * @return true if translation is enabled.
+     */
+    virtual bool get_noc_translation_enabled([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
@@ -39,6 +39,10 @@ public:
     // Simulated devices have no power domains to manage.
     void set_power_state(
         [[maybe_unused]] PowerState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override {}
+
+    // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is
+    // never applied.
+    bool get_noc_translation_enabled([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override { return false; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -60,6 +60,8 @@ public:
 
     void set_power_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    bool get_noc_translation_enabled(NocId noc_id = NocId::DEFAULT_NOC) override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -61,7 +61,6 @@ public:
     void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     uint32_t get_clock() override;
     uint32_t get_min_clock_freq() override;
-    bool get_noc_translation_enabled() override;
     void dma_write_to_core_range(
         const void* src,
         uint64_t dst_addr,

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -417,7 +417,7 @@ public:
 
     BoardType get_board_type();
 
-    virtual bool get_noc_translation_enabled() = 0;
+    bool get_noc_translation_enabled();
 
     double get_asic_temperature();
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -30,8 +30,6 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    bool get_noc_translation_enabled() override;
-
     void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -117,19 +117,6 @@ void BlackholeTTDevice::configure_iatu_region(size_t region, uint64_t target, si
         target);
 }
 
-bool BlackholeTTDevice::get_noc_translation_enabled() {
-    uint32_t niu_cfg;
-    const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + 0x100;
-
-    if (get_communication_device_type() == IODeviceType::JTAG) {
-        // Target arc core.
-        niu_cfg = get_jtag_interface()->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);
-    } else {
-        niu_cfg = bar_read32(addr);
-    }
-    return ((niu_cfg >> 14) & 0x1) != 0;
-}
-
 ChipInfo BlackholeTTDevice::get_chip_info() {
     ChipInfo chip_info = TTDevice::get_chip_info();
     chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -284,7 +284,7 @@ void BlackholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds time
     }
 }
 
-bool BlackholeDeviceFirmware::get_noc_translation_enabled() const {
+bool BlackholeDeviceFirmware::get_noc_translation_enabled(NocId /*noc_id*/) {
     uint32_t niu_cfg;
     if (get_io_device_type() == IODeviceType::JTAG) {
         niu_cfg = jtag_interface_->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -464,6 +464,15 @@ void WormholeDeviceFirmware::wait_for_aiclk_value(
     }
 }
 
+bool WormholeDeviceFirmware::get_noc_translation_enabled(NocId noc_id) {
+    constexpr uint32_t ARC_APB_NIU_0_OFFSET = 0x50000;
+    constexpr uint32_t NIU_CFG_0_OFFSET = 0x100;
+
+    uint32_t niu_cfg = 0x0;
+    read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof(niu_cfg), noc_id);
+    return (niu_cfg & (1 << 14)) != 0;
+}
+
 tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
     return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
 }

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -300,12 +300,6 @@ std::unique_ptr<TlbWindow> SimulationTTDevice::get_io_window(tlb_data config, Tl
     return create_tlb_window(tlb_index, actual_size, mapping, config);
 }
 
-bool SimulationTTDevice::get_noc_translation_enabled() {
-    // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is never
-    // applied.
-    return false;
-}
-
 void SimulationTTDevice::noc_multicast_write(
     const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -214,7 +214,11 @@ void TTDevice::set_clock_state(ClockState state, NocId /*noc_id*/) {
     get_device_firmware()->set_clock_state(state, get_selected_noc_id());
 }
 
-bool TTDevice::get_noc_translation_enabled() { return get_device_firmware()->get_noc_translation_enabled(); }
+bool TTDevice::get_noc_translation_enabled() {
+    // The overrides this replaces routed their device reads per the thread-selected NOC (via the
+    // TTDevice accessors); keep that.
+    return get_device_firmware()->get_noc_translation_enabled(get_selected_noc_id());
+}
 
 DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -214,6 +214,8 @@ void TTDevice::set_clock_state(ClockState state, NocId /*noc_id*/) {
     get_device_firmware()->set_clock_state(state, get_selected_noc_id());
 }
 
+bool TTDevice::get_noc_translation_enabled() { return get_device_firmware()->get_noc_translation_enabled(); }
+
 DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }
 
 PcieInterface *TTDevice::get_pcie_interface() {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -44,14 +44,6 @@ WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDev
     WormholeTTDevice::set_arc_coordinate();
 }
 
-bool WormholeTTDevice::get_noc_translation_enabled() {
-    uint32_t niu_cfg = 0x0;
-    constexpr uint32_t ARC_APB_NIU_0_OFFSET = 0x50000;
-    constexpr uint32_t NIU_CFG_0_OFFSET = 0x100;
-    read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof niu_cfg);
-    return (niu_cfg & (1 << 14)) != 0;
-}
-
 ChipInfo WormholeTTDevice::get_chip_info() {
     ChipInfo chip_info = TTDevice::get_chip_info();
 


### PR DESCRIPTION
## Issue


#2872
Delegate `get_noc_translation_enabled` to `DeviceFirmware`.

## Description

The Wormhole read (NIU config over the ARC APB window) and the Blackhole read (BAR/JTAG, never over a NOC) move into the firmware implementations. Blackhole's is the promotion of the private constructor helper from #3319 to the interface method — the temporary duplication flagged there ends here. Simulation returns `false` through the firmware now, same value as its deleted `TTDevice` override.

`TTDevice::get_noc_translation_enabled()` becomes a non-virtual forwarder; the pure virtual and all three overrides die.

## List of the changes

- `DeviceFirmware::get_noc_translation_enabled(NocId)`; implemented in WH (APB window read), BH (BAR/JTAG read, promoted from the private helper), simulation (`false`).
- `TTDevice::get_noc_translation_enabled` non-virtual forwarder; WH/BH/simulation overrides deleted.

## Testing

`baremetal_tests` 254/254, simulation on and off, no undefined symbols.

## API Changes

None — `TTDevice::get_noc_translation_enabled()` keeps its signature (now non-virtual). `DeviceFirmware::get_noc_translation_enabled` added.

Stacked on #3324.

## Adversarial review round

Follow-up: the facade forwards the thread-selected NOC (the deleted overrides' device reads honored it), and the constructor's now-stale `BlackholeTTDevice::` qualifier is dropped.
