### PR TITLE
Simulation: expose the simulation API to Python

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -26,6 +26,9 @@
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/simulation_connector.hpp"
+#endif  // TT_UMD_BUILD_SIMULATION
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
@@ -329,6 +332,15 @@ public:
     // the library is built with TT_UMD_BUILD_SIMULATION=ON.
     void register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction);
     void register_sim_fabric_node_id(ChipId chip_id, uint32_t mesh_id, uint32_t fabric_chip_id);
+
+    /**
+     * What simulation this cluster is connected to: whether this process hosts the simulation or
+     * attached to one another process hosts, which simulator sits behind it, and -- for a host that
+     * serves -- the directory and sockets it serves on, including one UMD allocated itself.
+     *
+     * std::nullopt for a cluster that is not a simulation cluster.
+     */
+    std::optional<SimulationConnector::Connection> get_simulation_connection() const;
 #endif  // TT_UMD_BUILD_SIMULATION
 
     //---------- Start and stop the device and tensix cores.
@@ -808,6 +820,11 @@ private:
     std::unique_ptr<RemoteChip> create_simulation_remote_chip(
         ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc);
 
+    // Host simulation Cluster only: describes the simulation this process runs, for
+    // get_simulation_connection(). Called once the chips exist, so the arch is known. The serving
+    // directory and sockets are filled in afterwards by serve_simulation_devices_over_sockets().
+    SimulationConnector::Connection describe_simulation_host(const std::filesystem::path& simulator_directory) const;
+
     // Host simulation Cluster only: exposes each simulation chip's device on its per-chip socket so a
     // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A
     // no-op for a client Cluster. Called once from the constructor after the chips are built.
@@ -832,6 +849,11 @@ private:
     tt::ARCH arch_name;
 
     std::unique_ptr<ClusterDescriptor> cluster_desc;
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Filled during construction for a simulation cluster: by discovery on the client path, by
+    // describe_simulation_host() plus serve_simulation_devices_over_sockets() on the host path.
+    std::optional<SimulationConnector::Connection> simulation_connection_;
+#endif  // TT_UMD_BUILD_SIMULATION
 
     // Options used to construct this cluster, needed to re-run topology discovery on refresh.
     ClusterOptions options_;

--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -9,6 +9,8 @@
 #include <memory>
 #include <vector>
 
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
 namespace tt::umd {
@@ -59,7 +61,36 @@ public:
     enum class Role { Host, Client };
     static Role role_for(const std::filesystem::path& simulator_directory);
 
-    static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);
+    // What a discover() call actually opened: which side of the connection this process ended up
+    // on, and what simulator sits behind it. Reported alongside the devices because none of it is
+    // recoverable afterwards -- re-classifying the path answers only the role, and races a host
+    // that has since exited, while a server directory discover() allocated itself is otherwise
+    // never told to the caller at all.
+    struct Connection {
+        Role role = Role::Host;
+        // The simulator behind the devices: a libttsim .so path or an RTL build directory. As a
+        // host, the build this process opened; as a client, the build the host reports it runs --
+        // empty when talking to a host that predates serving that field.
+        std::filesystem::path simulator;
+        // Which kind of simulator that is, and the architecture it simulates.
+        SimulationBackendType backend = SimulationBackendType::TTSIM;
+        tt::ARCH arch = tt::ARCH::Invalid;
+        // As a host, the directory this process serves its sockets in: empty when serving is off,
+        // and the freshly allocated directory when the caller left server_directory empty. As a
+        // client, the directory it attached to.
+        std::filesystem::path server_directory;
+        // The per-chip sockets in that directory ({chip_id -> socket path}). Empty for a host that
+        // is not serving.
+        std::map<ChipId, std::filesystem::path> sockets;
+    };
+
+    // The devices discover() opened, and the connection it opened them over.
+    struct Result {
+        Connection connection;
+        std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+    };
+
+    static Result discover(const SimulationConnectorOptions& options);
 
     // Claims a fresh directory for one simulation server (the lowest free index) and returns it, so
     // a caller can report the location before it starts serving there (pass it back as

--- a/device/api/umd/device/simulation/simulation_device_identity.hpp
+++ b/device/api/umd/device/simulation/simulation_device_identity.hpp
@@ -18,8 +18,12 @@ namespace tt::umd {
 // topology without a local simulator build.
 
 // Host side: package this device's SocDescriptor into a wire message, so a client can receive it
-// and build its own matching SocDescriptor. backend_type records which simulator the host runs.
-SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type);
+// and build its own matching SocDescriptor. backend_type records which kind of simulator the host
+// runs, simulator_path which build of it -- together they let a client report what it is attached to.
+SimulationServerDeviceInfo describe_device(
+    const SocDescriptor& soc_descriptor,
+    SimulationBackendType backend_type,
+    const std::filesystem::path& simulator_path);
 
 // Client side: build a SocDescriptor from a wire message served by the host.
 SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info);

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -80,6 +80,9 @@ struct SimulationServerDeviceInfo {
     uint32_t eth_harvesting_mask = 0;
     uint32_t l2cpu_harvesting_mask = 0;
     uint32_t pcie_harvesting_mask = 0;
+    // The simulator the host runs (its .so path or RTL build directory), so a client can report
+    // what it is attached to. Empty from a host that predates the field.
+    std::string simulator_path;
 };
 
 // Cluster topology a host serves in reply to a GetClusterDescriptor request; mirrors

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -84,6 +84,11 @@ public:
 
     std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
 
+    // Which simulator this device runs (TTSim vs RTL). Served as part of the device identity so a
+    // remote client can build the matching device class, and reported by Cluster so a caller can
+    // tell what its simulation is backed by.
+    virtual SimulationBackendType backend_type() const = 0;
+
 protected:
     SimulationTTDevice(
         std::unique_ptr<TTDeviceModel> model,
@@ -116,10 +121,6 @@ protected:
     // read_from_device/write_to_device translate the CoreCoord once (via
     // translate_chip_coord_to_translated) before dispatching, so the `core` handed to every hook
     // below is already a TRANSLATED coordinate -- do not translate it again.
-
-    // Which simulator this device runs (TTSim vs RTL). Served as part of the device identity so a
-    // remote client can build the matching device class.
-    virtual SimulationBackendType backend_type() const = 0;
 
     // Direct tile (NOC unicast) access through the backend communicator.
     virtual void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) = 0;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -465,7 +465,9 @@ Cluster::Cluster(ClusterOptions options) {
                 connector_options.simulator_directory = options.simulator_directory;
                 connector_options.num_host_mem_channels =
                     static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(0));
