### PR TITLE
[Base API] Delegate get_firmware_noc_coord to DeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -52,8 +52,6 @@ protected:
     // Number of retrain attempts is chosen based on syseng team testing.
     uint32_t get_max_dram_retrain_attempts() const override { return 3; }
 
-    void set_arc_coordinate() override;
-
 private:
     const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::BLACKHOLE);
 

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -69,6 +69,8 @@ public:
 
     ChipInfo get_chip_info(NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id = NocId::DEFAULT_NOC) const override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *
@@ -115,10 +117,6 @@ private:
     // Polls AICLK until it is within tolerance of target_aiclk. Logs and returns if it does not
     // settle, rather than throwing.
     void wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
-
-    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
-    // API it replaces moves here.
-    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
 
     // Thin wrapper that resolves the ARC core for noc_id and hands the access to arc_apb_.
     void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -11,6 +11,7 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/power_state.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -112,6 +113,12 @@ public:
      * state the firmware publishes.
      */
     virtual ChipInfo get_chip_info([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+
+    /**
+     * @brief Returns the NOC coordinate of the management firmware core.
+     * @param noc_id NOC to resolve the coordinate for.
+     */
+    virtual tt_xy_pair get_firmware_noc_coord([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) const = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
@@ -63,6 +63,12 @@ public:
         return chip_info;
     }
 
+    // A simulated device has no management firmware core; callers that need a coordinate get the
+    // origin, matching what TTDevice::get_arc_core() returned for simulation before this existed.
+    tt_xy_pair get_firmware_noc_coord([[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) const override {
+        return tt_xy_pair{};
+    }
+
 private:
     tt::ARCH arch_ = tt::ARCH::Invalid;
 };

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -64,6 +64,8 @@ public:
 
     ChipInfo get_chip_info(NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id = NocId::DEFAULT_NOC) const override;
+
     /**
      * @brief Telemetry published by the management firmware.
      *
@@ -111,10 +113,6 @@ private:
     // settle, rather than throwing.
     void wait_for_aiclk_value(
         uint32_t target_aiclk, NocId noc_id, std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
-
-    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
-    // API it replaces moves here.
-    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
 
     // Thin wrappers that resolve the ARC core for noc_id and hand the access to arc_apb_/arc_csm_.
     void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -535,13 +535,8 @@ protected:
 
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
-    xy_pair arc_core_noc0;
-    xy_pair arc_core_noc1;
-
     void construct_soc_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     void set_soc_descriptor(const SocDescriptor &soc_descriptor);
-
-    virtual void set_arc_coordinate() {}
 
 private:
     // Wires the model's hang detector to this device: routes a timed-out MMIO op to a NOC liveness

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -46,8 +46,6 @@ protected:
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 
-    void set_arc_coordinate() override;
-
 private:
     const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::WORMHOLE_B0);
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -41,9 +41,7 @@
 
 namespace tt::umd {
 
-BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
-    BlackholeTTDevice::set_arc_coordinate();
-}
+BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {}
 
 BlackholeTTDevice::~BlackholeTTDevice() {
     // Turn off iATU for the regions we programmed.  This won't happen if the
@@ -219,11 +217,6 @@ void BlackholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
             error::RuntimeError,
             fmt::format("Failed to retrain DRAM core {} with exit code {}.", dram_channel, ret_code));
     }
-}
-
-void BlackholeTTDevice::set_arc_coordinate() {
-    arc_core_noc0 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/false);
-    arc_core_noc1 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/true);
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -561,10 +561,10 @@ void TTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs
     set_risc_reset_state(core, soft_reset_new_with_staggered_start);
 }
 
-tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
+tt_xy_pair TTDevice::get_arc_core() const { return get_arc_core(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0); }
 
 tt_xy_pair TTDevice::get_arc_core(const NocId noc_id) const {
-    return noc_id == NocId::NOC1 ? arc_core_noc1 : arc_core_noc0;
+    return get_device_firmware()->get_firmware_noc_coord(noc_id);
 }
 
 void TTDevice::noc_multicast_write(

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -40,9 +40,7 @@
 
 namespace tt::umd {
 
-WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {
-    WormholeTTDevice::set_arc_coordinate();
-}
+WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {}
 
 uint32_t WormholeTTDevice::get_clock() {
     // There is one return value from AICLK ARC message.
@@ -200,13 +198,6 @@ EthTrainingStatus WormholeTTDevice::read_eth_core_training_status(CoreCoord eth_
 
 void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported on WormholeTTDevice.");
-}
-
-void WormholeTTDevice::set_arc_coordinate() {
-    arc_core_noc0 = wormhole::ARC_CORES_NOC0[0];
-    arc_core_noc1 = tt_xy_pair(
-        wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
-        wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
## Issue


#2872
Delegate `get_firmware_noc_coord` to `DeviceFirmware`.

## Description

The firmware implementations have resolved the ARC coordinate per NOC in their constructors since #3319 (Wormhole's is fixed; Blackhole's depends on the NOC-translation state, fixed for the device's lifetime). This promotes that private helper to the interface — the only `const` method on it — and deletes the `TTDevice` copy of the same knowledge: the `arc_core_noc0`/`arc_core_noc1` members, `set_arc_coordinate()` and both overrides. `TTDevice::get_arc_core()` forwards.

Simulation returns the origin, matching what the defaulted members used to hold.

## List of the changes

- `DeviceFirmware::get_firmware_noc_coord(NocId) const`; WH/BH promote their private helper, simulation returns `{0, 0}`.
- `TTDevice`: `arc_core_noc0`/`arc_core_noc1`, `set_arc_coordinate()` + WH/BH overrides deleted; `get_arc_core()` forwards to the firmware.

## Testing

`baremetal_tests` 254/254, simulation on and off, no undefined symbols.

## API Changes

None — `TTDevice::get_arc_core()` keeps its signature and values. `DeviceFirmware::get_firmware_noc_coord` added.

Stacked on #3326.

