### PR TITLE
[Base API] Delegate get_chip_info to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -37,8 +37,6 @@ public:
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
-    ChipInfo get_chip_info() override;
-
     std::chrono::milliseconds wait_eth_core_training(
         CoreCoord eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
 

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -67,6 +67,8 @@ public:
      */
     bool get_noc_translation_enabled(NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    ChipInfo get_chip_info(NocId noc_id = NocId::DEFAULT_NOC) override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/power_state.hpp"
 
@@ -102,6 +103,15 @@ public:
      * @return true if translation is enabled.
      */
     virtual bool get_noc_translation_enabled([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+
+    /**
+     * @brief Queries the chip's physical identity and configuration.
+     * @param noc_id NOC to route through.
+     * @return ChipInfo Harvesting masks, board identity, and NOC translation state.
+     * @throws error::UninitializedDeviceError if init_firmware() has not run: the answers come from
+     * state the firmware publishes.
+     */
+    virtual ChipInfo get_chip_info([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
@@ -17,6 +18,12 @@ namespace tt::umd {
  */
 class SimulationDeviceFirmware : public DeviceFirmware {
 public:
+    /**
+     * @brief Builds firmware for a simulated device of the given architecture.
+     * @param arch Architecture being simulated; get_chip_info() reports harvesting per architecture.
+     */
+    explicit SimulationDeviceFirmware(tt::ARCH arch) : arch_(arch) {}
+
     // A simulated device's firmware is ready by construction, so there is nothing to wait for.
     void init_firmware(
         [[maybe_unused]] std::chrono::milliseconds timeout_ms,
@@ -43,6 +50,21 @@ public:
     // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is
     // never applied.
     bool get_noc_translation_enabled([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override { return false; }
+
+    // There is no FirmwareInfoProvider on a simulator, so the defaults mirror the ones
+    // TTSimTTDevice::create() uses. Blackhole SocDescriptor construction rejects an empty
+    // eth_harvesting_mask ("Exactly 2 or 14 ETH cores should be harvested on full Blackhole"), so
+    // the same 0x120 default is applied here. Keep in sync with create().
+    ChipInfo get_chip_info([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override {
+        ChipInfo chip_info{};
+        if (arch_ == tt::ARCH::BLACKHOLE) {
+            chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
+        }
+        return chip_info;
+    }
+
+private:
+    tt::ARCH arch_ = tt::ARCH::Invalid;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -62,6 +62,8 @@ public:
 
     bool get_noc_translation_enabled(NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    ChipInfo get_chip_info(NocId noc_id = NocId::DEFAULT_NOC) override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -346,7 +346,7 @@ public:
      */
     virtual void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
 
-    virtual ChipInfo get_chip_info();
+    ChipInfo get_chip_info();
 
     FirmwareBundleVersion get_firmware_version();
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -73,7 +73,6 @@ public:
     std::chrono::milliseconds wait_eth_core_training(
         CoreCoord eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(CoreCoord eth_core) override;
-    ChipInfo get_chip_info() override;
 
     void close_device();
     void start_device();

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -34,8 +34,6 @@ public:
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
-    ChipInfo get_chip_info() override;
-
     std::chrono::milliseconds wait_eth_core_training(
         CoreCoord eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -117,50 +117,6 @@ void BlackholeTTDevice::configure_iatu_region(size_t region, uint64_t target, si
         target);
 }
 
-ChipInfo BlackholeTTDevice::get_chip_info() {
-    ChipInfo chip_info = TTDevice::get_chip_info();
-    chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
-        tt::ARCH::BLACKHOLE,
-        get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_TENSIX_COL)
-            ? (~get_firmware_telemetry_reader()->read_entry(TelemetryTag::ENABLED_TENSIX_COL) & 0x3FFF)
-            : 0);
-    chip_info.harvesting_masks.dram_harvesting_mask =
-        get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_GDDR)
-            ? (~get_firmware_telemetry_reader()->read_entry(TelemetryTag::ENABLED_GDDR) & 0xFF)
-            : 0;
-
-    chip_info.harvesting_masks.eth_harvesting_mask =
-        get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_ETH)
-            ? (~get_firmware_telemetry_reader()->read_entry(TelemetryTag::ENABLED_ETH) & 0x3FFF)
-            : 0;
-
-    chip_info.harvesting_masks.pcie_harvesting_mask = 0;
-    if (get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::PCIE_USAGE)) {
-        uint32_t pcie_usage = get_firmware_telemetry_reader()->read_entry(TelemetryTag::PCIE_USAGE);
-
-        uint32_t pcie0_usage = pcie_usage & 0x3;
-        uint32_t pcie1_usage = (pcie_usage >> 2) & 0x3;
-
-        const uint32_t pcie_usage_endpoint = 1;
-        chip_info.harvesting_masks.pcie_harvesting_mask = 0;
-        if (pcie0_usage != pcie_usage_endpoint) {
-            chip_info.harvesting_masks.pcie_harvesting_mask |= 0x1;
-        }
-
-        if (pcie1_usage != pcie_usage_endpoint) {
-            chip_info.harvesting_masks.pcie_harvesting_mask |= (1 << 1);
-        }
-    }
-
-    chip_info.harvesting_masks.l2cpu_harvesting_mask = 0;
-    if (get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_L2CPU)) {
-        chip_info.harvesting_masks.l2cpu_harvesting_mask = CoordinateManager::shuffle_l2cpu_harvesting_mask(
-            tt::ARCH::BLACKHOLE, get_firmware_telemetry_reader()->read_entry(TelemetryTag::ENABLED_L2CPU));
-    }
-
-    return chip_info;
-}
-
 uint32_t BlackholeTTDevice::get_clock() {
     if (get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::AICLK)) {
         return get_firmware_telemetry_reader()->read_entry(TelemetryTag::AICLK);

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -13,6 +13,7 @@
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
@@ -238,6 +239,62 @@ void BlackholeDeviceFirmware::wait_for_aiclk_value(uint32_t target_aiclk, std::c
             AICLK_TOLERANCE_PERCENT,
             target_aiclk);
     }
+}
+
+ChipInfo BlackholeDeviceFirmware::get_chip_info(NocId noc_id) {
+    UMD_ASSERT(
+        firmware_info_provider_ != nullptr && firmware_telemetry_reader_ != nullptr,
+        error::UninitializedDeviceError,
+        get_io_device_type(),
+        device_id_,
+        tt::ARCH::BLACKHOLE);
+    ChipInfo chip_info;
+
+    chip_info.noc_translation_enabled = get_noc_translation_enabled(noc_id);
+    chip_info.board_id = firmware_info_provider_->get_board_id().value_or(0);
+    chip_info.board_type = get_board_type_from_board_id(chip_info.board_id);
+    chip_info.asic_location = firmware_info_provider_->get_asic_location().value_or(0);
+
+    chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
+        tt::ARCH::BLACKHOLE,
+        firmware_telemetry_reader_->is_entry_available(TelemetryTag::ENABLED_TENSIX_COL)
+            ? (~firmware_telemetry_reader_->read_entry(TelemetryTag::ENABLED_TENSIX_COL) & 0x3FFF)
+            : 0);
+    chip_info.harvesting_masks.dram_harvesting_mask =
+        firmware_telemetry_reader_->is_entry_available(TelemetryTag::ENABLED_GDDR)
+            ? (~firmware_telemetry_reader_->read_entry(TelemetryTag::ENABLED_GDDR) & 0xFF)
+            : 0;
+
+    chip_info.harvesting_masks.eth_harvesting_mask =
+        firmware_telemetry_reader_->is_entry_available(TelemetryTag::ENABLED_ETH)
+            ? (~firmware_telemetry_reader_->read_entry(TelemetryTag::ENABLED_ETH) & 0x3FFF)
+            : 0;
+
+    chip_info.harvesting_masks.pcie_harvesting_mask = 0;
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::PCIE_USAGE)) {
+        uint32_t pcie_usage = firmware_telemetry_reader_->read_entry(TelemetryTag::PCIE_USAGE);
+
+        uint32_t pcie0_usage = pcie_usage & 0x3;
+        uint32_t pcie1_usage = (pcie_usage >> 2) & 0x3;
+
+        const uint32_t pcie_usage_endpoint = 1;
+        chip_info.harvesting_masks.pcie_harvesting_mask = 0;
+        if (pcie0_usage != pcie_usage_endpoint) {
+            chip_info.harvesting_masks.pcie_harvesting_mask |= 0x1;
+        }
+
+        if (pcie1_usage != pcie_usage_endpoint) {
+            chip_info.harvesting_masks.pcie_harvesting_mask |= (1 << 1);
+        }
+    }
+
+    chip_info.harvesting_masks.l2cpu_harvesting_mask = 0;
+    if (firmware_telemetry_reader_->is_entry_available(TelemetryTag::ENABLED_L2CPU)) {
+        chip_info.harvesting_masks.l2cpu_harvesting_mask = CoordinateManager::shuffle_l2cpu_harvesting_mask(
+            tt::ARCH::BLACKHOLE, firmware_telemetry_reader_->read_entry(TelemetryTag::ENABLED_L2CPU));
+    }
+
+    return chip_info;
 }
 
 void BlackholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -14,6 +14,7 @@
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
@@ -471,6 +472,35 @@ bool WormholeDeviceFirmware::get_noc_translation_enabled(NocId noc_id) {
     uint32_t niu_cfg = 0x0;
     read_from_arc_apb(&niu_cfg, ARC_APB_NIU_0_OFFSET + NIU_CFG_0_OFFSET, sizeof(niu_cfg), noc_id);
     return (niu_cfg & (1 << 14)) != 0;
+}
+
+ChipInfo WormholeDeviceFirmware::get_chip_info(NocId noc_id) {
+    if (firmware_info_provider_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, get_io_device_type(), device_id_, tt::ARCH::WORMHOLE_B0);
+    }
+    ChipInfo chip_info;
+
+    chip_info.noc_translation_enabled = get_noc_translation_enabled(noc_id);
+    chip_info.board_id = firmware_info_provider_->get_board_id().value_or(0);
+    chip_info.board_type = get_board_type_from_board_id(chip_info.board_id);
+    chip_info.asic_location = firmware_info_provider_->get_asic_location().value_or(0);
+
+    // Wormhole reports harvesting through an ARC message rather than telemetry, and only the tensix
+    // mask is available.
+    DeviceCommandResult result = send_device_command(
+        wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
+        {0, 0},
+        timeout::ARC_MESSAGE_TIMEOUT,
+        noc_id);
+    if (result.exit_code != 0) {
+        UMD_THROW(
+            error::RuntimeError, fmt::format("Failed to get harvesting masks with exit code: {}", result.exit_code));
+    }
+
+    chip_info.harvesting_masks.tensix_harvesting_mask =
+        CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, result.return_values.at(0));
+
+    return chip_info;
 }
 
 tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -517,19 +517,7 @@ double TTDevice::get_asic_temperature() { return get_firmware_info_provider()->g
 
 uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get_asic_location().value_or(0); }
 
-ChipInfo TTDevice::get_chip_info() {
-    if (model_->get_firmware_info_provider() == nullptr) {
-        UMD_THROW(error::UninitializedDeviceError, *this);
-    }
-    ChipInfo chip_info;
-
-    chip_info.noc_translation_enabled = get_noc_translation_enabled();
-    chip_info.board_id = get_board_id();
-    chip_info.board_type = get_board_type();
-    chip_info.asic_location = get_asic_location();
-
-    return chip_info;
-}
+ChipInfo TTDevice::get_chip_info() { return get_device_firmware()->get_chip_info(); }
 
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq().value_or(0); }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -517,7 +517,11 @@ double TTDevice::get_asic_temperature() { return get_firmware_info_provider()->g
 
 uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get_asic_location().value_or(0); }
 
-ChipInfo TTDevice::get_chip_info() { return get_device_firmware()->get_chip_info(); }
+ChipInfo TTDevice::get_chip_info() {
+    // The overrides this replaces read harvesting through ArcMessenger, which routed on the
+    // thread-selected NOC; keep that.
+    return get_device_firmware()->get_chip_info(get_selected_noc_id());
+}
 
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq().value_or(0); }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -346,18 +346,6 @@ EthTrainingStatus TTSimTTDevice::read_eth_core_training_status(CoreCoord eth_cor
     UMD_THROW(error::RuntimeError, "Reading ETH core training status is not supported in TTSim simulation device.");
 }
 
-ChipInfo TTSimTTDevice::get_chip_info() {
-    // No firmware_info_provider on the simulator; mirror the defaults used inside
-    // TTSimTTDevice::create(). BH SocDescriptor construction rejects an empty eth_harvesting_mask
-    // ("Exactly 2 or 14 ETH cores should be harvested on full Blackhole"), so apply the same 0x120
-    // default here. Keep in sync with create() above.
-    ChipInfo chip_info{};
-    if (get_arch() == tt::ARCH::BLACKHOLE) {
-        chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
-    }
-    return chip_info;
-}
-
 void TTSimTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
     // Configure the outbound iATU the silicon way: iATU register writes via BAR2 (BH writes these
     // directly on real HW at ATU_OFFSET_IN_BH_BAR2=0x1000; WH models its iATU regs at 0x1200). We issue

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -44,26 +44,6 @@ WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDev
     WormholeTTDevice::set_arc_coordinate();
 }
 