-                tt_devices = SimulationConnector::discover(connector_options);
+                auto discovered = SimulationConnector::discover(connector_options);
+                simulation_connection_ = std::move(discovered.connection);
+                tt_devices = std::move(discovered.devices);
 
                 // Every chip the topology names must have a socket-backed device (single-chip today;
                 // a multichip host will publish one socket per chip). Fail clearly rather than later
@@ -654,9 +656,16 @@ Cluster::Cluster(ClusterOptions options) {
 #endif  // TT_UMD_BUILD_SIMULATION
 
 #ifdef TT_UMD_BUILD_SIMULATION
-    if (options.chip_type == ChipType::SIMULATION && options.serve_simulation_devices_over_sockets) {
-        serve_simulation_devices_over_sockets(
-            options.simulator_directory, options.simulator_server_directory, options.simulation_shutdown_handler);
+    if (options.chip_type == ChipType::SIMULATION) {
+        // The client path recorded its connection during discovery, so reaching here without one
+        // means this process runs the simulation itself.
+        if (!simulation_connection_.has_value()) {
+            simulation_connection_ = describe_simulation_host(options.simulator_directory);
+        }
+        if (options.serve_simulation_devices_over_sockets) {
+            serve_simulation_devices_over_sockets(
+                options.simulator_directory, options.simulator_server_directory, options.simulation_shutdown_handler);
+        }
     }
 #endif  // TT_UMD_BUILD_SIMULATION
 
@@ -668,6 +677,28 @@ Cluster::Cluster(ClusterOptions options) {
 }
 
 #ifdef TT_UMD_BUILD_SIMULATION
+std::optional<SimulationConnector::Connection> Cluster::get_simulation_connection() const {
+    return simulation_connection_;
+}
+
+SimulationConnector::Connection Cluster::describe_simulation_host(
+    const std::filesystem::path& simulator_directory) const {
+    SimulationConnector::Connection connection;
+    connection.role = SimulationConnector::Role::Host;
+    connection.simulator = simulator_directory;
+    // Take the backend and arch from a device rather than re-deriving them from the path, so this
+    // reports what was actually built. server_directory and sockets stay empty until (and unless)
+    // serve_simulation_devices_over_sockets() fills them.
+    for (const auto& [chip_id, chip] : chips_) {
+        if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
+            connection.backend = sim_device->backend_type();
+            connection.arch = sim_device->get_soc_descriptor().arch;
+            break;
+        }
+    }
+    return connection;
+}
+
 void Cluster::serve_simulation_devices_over_sockets(
     const std::filesystem::path& simulator_directory,
     const std::filesystem::path& simulator_server_directory,
@@ -688,11 +719,21 @@ void Cluster::serve_simulation_devices_over_sockets(
                                                        ? SimulationServerSocket::allocate_server_directory()
                                                        : simulator_server_directory;
     log_info(LogUMD, "Simulation host serving sockets in {}", server_directory.string());
+    // Report where this host serves. When the caller left simulator_server_directory empty the
+    // directory was allocated just above, so this is the only way it learns of it -- recorded here
+    // rather than per chip, so a host that turns out to have no simulation devices still reports
+    // the directory it claimed instead of reading as "not serving".
+    if (simulation_connection_.has_value()) {
+        simulation_connection_->server_directory = server_directory;
+    }
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
-            sim_device->adopt_socket(
-                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id)),
-                shutdown_handler);
+            const std::filesystem::path socket_path =
+                SimulationServerSocket::default_socket_path(server_directory, chip_id);
+            sim_device->adopt_socket(SimulationServerSocket::create(socket_path), shutdown_handler);
+            if (simulation_connection_.has_value()) {
+                simulation_connection_->sockets.emplace(chip_id, socket_path);
+            }
         }
     }
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -689,12 +689,26 @@ SimulationConnector::Connection Cluster::describe_simulation_host(
     // Take the backend and arch from a device rather than re-deriving them from the path, so this
     // reports what was actually built. server_directory and sockets stay empty until (and unless)
     // serve_simulation_devices_over_sockets() fills them.
+    bool described = false;
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             connection.backend = sim_device->backend_type();
             connection.arch = sim_device->get_soc_descriptor().arch;
+            described = true;
             break;
         }
+    }
+    // A simulation Cluster with no simulation device is degenerate but legal -- an empty
+    // target_devices with no cluster_descriptor.yaml beside the simulator yields zero chips -- so
+    // warn instead of asserting. Say so rather than reporting the defaults (TTSim/Invalid) as if
+    // they had been read off a device, which is also how a future regression that describes the
+    // host before the chips exist would surface.
+    if (!described) {
+        log_warning(
+            LogUMD,
+            "Simulation host {} has no simulation device to describe; reporting an unknown backend and "
+            "architecture.",
+            simulator_directory.string());
     }
     return connection;
 }
@@ -713,6 +727,13 @@ void Cluster::serve_simulation_devices_over_sockets(
     if (SimulationConnector::role_for(simulator_directory) != SimulationConnector::Role::Host) {
         return;
     }
+    // The constructor describes the host connection before it starts serving, so there is always
+    // one to record into here. Asserted rather than guarded, so a future reordering fails loudly
+    // instead of quietly serving sockets it never reports.
+    UMD_ASSERT(
+        simulation_connection_.has_value(),
+        error::RuntimeError,
+        "Simulation host started serving sockets before its connection was described.");
     // Serve in a dedicated directory -- the caller's, or a fresh one -- so two hosts on the same
     // machine never collide even when they serve the same chip id.
     const std::filesystem::path server_directory = simulator_server_directory.empty()
@@ -723,17 +744,13 @@ void Cluster::serve_simulation_devices_over_sockets(
     // directory was allocated just above, so this is the only way it learns of it -- recorded here
     // rather than per chip, so a host that turns out to have no simulation devices still reports
     // the directory it claimed instead of reading as "not serving".
-    if (simulation_connection_.has_value()) {
-        simulation_connection_->server_directory = server_directory;
-    }
+    simulation_connection_->server_directory = server_directory;
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             const std::filesystem::path socket_path =
                 SimulationServerSocket::default_socket_path(server_directory, chip_id);
             sim_device->adopt_socket(SimulationServerSocket::create(socket_path), shutdown_handler);
-            if (simulation_connection_.has_value()) {
-                simulation_connection_->sockets.emplace(chip_id, socket_path);
-            }
+            simulation_connection_->sockets.emplace(chip_id, socket_path);
         }
     }
 }

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -124,8 +124,9 @@ std::vector<SimulationServerInfo> SimulationConnector::list_servers() {
     return servers;
 }
 
-std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
-    std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+SimulationConnector::Result SimulationConnector::discover(const SimulationConnectorOptions& options) {
+    Result result;
+    std::map<ChipId, std::unique_ptr<TTDevice>>& devices = result.devices;
     const std::filesystem::path& simulator_path = options.simulator_directory;
 
     const Classification classification = classify(simulator_path);
@@ -142,7 +143,40 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
                 // pick the device class, and passes the fetched identity into create_client so it is
                 // not fetched again.
                 const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
+                // A server directory is claimed atomically by one host (see
+                // allocate_server_directory), so every socket in it is served by one process
+                // running one simulator: the first socket that answers describes the whole
+                // directory. Warn rather than silently describing only the first if that ever
+                // fails to hold -- a hand-assembled directory mixing two servers' sockets is the
+                // only way it can, and it should not pass unnoticed.
+                if (result.devices.empty()) {
+                    result.connection.simulator = info.simulator_path;
+                    result.connection.backend = info.backend_type;
+                    result.connection.arch = static_cast<tt::ARCH>(info.arch);
+                } else if (
+                    info.simulator_path != result.connection.simulator.string() ||
+                    info.backend_type != result.connection.backend ||
+                    static_cast<tt::ARCH>(info.arch) != result.connection.arch) {
+                    log_warning(
+                        LogUMD,
+                        "Simulation socket {} (chip {}) reports a different simulation than the rest of {}: "
+                        "{} ({}/{}) instead of {} ({}/{}). Reporting the first; the directory is serving more "
+                        "than one host.",
+                        socket_file.string(),
+                        chip_id,
+                        simulator_path.string(),
+                        info.simulator_path,
+                        arch_to_str(static_cast<tt::ARCH>(info.arch)),
+                        info.backend_type == SimulationBackendType::TTSIM ? "ttsim" : "rtl",
+                        result.connection.simulator.string(),
+                        arch_to_str(result.connection.arch),
+                        result.connection.backend == SimulationBackendType::TTSIM ? "ttsim" : "rtl");
+                }
                 devices.emplace(chip_id, make_client_device(chip_id, std::move(client), info));
+                // Only once the device is in: make_client_device() throws on a backend kind this
+                // build doesn't know, and the catch below skips the chip. Recording the socket
+                // first would leave connection.sockets naming a chip that has no device.
+                result.connection.sockets.emplace(chip_id, socket_file);
             } catch (const std::exception& e) {
                 log_warning(
                     LogUMD, "Skipping simulation socket {} (chip {}): {}", socket_file.string(), chip_id, e.what());
@@ -154,7 +188,9 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
             !devices.empty(),
             error::RuntimeError,
             fmt::format("No reachable simulation hosts among the sockets in {}", simulator_path.string()));
-        return devices;
+        result.connection.role = Role::Client;
+        result.connection.server_directory = simulator_path;
+        return result;
     }
 
     // Host: single chip for now. Serving over sockets is opt-in: by default the host device stays
@@ -167,12 +203,24 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
         const std::filesystem::path server_directory = options.server_directory.empty()
                                                            ? SimulationServerSocket::allocate_server_directory()
                                                            : options.server_directory;
-        socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id));
+        const std::filesystem::path socket_path =
+            SimulationServerSocket::default_socket_path(server_directory, chip_id);
+        socket = SimulationServerSocket::create(socket_path);
+        // Report where this host ended up serving -- the allocated directory is otherwise known
+        // only in here, so a caller that did not pre-allocate one could never name it.
+        result.connection.server_directory = server_directory;
+        result.connection.sockets.emplace(chip_id, socket_path);
     }
     devices.emplace(
         chip_id,
         make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));
-    return devices;
+
+    result.connection.role = Role::Host;
+    result.connection.simulator = simulator_path;
+    result.connection.backend =
+        classification.kind == PathKind::HOST_TTSIM ? SimulationBackendType::TTSIM : SimulationBackendType::RTL;
+    result.connection.arch = devices.at(chip_id)->get_soc_descriptor().arch;
+    return result;
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -58,7 +58,10 @@ ScopedTempFile write_temp_file(const std::string& contents, const char* suffix) 
 
 }  // namespace
 
-SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type) {
+SimulationServerDeviceInfo describe_device(
+    const SocDescriptor& soc_descriptor,
+    SimulationBackendType backend_type,
+    const std::filesystem::path& simulator_path) {
     const std::string& yaml_path = soc_descriptor.get_arch_descriptor().get_device_descriptor_file_path();
     UMD_ASSERT(
         !yaml_path.empty(),
@@ -81,6 +84,7 @@ SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, 
     info.eth_harvesting_mask = soc_descriptor.harvesting_masks.eth_harvesting_mask;
     info.l2cpu_harvesting_mask = soc_descriptor.harvesting_masks.l2cpu_harvesting_mask;
     info.pcie_harvesting_mask = soc_descriptor.harvesting_masks.pcie_harvesting_mask;
+    info.simulator_path = simulator_path.string();
     return info;
 }
 

--- a/device/simulation/simulation_server_protocol.cpp
+++ b/device/simulation/simulation_server_protocol.cpp
@@ -58,6 +58,11 @@ std::vector<uint8_t> encode(const SimulationServerResponse& response) {
 std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
     flatbuffers::FlatBufferBuilder builder;
     auto yaml = builder.CreateString(device_info.soc_descriptor_yaml);
+    // Left absent when empty rather than written as an empty string, so a message carrying no
+    // simulator path is indistinguishable from one produced before the field existed. decode()
+    // reads both as empty.
+    auto simulator_path = device_info.simulator_path.empty() ? flatbuffers::Offset<flatbuffers::String>()
+                                                             : builder.CreateString(device_info.simulator_path);
     builder.Finish(wire::CreateSimulationServerDeviceInfo(
         builder,
         device_info.status,
@@ -69,7 +74,8 @@ std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
         device_info.dram_harvesting_mask,
         device_info.eth_harvesting_mask,
         device_info.l2cpu_harvesting_mask,
-        device_info.pcie_harvesting_mask));
+        device_info.pcie_harvesting_mask,
+        simulator_path));
     return to_bytes(builder);
 }
 