-ChipInfo WormholeTTDevice::get_chip_info() {
-    ChipInfo chip_info = TTDevice::get_chip_info();
-
-    DeviceCommandResult result = get_device_firmware()->send_device_command(
-        wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
-        {0, 0},
-        timeout::ARC_MESSAGE_TIMEOUT,
-        get_selected_noc_id());
-
-    if (result.exit_code != 0) {
-        UMD_THROW(
-            error::RuntimeError, fmt::format("Failed to get harvesting masks with exit code: {}", result.exit_code));
-    }
-
-    chip_info.harvesting_masks.tensix_harvesting_mask =
-        CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, result.return_values.at(0));
-
-    return chip_info;
-}
-
 uint32_t WormholeTTDevice::get_clock() {
     // There is one return value from AICLK ARC message.
     DeviceCommandResult result = get_device_firmware()->send_device_command(

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -12,7 +12,7 @@ namespace tt::umd {
 SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
     arch_(arch),
     architecture_impl_(ArchitectureImplementation::create(arch)),
-    device_firmware_(std::make_unique<SimulationDeviceFirmware>()) {}
+    device_firmware_(std::make_unique<SimulationDeviceFirmware>(arch)) {}
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.


### PR DESCRIPTION
## Issue


#2872
Delegate `get_chip_info` to `DeviceFirmware`.

## Description

The full per-arch bodies move into the firmware implementations:

- **Wormhole**: board identity from the info provider plus the tensix harvesting mask via the `ARC_GET_HARVESTING` command (built on #3322).
- **Blackhole**: all five harvesting masks from telemetry, same tag logic as before.
- **Simulation**: `SimulationDeviceFirmware` now takes the architecture from its model and serves the defaults `TTSimTTDevice::get_chip_info()` used to hard-code — including the Blackhole `eth_harvesting_mask = 0x120` that `SocDescriptor` construction requires. (This default silently vanishing was the trap that broke TTSim in the first attempt at this move; here it travels in the same diff as the deletion.)

`TTDevice::get_chip_info()` becomes a non-virtual forwarder; the base composition and the WH/BH/TTSim overrides die. Pre-init calls throw `UninitializedDeviceError`, as before.

One deliberate nuance: `RtlSimulationTTDevice` previously fell through to the base `TTDevice::get_chip_info()`, which threw pre-init; through the shared simulation firmware it now returns the same defaults TTSim gets. Nothing calls it on RTL today.

## List of the changes

- `DeviceFirmware::get_chip_info(NocId)`; implemented in WH, BH, and simulation (arch-aware defaults).
- `SimulationDeviceFirmware` gains an `explicit (tt::ARCH)` constructor; `SimulationTTDeviceModel` passes its arch.
- `TTDevice::get_chip_info` non-virtual forwarder; WH/BH/TTSim overrides and the base composition deleted.

## Testing

`baremetal_tests` 254/254, simulation on and off, no undefined symbols.

## API Changes

None — `TTDevice::get_chip_info()` keeps its signature (now non-virtual). `DeviceFirmware::get_chip_info` added.

Stacked on #3325.

## Adversarial review round

Follow-up: the facade forwards the thread-selected NOC — the deleted overrides sent the harvesting query through ArcMessenger, which routed on it.