@@ -119,6 +125,9 @@ SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size) 
     info.eth_harvesting_mask = fb->eth_harvesting_mask();
     info.l2cpu_harvesting_mask = fb->l2cpu_harvesting_mask();
     info.pcie_harvesting_mask = fb->pcie_harvesting_mask();
+    if (fb->simulator_path() != nullptr) {
+        info.simulator_path = fb->simulator_path()->str();
+    }
     return info;
 }
 

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -55,7 +55,8 @@ table SimulationServerResponse {
 
 // Device identity served in response to a GET_DEVICE_INFO request. Carries everything a client
 // needs to build a SocDescriptor matching the host's without reading a local simulator build:
-// the arch, the full SoC-descriptor YAML text, and the per-chip harvesting masks.
+// the arch, the full SoC-descriptor YAML text, and the per-chip harvesting masks. It also names
+// the simulator the host runs, so a client can report what it is attached to.
 table SimulationServerDeviceInfo {
     status : int32;
     arch : int32;
@@ -67,6 +68,9 @@ table SimulationServerDeviceInfo {
     eth_harvesting_mask : uint32;
     l2cpu_harvesting_mask : uint32;
     pcie_harvesting_mask : uint32;
+    // The simulator the host runs: its libttsim .so path, or its RTL build directory. Appended last
+    // so a host built before this field still decodes -- the client then reads it as empty.
+    simulator_path : string;
 }
 
 // Cluster topology served in response to a GET_CLUSTER_DESCRIPTOR request. `yaml` is the host's

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     // read/write skeleton below (SimulationServerResponse), so it is handled up front.
     if (request.command == SimulationServerCommand::GET_DEVICE_INFO) {
         try {
-            return encode(describe_device(get_soc_descriptor(), backend_type()));
+            return encode(describe_device(get_soc_descriptor(), backend_type(), simulator_directory_));
         } catch (const std::exception& e) {
             log_warning(tt::LogUMD, "Simulation host failed to serve device info: {}", e.what());
             SimulationServerDeviceInfo info;

--- a/docs/SIMULATION_SERVER.md
+++ b/docs/SIMULATION_SERVER.md
@@ -204,13 +204,19 @@ using namespace tt::umd;
 
 SimulationConnectorOptions options;
 options.simulator_directory = "/tmp/tt-umd-sim-server-0";  // same server directory
-std::map<ChipId, std::unique_ptr<TTDevice>> devices = SimulationConnector::discover(options);
+SimulationConnector::Result result = SimulationConnector::discover(options);
 
 // Each device is a client already attached to the running host.
-for (auto& [chip_id, device] : devices) {
+for (auto& [chip_id, device] : result.devices) {
     // use `device` directly, or hand it to higher-level UMD code
 }
 ```
+
+`result.connection` says what you actually opened: the role this process took, the simulator behind
+it (as a host, the build you named; as a client, the one the host reports it runs), its backend and
+arch, and -- for a host that serves -- the directory and per-chip sockets it serves on. That last
+part matters when you leave `server_directory` empty: UMD allocates one, and this is the only place
+it tells you which. `Cluster::get_simulation_connection()` reports the same thing for a cluster.
 
 In both cases the target is the server directory, and pointing at it is what makes your process a
 client — there is no separate "connect" call.

--- a/docs/SIMULATION_SERVER.md
+++ b/docs/SIMULATION_SERVER.md
@@ -115,7 +115,7 @@ flowchart TB
      ./build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.RegReadWrite"
    ```
 
-   There is no Python entry point today.
+   Python works the same way — see [From Python](#from-python) below.
 
 4. **Stop the server.**
 
@@ -158,7 +158,7 @@ sequenceDiagram
 ## Connecting from code
 
 Attaching to a running server is the same code path as opening real hardware — you point UMD at that
-server's socket directory instead of picking a role. There are two levels you can enter at.
+server's socket directory instead of picking a role. There are a few levels you can enter at.
 
 ### At the Cluster level
 
@@ -218,7 +218,34 @@ arch, and -- for a host that serves -- the directory and per-chip sockets it ser
 part matters when you leave `server_directory` empty: UMD allocates one, and this is the only place
 it tells you which. `Cluster::get_simulation_connection()` reports the same thing for a cluster.
 
-In both cases the target is the server directory, and pointing at it is what makes your process a
+### From Python
+
+`SimulationConnector` is bound in the `tt_umd` wheel whenever UMD is built with simulation support,
+and behaves exactly as it does in C++ — including deciding the role from the path.
+
+```python
+import tt_umd
+
+# What is running on this machine, without connecting to any of it.
+for server in tt_umd.SimulationConnector.list_servers():
+    print(server.index, server.directory, server.sockets)
+
+options = tt_umd.SimulationConnectorOptions()
+options.simulator_directory = "/tmp/tt-umd-sim-server-0"  # a server directory -> client
+assert (
+    tt_umd.SimulationConnector.role_for(options.simulator_directory)
+    == tt_umd.SimulationConnector.Role.CLIENT
+)
+
+connection, devices = tt_umd.SimulationConnector.discover(options)  # devices: {chip_id: TTDevice}
+print(connection.role, connection.simulator, connection.arch, connection.server_directory)
+```
+
+To host instead, name a simulator rather than a server directory, and set
+`options.serve_over_sockets = True` to publish it. `SimulationConnector.allocate_server_directory()`
+claims a directory up front when you want to report where you are about to serve.
+
+In all cases the target is the server directory, and pointing at it is what makes your process a
 client — there is no separate "connect" call.
 
 ## Where things live

--- a/nanobind/CMakeLists.txt
+++ b/nanobind/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(
 )
 
 # Define the Python interface target
-nanobind_add_module(nanobind_tt_umd MODULE py_api_module.cpp py_api_basic_types.cpp py_api_error.cpp py_api_topology_discovery.cpp py_api_telemetry.cpp py_api_tt_device.cpp py_api_cluster.cpp py_api_warm_reset.cpp py_api_soc_descriptor.cpp py_api_logging.cpp)
+nanobind_add_module(nanobind_tt_umd MODULE py_api_module.cpp py_api_basic_types.cpp py_api_error.cpp py_api_topology_discovery.cpp py_api_telemetry.cpp py_api_tt_device.cpp py_api_cluster.cpp py_api_warm_reset.cpp py_api_soc_descriptor.cpp py_api_logging.cpp py_api_simulation.cpp)
 if(TT_UMD_BUILD_SIMULATION)
     target_compile_definitions(nanobind_tt_umd PRIVATE TT_UMD_BUILD_SIMULATION)
 endif()

--- a/nanobind/py_api_cluster.cpp
+++ b/nanobind/py_api_cluster.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/set.h>
 
 #include "umd/device/cluster.hpp"
@@ -23,5 +25,14 @@ void bind_cluster(nb::module_ &m) {
     nb::class_<Cluster>(m, "Cluster")
         .def(nb::init<>(), release_gil())
         .def("get_target_device_ids", &Cluster::get_target_device_ids, release_gil())
-        .def("get_clocks", &Cluster::get_clocks, release_gil());
+        .def("get_clocks", &Cluster::get_clocks, release_gil())
+#ifdef TT_UMD_BUILD_SIMULATION
+        .def(
+            "get_simulation_connection",
+            &Cluster::get_simulation_connection,
+            release_gil(),
+            "What simulation this cluster is connected to (role, simulator, server directory), or None when it is "
+            "not a simulation cluster.")
+#endif
+        ;
 }

--- a/nanobind/py_api_module.cpp
+++ b/nanobind/py_api_module.cpp
@@ -16,6 +16,7 @@ void bind_warm_reset(nb::module_ &m);
 void bind_soc_descriptor(nb::module_ &m);
 void bind_logging(nb::module_ &m);
 void bind_error(nb::module_ &m);
+void bind_simulation(nb::module_ &m);
 
 // Main module entry point.
 NB_MODULE(tt_umd, m) {
@@ -28,4 +29,5 @@ NB_MODULE(tt_umd, m) {
     bind_soc_descriptor(m);
     bind_logging(m);
     bind_error(m);
+    bind_simulation(m);
 }

--- a/nanobind/py_api_simulation.cpp
+++ b/nanobind/py_api_simulation.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/format.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/vector.h>
+
+#include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/simulation/simulation_connector.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+
+namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
+
+using namespace tt::umd;
+
+#ifdef TT_UMD_BUILD_SIMULATION
+
+void bind_simulation(nb::module_ &m) {
+    nb::class_<SimulationConnectorOptions>(m, "SimulationConnectorOptions")
+        .def(nb::init<>())
+        .def_rw(
+            "simulator_directory",
+            &SimulationConnectorOptions::simulator_directory,
+            "The simulator build to host (a TTSim .so or an RTL simulator directory), or the directory a running "
+            "server keeps its sockets in to attach as a client.")
+        .def_rw(
+            "serve_over_sockets",
+            &SimulationConnectorOptions::serve_over_sockets,
+            "Host path only: publish each simulated chip over a per-chip socket so other processes can attach as "
+            "clients. Off by default, so discover() yields private in-process devices.")
+        .def_rw(
+            "server_directory",
+            &SimulationConnectorOptions::server_directory,
+            "Host path only: the directory to serve the per-chip sockets in. Empty means allocate a fresh one.")
+        .def_rw(
+            "cluster_descriptor",
+            &SimulationConnectorOptions::cluster_descriptor,
+            "Connectivity/topology used to configure the simulator on the host path. Optional; a client takes the "
+            "topology from the host instead.")
+        .def_rw("num_host_mem_channels", &SimulationConnectorOptions::num_host_mem_channels);
+
+    nb::class_<SimulationServerInfo>(m, "SimulationServerInfo")
+        .def_ro("index", &SimulationServerInfo::index, "The server's index, as used by the sim_server tool.")
+        .def_ro("directory", &SimulationServerInfo::directory, "The directory this server serves its sockets in.")
+        .def_ro(
+            "sockets", &SimulationServerInfo::sockets, "Per-chip sockets present in the directory: chip id -> path.")
+        .def("__repr__", [](const SimulationServerInfo &self) {
+            return fmt::format(
+                "SimulationServerInfo(index={}, directory='{}', chips={})",
+                self.index,
+                self.directory.string(),
+                self.sockets.size());
+        });
+
+    nb::enum_<SimulationBackendType>(m, "SimulationBackendType")
+        .value("TTSIM", SimulationBackendType::TTSIM, "The functional simulator (a libttsim .so).")
+        .value("RTL", SimulationBackendType::RTL, "An RTL simulator build.");
+
+    nb::class_<SimulationConnector> simulation_connector(
+        m,
+        "SimulationConnector",
+        "Entry point for opening simulated devices, mirroring silicon TopologyDiscovery. The role is decided purely "
+        "from what simulator_directory points at.");
+
+    nb::enum_<SimulationConnector::Role>(simulation_connector, "Role")
+        .value("HOST", SimulationConnector::Role::Host, "This process runs the simulation.")
+        .value("CLIENT", SimulationConnector::Role::Client, "This process attaches to a simulation another host runs.");
+
+    nb::class_<SimulationConnector::Connection>(
+        simulation_connector,
+        "Connection",
+        "What a discover() call opened: the role this process took and the simulator behind it.")
+        .def_ro(
+            "role",
+            &SimulationConnector::Connection::role,
+            "Whether this process hosts the simulation or attached to one.")
+        .def_ro(
+            "simulator",
+            &SimulationConnector::Connection::simulator,
+            "The simulator behind the devices: a libttsim .so path or an RTL build directory. Empty when attached to "
+            "a host that predates reporting it.")
+        .def_ro("backend", &SimulationConnector::Connection::backend, "Which kind of simulator that is.")
+        .def_ro("arch", &SimulationConnector::Connection::arch, "The architecture it simulates.")
+        .def_ro(
+            "server_directory",
+            &SimulationConnector::Connection::server_directory,
+            "As a host, the directory it serves its sockets in -- empty when serving is off. As a client, the "
+            "directory it attached to.")
+        .def_ro(
+            "sockets",
+            &SimulationConnector::Connection::sockets,
+            "The per-chip sockets in that directory: chip id -> path.")
+        .def("__repr__", [](const SimulationConnector::Connection &self) {
+            return fmt::format(
+                "SimulationConnection(role={}, simulator='{}', arch={}, server_directory='{}')",
+                self.role == SimulationConnector::Role::Host ? "HOST" : "CLIENT",
+                self.simulator.string(),
+                tt::arch_to_str(self.arch),
+                self.server_directory.string());
+        });
+
+    simulation_connector
+        .def_static(
+            "role_for",
+            &SimulationConnector::role_for,
+            nb::arg("simulator_directory"),
+            release_gil(),
+            "Host or client, decided from the path: a directory holding live simulation sockets means a host already "
+            "serves there, so attach to it; anything else is a simulator build to host.")
+        .def_static(
+            "discover",
+            [](const SimulationConnectorOptions &options) {
+                SimulationConnector::Result result = SimulationConnector::discover(options);
+                return std::make_pair(std::move(result.connection), std::move(result.devices));
+            },
+            nb::arg("options"),
+            release_gil(),
+            "Opens the simulated devices for these options. Returns (connection, {chip_id: TTDevice}) -- the "
+            "connection says which role this process took and what simulator is behind it.")
+        .def_static(
+            "allocate_server_directory",
+            &SimulationConnector::allocate_server_directory,
+            release_gil(),
+            "Claims a fresh directory for one simulation server (the lowest free index) and returns it, so a caller "
+            "can report the location before it starts serving there. The claim is atomic.")
+        .def_static(
+            "list_servers",
+            &SimulationConnector::list_servers,
+            release_gil(),
+            "The simulation servers currently open on this machine, ordered by index. Does not connect to them.");
+}
+
+#else
+
+// Simulation support is not built; the module exposes no simulation API.
+void bind_simulation(nb::module_ &) {}
+
+#endif

--- a/nanobind/tests/test_py_simulation_connector.py
+++ b/nanobind/tests/test_py_simulation_connector.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import tt_umd
+
+# The simulation bindings only exist when UMD is built with TT_UMD_BUILD_SIMULATION.
+SIMULATION_BUILT = hasattr(tt_umd, "SimulationConnector")
+
+# A host's per-chip sockets are named tt-umd-sim-<chip_id>.sock; a directory holding one is what
+# makes UMD classify a path as a live server to attach to.
+SOCKET_NAME = "tt-umd-sim-0.sock"
+
+
+@unittest.skipUnless(SIMULATION_BUILT, "UMD was built without simulation support")
+class TestSimulationConnector(unittest.TestCase):
+    def test_role_for_directory_without_sockets_is_host(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(
+                tt_umd.SimulationConnector.role_for(directory),
+                tt_umd.SimulationConnector.Role.HOST,
+            )
+
+    def test_allocate_server_directory_claims_distinct_directories(self):
+        first = tt_umd.SimulationConnector.allocate_server_directory()
+        try:
+            second = tt_umd.SimulationConnector.allocate_server_directory()
+            try:
+                self.assertTrue(first.is_dir())
+                self.assertTrue(second.is_dir())
+                self.assertNotEqual(first, second)
+            finally:
+                shutil.rmtree(second, ignore_errors=True)
+        finally:
+            shutil.rmtree(first, ignore_errors=True)
+
+    def test_list_servers_reports_an_allocated_directory(self):
+        directory = tt_umd.SimulationConnector.allocate_server_directory()
+        try:
+            servers = tt_umd.SimulationConnector.list_servers()
+            listed = [server for server in servers if server.directory == directory]
+            self.assertEqual(len(listed), 1, f"{directory} missing from {servers}")
+            # Nothing serves in it yet, so it has no per-chip sockets.
+            self.assertEqual(listed[0].sockets, {})
+            self.assertGreaterEqual(listed[0].index, 0)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipUnless(SIMULATION_BUILT, "UMD was built without simulation support")
+@unittest.skipUnless(os.environ.get("TT_UMD_SIMULATOR"), "TT_UMD_SIMULATOR is not set")
+class TestSimulationConnectorAgainstSimulator(unittest.TestCase):
+    """Mirrors tests/api/test_simulation_connector.cpp; needs a real simulator build."""
+
+    def test_host_serves_a_socket_a_client_can_attach_to(self):
+        server_directory = tt_umd.SimulationConnector.allocate_server_directory()
+        try:
+            host_options = tt_umd.SimulationConnectorOptions()
+            host_options.simulator_directory = os.environ["TT_UMD_SIMULATOR"]
+            host_options.serve_over_sockets = True
+            host_options.server_directory = server_directory
+
+            self.assertEqual(
+                tt_umd.SimulationConnector.role_for(host_options.simulator_directory),
+                tt_umd.SimulationConnector.Role.HOST,
+            )
+
+            host_connection, host_devices = tt_umd.SimulationConnector.discover(
+                host_options
+            )
+            self.assertEqual(len(host_devices), 1)
+            self.assertTrue((server_directory / SOCKET_NAME).exists())
+
+            # The host reports what it opened and where it serves.
+            self.assertEqual(host_connection.role, tt_umd.SimulationConnector.Role.HOST)
+            self.assertEqual(
+                host_connection.simulator, Path(os.environ["TT_UMD_SIMULATOR"])
+            )
+            self.assertEqual(
+                host_connection.backend, tt_umd.SimulationBackendType.TTSIM
+            )
+            self.assertEqual(host_connection.server_directory, server_directory)
+            self.assertEqual(
+                host_connection.sockets, {0: server_directory / SOCKET_NAME}
+            )
+
+            # The server directory now holds a live socket, so pointing at it makes us a client.
+            self.assertEqual(
+                tt_umd.SimulationConnector.role_for(server_directory),
+                tt_umd.SimulationConnector.Role.CLIENT,
+            )
+
+            client_options = tt_umd.SimulationConnectorOptions()
+            client_options.simulator_directory = server_directory
+            client_connection, client_devices = tt_umd.SimulationConnector.discover(
+                client_options
+            )
+            self.assertEqual(sorted(client_devices), sorted(host_devices))
+
+            # The client builds the device class matching the backend the host reports, so the
+            # concrete type is visible from Python and not just the TTDevice base.
+            expected_type = (
+                tt_umd.TTSimTTDevice
+                if host_connection.backend == tt_umd.SimulationBackendType.TTSIM
+                else tt_umd.RtlSimulationTTDevice
+            )
+            self.assertIsInstance(host_devices[0], expected_type)
+            self.assertIsInstance(client_devices[0], expected_type)
+
+            # The client reports the directory it attached to, and the simulator the host
+            # named over the wire.
+            self.assertEqual(
+                client_connection.role, tt_umd.SimulationConnector.Role.CLIENT
+            )
+            self.assertEqual(client_connection.server_directory, server_directory)
+            self.assertEqual(client_connection.simulator, host_connection.simulator)
+            self.assertEqual(client_connection.backend, host_connection.backend)
+            self.assertEqual(client_connection.arch, host_connection.arch)
+
+            # What the client writes over the socket, the host sees directly.
+            client = client_devices[0]
+            soc = client.get_soc_descriptor()
+            tensix = soc.get_cores(tt_umd.CoreType.TENSIX)[0]
+            core = soc.translate_chip_coord_to_translated(tensix)
+            client.noc_write32(core.x, core.y, 0x1000, 0xDEADBEEF)
+            self.assertEqual(client.noc_read32(core.x, core.y, 0x1000), 0xDEADBEEF)
+            self.assertEqual(
+                host_devices[0].noc_read32(core.x, core.y, 0x1000), 0xDEADBEEF
+            )
+        finally:
+            shutil.rmtree(server_directory, ignore_errors=True)
+
+    def test_host_learns_the_server_directory_umd_allocated(self):
+        options = tt_umd.SimulationConnectorOptions()
+        options.simulator_directory = os.environ["TT_UMD_SIMULATOR"]
+        options.serve_over_sockets = True
+        # server_directory left empty: UMD allocates one and must report it back.
+
+        connection, _devices = tt_umd.SimulationConnector.discover(options)
+        try:
+            self.assertNotEqual(connection.server_directory, Path(""))
+            self.assertTrue(connection.server_directory.is_dir())
+            self.assertEqual(connection.sockets[0].parent, connection.server_directory)
+        finally:
+            shutil.rmtree(connection.server_directory, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -41,7 +41,7 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
     options.server_directory = server_directory;
 
     {
-        auto devices = SimulationConnector::discover(options);
+        auto devices = SimulationConnector::discover(options).devices;
         ASSERT_EQ(devices.size(), 1u);
         ASSERT_NE(devices.at(0), nullptr);
         EXPECT_TRUE(std::filesystem::exists(socket));  // host exposed it
@@ -70,7 +70,7 @@ TEST(SimulationConnector, CreatesPrivateHostDeviceWhenNotServing) {
     // serve_over_sockets defaults to false: a private in-process host, no socket published.
     options.server_directory = server_directory;
 
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     EXPECT_NE(devices.at(0), nullptr);              // a usable host device...
     EXPECT_FALSE(std::filesystem::exists(socket));  // ...that published no socket
@@ -105,7 +105,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     options.simulator_directory = simulator_path;
     options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
     ASSERT_NE(host, nullptr);
@@ -166,7 +166,7 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     options.simulator_directory = simulator_path;
     options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
     ASSERT_NE(host, nullptr);
@@ -210,14 +210,14 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
 
     // The .so path hosts and publishes its per-chip socket; pointing discovery at that server's
     // directory takes the client path, attaching one client device per socket.
-    auto host_devices = SimulationConnector::discover(host_options);
+    auto host_devices = SimulationConnector::discover(host_options).devices;
     ASSERT_EQ(host_devices.size(), 1u);
     TTDevice* host = host_devices.at(0).get();
     ASSERT_NE(host, nullptr);
 
     SimulationConnectorOptions client_options;
     client_options.simulator_directory = server_directory;
-    auto client_devices = SimulationConnector::discover(client_options);
+    auto client_devices = SimulationConnector::discover(client_options).devices;
     ASSERT_EQ(client_devices.count(0), 1u);
     TTDevice* client = client_devices.at(0).get();
     ASSERT_NE(client, nullptr);
@@ -277,6 +277,24 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     // The client reconstructed the same chips the host serves.
     EXPECT_EQ(client_cluster.get_target_device_ids(), host_cluster.get_target_device_ids());
 
+    // Each Cluster can say what it is connected to: the host names the simulator it runs and the
+    // directory it serves in; the client names the directory it attached to and the simulator the
+    // host reported over the wire.
+    const auto host_connection = host_cluster.get_simulation_connection();
+    ASSERT_TRUE(host_connection.has_value());
+    EXPECT_EQ(host_connection->role, SimulationConnector::Role::Host);
+    EXPECT_EQ(host_connection->simulator, std::filesystem::path(simulator_path));
+    EXPECT_EQ(host_connection->server_directory, server_directory);
+    EXPECT_FALSE(host_connection->sockets.empty());
+
+    const auto client_connection = client_cluster.get_simulation_connection();
+    ASSERT_TRUE(client_connection.has_value());
+    EXPECT_EQ(client_connection->role, SimulationConnector::Role::Client);
+    EXPECT_EQ(client_connection->server_directory, server_directory);
+    EXPECT_EQ(client_connection->simulator, std::filesystem::path(simulator_path));
+    EXPECT_EQ(client_connection->backend, host_connection->backend);
+    EXPECT_EQ(client_connection->arch, host_connection->arch);
+
     const tt::ChipId chip = 0;
     const SocDescriptor& soc = host_cluster.get_soc_descriptor(chip);
     const CoreCoord tensix = soc.get_cores(tt::CoreType::TENSIX).at(0);
@@ -288,4 +306,106 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     std::vector<uint8_t> readback(pattern.size());
     client_cluster.read_from_device(readback.data(), chip, tensix, addr, pattern.size());
     EXPECT_EQ(readback, pattern);
+}
+
+// discover() reports the connection it opened, not just the devices: as a serving host, the
+// simulator it runs, the backend and arch behind it, and the directory and per-chip sockets it
+// serves on. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsServingHostConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;
+    options.server_directory = server_directory;
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+    const SimulationConnector::Connection& connection = result.connection;
+
+    EXPECT_EQ(connection.role, SimulationConnector::Role::Host);
+    EXPECT_EQ(connection.simulator, std::filesystem::path(simulator_path));
+    const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
+    EXPECT_EQ(connection.backend, is_ttsim ? SimulationBackendType::TTSIM : SimulationBackendType::RTL);
+    EXPECT_EQ(connection.arch, result.devices.at(0)->get_soc_descriptor().arch);
+    EXPECT_EQ(connection.server_directory, server_directory);
+    EXPECT_EQ(connection.sockets.size(), result.devices.size());
+    EXPECT_EQ(connection.sockets.at(0), SimulationServerSocket::default_socket_path(server_directory, 0));
+}
+
+// The point of reporting the connection on the host side: with server_directory left empty the
+// connector allocates one internally, and the caller has no other way to learn which. Requires
+// TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsTheServerDirectoryItAllocated) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;
+    // server_directory deliberately left empty: the connector allocates one.
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+
+    ASSERT_FALSE(result.connection.server_directory.empty());
+    EXPECT_TRUE(std::filesystem::is_directory(result.connection.server_directory));
+    ASSERT_EQ(result.connection.sockets.count(0), 1u);
+    EXPECT_EQ(result.connection.sockets.at(0).parent_path(), result.connection.server_directory);
+    EXPECT_TRUE(std::filesystem::exists(result.connection.sockets.at(0)));
+}
+
+// A private in-process host still reports its role and simulator; an empty server_directory is how
+// "not serving" reads. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsPrivateHostConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    // serve_over_sockets defaults to false.
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+
+    EXPECT_EQ(result.connection.role, SimulationConnector::Role::Host);
+    EXPECT_EQ(result.connection.simulator, std::filesystem::path(simulator_path));
+    EXPECT_NE(result.connection.arch, tt::ARCH::Invalid);
+    EXPECT_TRUE(result.connection.server_directory.empty());
+    EXPECT_TRUE(result.connection.sockets.empty());
+}
+
+// A client reports the directory it attached to and the simulator the host runs -- the latter comes
+// over the wire, since a client has no local simulator build to read. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsClientConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+
+    SimulationConnectorOptions host_options;
+    host_options.simulator_directory = simulator_path;
+    host_options.serve_over_sockets = true;
+    host_options.server_directory = server_directory;
+    const SimulationConnector::Result host = SimulationConnector::discover(host_options);
+
+    SimulationConnectorOptions client_options;
+    client_options.simulator_directory = server_directory;
+    const SimulationConnector::Result client = SimulationConnector::discover(client_options);
+
+    EXPECT_EQ(client.connection.role, SimulationConnector::Role::Client);
+    EXPECT_EQ(client.connection.server_directory, server_directory);
+    EXPECT_EQ(client.connection.sockets, host.connection.sockets);
+    // Reported by the host over GET_DEVICE_INFO, and matching what the host itself says it runs.
+    EXPECT_EQ(client.connection.simulator, host.connection.simulator);
+    EXPECT_EQ(client.connection.backend, host.connection.backend);
+    EXPECT_EQ(client.connection.arch, host.connection.arch);
 }

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -33,11 +33,13 @@ TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
     SocDescriptor original(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")), chip_info);
 
-    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSIM);
+    const SimulationServerDeviceInfo info =
+        describe_device(original, SimulationBackendType::TTSIM, "/opt/sim_bh/libttsim.so");
     EXPECT_EQ(info.status, 0);
     EXPECT_EQ(info.backend_type, SimulationBackendType::TTSIM);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.tensix_harvesting_mask, 0x1u);
+    EXPECT_EQ(info.simulator_path, "/opt/sim_bh/libttsim.so");
 
     const SocDescriptor rebuilt = build_soc_descriptor(info);
     EXPECT_EQ(rebuilt.arch, original.arch);

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -107,6 +107,7 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     info.eth_harvesting_mask = 0x120;
     info.l2cpu_harvesting_mask = 0x0;
     info.pcie_harvesting_mask = 0x3;
+    info.simulator_path = "/opt/sim_wh/libttsim.so";
 
     const SimulationServerDeviceInfo decoded = decode_device_info(encode(info));
 
@@ -120,6 +121,22 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     EXPECT_EQ(decoded.eth_harvesting_mask, info.eth_harvesting_mask);
     EXPECT_EQ(decoded.l2cpu_harvesting_mask, info.l2cpu_harvesting_mask);
     EXPECT_EQ(decoded.pcie_harvesting_mask, info.pcie_harvesting_mask);
+    EXPECT_EQ(decoded.simulator_path, info.simulator_path);
+}
+
+// simulator_path was appended to the schema after the first hosts shipped. encode() omits it when
+// empty, so this message is on the wire exactly as an older host's would be -- which is what makes
+// this a backward-compatibility case and not just an empty-string one. Decoding it must yield an
+// empty path rather than dereferencing the absent field.
+TEST(SimulationServerProtocol, DeviceInfoWithAnAbsentSimulatorPathRoundTrip) {
+    SimulationServerDeviceInfo info;
+    info.arch = 2;
+    info.soc_descriptor_yaml = "arch: wormhole_b0\n";  // simulator_path left unset
+
+    const SimulationServerDeviceInfo decoded = decode_device_info(encode(info));
+
+    EXPECT_EQ(decoded.arch, info.arch);
+    EXPECT_TRUE(decoded.simulator_path.empty());
 }
 
 // The GetDeviceInfo command survives a request round-trip.


### PR DESCRIPTION
### Issue

#3315

### Description

`SimulationConnector` is the entry point for opening simulated devices, but only from C++ — `nanobind/` bound the per-device factories and nothing else, and `docs/SIMULATION_SERVER.md` said outright that there was no Python entry point. tt-exalens drives UMD from Python (#3314), so it could not attach to a running simulation host at all.

This binds the connector and its options. Role, discovery, directory allocation and server listing behave as they do in C++, including deciding host-vs-client from the path.

Most of the new tests need no simulator: `role_for` classifies on a real `AF_UNIX` socket named `tt-umd-sim-0.sock`, so a Python test can build one in a tmpdir. The host/client test does need one and skips without `TT_UMD_SIMULATOR` — it will only run once #3330 / #3331 build the Python module in the simulation lanes. It was verified locally against ttsim blackhole v1.10.3: a Python host serves a socket, a Python client attaches to its directory, and a `noc_write32` from the client is read back by the host.

### List of the changes

- New `nanobind/py_api_simulation.cpp`: `SimulationConnectorOptions`, `SimulationServerInfo`, and `SimulationConnector` with `Role.HOST`/`Role.CLIENT`, `role_for`, `discover`, `allocate_server_directory`, `list_servers`. Guarded by `TT_UMD_BUILD_SIMULATION`, like the existing simulation bindings.
- `nanobind/tests/test_py_simulation_connector.py`.
- `docs/SIMULATION_SERVER.md`: a "From Python" section under *Connecting from code*.

### Testing

CI

### API Changes

New Python API only; no C++ change.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/simulation-live-classification