### PR TITLE
Hand the simulation TLB allocator its window layout

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -21,10 +21,22 @@ namespace tt::umd {
  * Tracks which TLB indices are allocated per size class, and computes BAR0-relative
  * addresses for a given index. Counterpart to KMD-managed allocation on silicon —
  * no knowledge of TlbHandle / TlbWindow types.
+ *
+ * The window layout is handed in at construction rather than derived from the architecture, so
+ * supporting a new architecture is a matter of it having an entry in the architecture TLB table.
  */
 class SimulationTlbAllocator {
 public:
-    SimulationTlbAllocator(uint64_t bar0_base, tt::ARCH arch, uint64_t bar4_base = 0);
+    /**
+     * @param bar0_base Base address the architecture's BAR0-resident windows are mapped at.
+     * @param arch Architecture of the device this allocator serves. Carried so the TLB handles
+     *             built on top of it can answer get_arch(); the allocator never branches on it.
+     * @param tlbs Window layout to lay the pools out from, or nullptr when the simulator models no
+     *             TLB windows for this device at all (its communicator carries all I/O); see
+     *             allocate_tlb_index() for what that mode means.
+     * @param bar4_base Base address for the layout's BAR4-resident windows, if it has any.
+     */
+    SimulationTlbAllocator(uint64_t bar0_base, tt::ARCH arch, const ArchitectureTlbs* tlbs, uint64_t bar4_base = 0);
 
     /**
      * Allocate the smallest TLB whose size class is >= the requested size. If no
@@ -33,11 +45,11 @@ public:
      *
      * If size is 0, allocate any available TLB, preferring smaller size classes first.
      *
-     * QUASAR has no real TLBs; the pools are empty by design (simulator's communicator
-     * handles all I/O underneath). For QUASAR, hand back an auto-incrementing dummy
-     * index so TLBManager bookkeeping (keyed by tlb id) does not collide across
-     * allocations. Callers should use the requested size directly on QUASAR rather
-     * than querying get_tlb_size_from_index() (which has no pool to look up).
+     * An allocator built without a layout has no pools to allocate from. It hands back an
+     * auto-incrementing index instead, so TLBManager bookkeeping (keyed by tlb id) does not
+     * collide across allocations. Such an index addresses no window: callers should use the
+     * requested size directly rather than querying get_tlb_size_from_index(), which has no pool to
+     * look it up in. uses_window_addressing() distinguishes the two modes.
      *
      * @param size Requested TLB size in bytes (0 means any available).
      * @return TLB index if successful, -1 if no TLB available.
@@ -64,6 +76,12 @@ public:
      */
     uint64_t get_tlb_reg_address_from_index(int tlb_index);
 
+    /**
+     * Whether the indices this allocator hands out address a real window, i.e. whether it was given
+     * a layout. See allocate_tlb_index() for the layout-less mode.
+     */
+    bool uses_window_addressing() const;
+
     tt::ARCH get_architecture() const;
 
 private:
@@ -73,7 +91,7 @@ private:
         std::vector<bool> allocated;
     };
 
-    void initialize_architecture_config();
+    void initialize_pools(const ArchitectureTlbs* tlbs);
 
     // Returns the pool that owns `tlb_index`, or nullptr if no pool covers it
     // (including for negative indices).
@@ -82,15 +100,18 @@ private:
     uint64_t bar0_base_ = 0;
     uint64_t bar4_base_ = 0;
     tt::ARCH architecture_;
-    size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
+    // Both taken from the layout. Left at zero without one, where every getter that would use them
+    // throws before reaching them.
+    uint64_t cfg_reg_base_offset_ = 0;
+    uint64_t tlb_reg_size_bytes_ = 0;
 
     std::mutex allocation_mutex_;
     // Ordered smallest window size first, so allocate-with-escalation and the BAR0 address
     // layout both follow the iteration order.
     std::vector<TlbPool> pools_;
 
-    // Counter for the Quasar bypass branch of allocate_tlb_index(); see its docstring.
-    std::atomic<int> next_bypass_tlb_id_{0};
+    // Counter for the layout-less branch of allocate_tlb_index(); see its docstring.
+    std::atomic<int> next_bookkeeping_tlb_id_{0};
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -33,6 +33,8 @@ public:
 
     SimulationTlbAllocator* get_tlb_allocator() const { return allocator_.get(); }
 
+    bool maps_window() const override { return maps_window_; }
+
     tt::ARCH get_arch() const override;
 
 private:
@@ -41,6 +43,7 @@ private:
     void free_tlb() noexcept override;
 
     std::shared_ptr<SimulationTlbAllocator> allocator_;
+    bool maps_window_ = false;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tlb_handle.hpp
@@ -52,6 +52,14 @@ public:
      */
     int get_tlb_id() const { return tlb_id_; }
 
+    /**
+     * Whether a window was laid out behind this handle, i.e. whether it has an index with a base
+     * address (get_base()) and configuration registers to program. Always true on silicon. False for
+     * a simulation backend that models no TLB windows at all: there is nothing to program, and the
+     * window object names its target core explicitly instead of deriving an address from the handle.
+     */
+    virtual bool maps_window() const { return true; }
+
     virtual tt::ARCH get_arch() const = 0;
 
 protected:

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -40,6 +40,8 @@ public:
 
     SimulationTlbAllocator* get_tlb_allocator() const { return allocator_.get(); }
 
+    bool maps_window() const override { return maps_window_; }
+
     tt::ARCH get_arch() const override;
 
 private:
@@ -56,6 +58,7 @@ private:
     std::shared_ptr<SimulationTlbAllocator> allocator_;
     class TTSimCommunicator* sim_communicator_;
     uint64_t tlb_reg_addr_ = 0;
+    bool maps_window_ = false;
 };
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -6,27 +6,25 @@
 
 #include <fmt/format.h>
 
-#include <tt-logger/tt-logger.hpp>
-
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, tt::ARCH arch, uint64_t bar4_base) :
+SimulationTlbAllocator::SimulationTlbAllocator(
+    uint64_t bar0_base, tt::ARCH arch, const ArchitectureTlbs* tlbs, uint64_t bar4_base) :
     bar0_base_(bar0_base), bar4_base_(bar4_base), architecture_(arch) {
-    initialize_architecture_config();
+    initialize_pools(tlbs);
 }
 
 int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
     ZoneScopedC(tracy::Color::Cyan);
 
-    // QUASAR has no real TLBs; the pools are empty by design (simulator's communicator
-    // handles all I/O underneath). Hand back an auto-incrementing dummy index so
-    // TLBManager bookkeeping (keyed by tlb id) does not collide across allocations.
-    if (architecture_ == tt::ARCH::QUASAR) {
-        return next_bypass_tlb_id_++;
+    // Built without a layout: there are no pools to allocate from, so hand back an
+    // auto-incrementing bookkeeping index instead. See allocate_tlb_index()'s docstring.
+    if (pools_.empty()) {
+        return next_bookkeeping_tlb_id_++;
     }
 
     std::lock_guard<std::mutex> lock(allocation_mutex_);
@@ -100,10 +98,10 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
     if (!find_pool_for_index(tlb_index)) {
         UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
-    // TLB configuration registers start at this offset from BAR0 base.
-    static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
-    return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
+    return bar0_base_ + cfg_reg_base_offset_ + tlb_index * tlb_reg_size_bytes_;
 }
+
+bool SimulationTlbAllocator::uses_window_addressing() const { return !pools_.empty(); }
 
 tt::ARCH SimulationTlbAllocator::get_architecture() const { return architecture_; }
 
@@ -122,26 +120,17 @@ SimulationTlbAllocator::TlbPool* SimulationTlbAllocator::find_pool_for_index(int
     return nullptr;
 }
 
-void SimulationTlbAllocator::initialize_architecture_config() {
-    if (architecture_ != tt::ARCH::WORMHOLE_B0 && architecture_ != tt::ARCH::BLACKHOLE) {
-        // Intentional: architectures like QUASAR construct a SimulationTlbAllocator
-        // but the sim TTDevice's constructor bypasses it entirely (builds the
-        // cached TLB window with a fixed index, never calling allocate_tlb_index).
-        // Leaving every pool empty is the signal that allocator-driven addressing
-        // is not in use.
-        log_debug(
-            LogUMD,
-            fmt::format(
-                "Architecture {} does not yet have support for TLB management in simulation. UMD will use legacy "
-                "tile_wr_bytes and tile_rd_bytes path.",
-                tt::arch_to_str(architecture_)));
+void SimulationTlbAllocator::initialize_pools(const ArchitectureTlbs* tlbs) {
+    if (tlbs == nullptr) {
+        // Intentional: the simulator models no TLB windows for this device, so there is nothing to
+        // lay out. Leaving every pool empty is what puts the allocator in bookkeeping-only mode.
         return;
     }
 
-    const ArchitectureTlbs& tlbs = get_architecture_tlbs(architecture_);
-    tlb_reg_size_bytes_ = tlbs.cfg_reg_size_bytes;
+    cfg_reg_base_offset_ = tlbs->static_cfg_addr;
+    tlb_reg_size_bytes_ = tlbs->cfg_reg_size_bytes;
 
-    for (const TlbSizeClass& size_class : tlbs.size_classes) {
+    for (const TlbSizeClass& size_class : tlbs->size_classes) {
         TlbPool pool;
         pool.layout = size_class;
         pool.allocated.resize(size_class.count, false);

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -22,10 +22,10 @@ RtlSimTlbHandle::RtlSimTlbHandle(
     tlb_size_ = size;
     tlb_mapping_ = mapping;
 
-    // QUASAR bypasses the simulation TLB allocator (see the Quasar branch in
-    // RtlSimulationTTDevice's constructor); skip the allocator query for it so
-    // get_tlb_address_from_index doesn't throw on the empty pool.
-    if (allocator_ && allocator_->get_architecture() != tt::ARCH::QUASAR) {
+    // An allocator without a layout has no pools; skip the query so get_tlb_address_from_index
+    // doesn't throw on the bookkeeping index it handed out.
+    maps_window_ = allocator_ && allocator_->uses_window_addressing();
+    if (maps_window_) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
         tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -32,11 +32,11 @@ TTSimTlbHandle::TTSimTlbHandle(
     tlb_mapping_ = tlb_mapping;
 
     // Compute the address for this TLB based on BAR0 base + TLB offset.
-    // QUASAR bypasses the simulation TLB allocator entirely (the communicator
-    // handles all I/O), so the allocator has no pools and the get_*_from_index
-    // calls would throw. Skip them for QUASAR; tlb_base_ / tlb_reg_addr_ stay at
-    // their defaults (nullptr / 0), which the QUASAR path never dereferences.
-    if (allocator_ && allocator_->get_architecture() != tt::ARCH::QUASAR) {
+    // An allocator without a layout (the communicator handles all I/O) has no pools, so the
+    // get_*_from_index calls would throw. Skip them; tlb_base_ / tlb_reg_addr_ stay at their
+    // defaults (nullptr / 0), which the windowless path never dereferences.
+    maps_window_ = allocator_ && allocator_->uses_window_addressing();
+    if (maps_window_) {
         tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
         tlb_reg_addr_ = allocator_->get_tlb_reg_address_from_index(tlb_id_);
     }
@@ -71,14 +71,13 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_.static_vc_buddy = 0;
     tlb_config_.static_vc_class = 0;
 
-    // Get architecture from allocator to determine correct offsets.
-    tt::ARCH architecture = get_arch();
-
-    // Quasar has no real TLB registers to program — the communicator handles
-    // all I/O directly, so configure is a no-op beyond storing tlb_config_.
-    if (architecture == tt::ARCH::QUASAR) {
+    // No window mapped means no TLB registers to program — the communicator handles all I/O
+    // directly, so configure is a no-op beyond storing tlb_config_.
+    if (!maps_window_) {
         return;
     }
+
+    tt::ARCH architecture = get_arch();
 
     log_debug(
         LogUMD,
@@ -95,6 +94,9 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
         tlb_config_.ordering);
 
     // Determine which TLB offset structure to use based on architecture and size.
+    // TODO: TlbSizeClass::register_layout in the architecture TLB table already carries these
+    // offsets and would replace this switch, but swapping it in is not behaviour-preserving: the
+    // fallbacks below accept an unrecognised size and warn, where the table simply has no entry.
     const tlb_offsets* offsets = nullptr;
     constexpr size_t SIZE_1MB = 1024 * 1024;
     constexpr size_t SIZE_2MB = 2 * 1024 * 1024;

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -12,7 +12,6 @@
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -43,13 +42,10 @@ void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) { r
 
 void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
     validate(offset, size);
-    // Quasar's TLB handle programs no TLB registers and is left without a base address, so a
-    // physical address derived from it carries no identity for the core this window was created
-    // for. Name the core explicitly. Wormhole and Blackhole keep the physical-address path.
-    //
-    // This is an arch check rather than a capability check because the simulator does not model
-    // Quasar TLBs at all. If it ever does, this needs to become a capability check.
-    if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
+    // A handle that maps no window programs no TLB registers and is left without a base address, so
+    // a physical address derived from it carries no identity for the core this window was created
+    // for. Name the core explicitly. A mapped window keeps the physical-address path.
+    if (tlb_handle->maps_window()) {
         sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
         return;
     }
@@ -66,7 +62,7 @@ void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size)
 
 void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
     validate(offset, size);
-    if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
+    if (tlb_handle->maps_window()) {
         sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
         return;
     }

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -14,6 +14,7 @@
 #include "noc_access.hpp"
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
@@ -26,6 +27,29 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+namespace {
+
+// Window layout the simulator models for `arch`, or nullptr when it models none at all -- Quasar,
+// where the communicator carries every access and a window index is bookkeeping only. Which
+// architectures are modelled is a property of the simulator, not of the allocator, which lays out
+// whatever layout it is handed.
+const ArchitectureTlbs* simulated_tlb_layout(const tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+        case tt::ARCH::BLACKHOLE:
+            return &get_architecture_tlbs(arch);
+        default:
+            log_debug(
+                LogUMD,
+                "Architecture {} does not yet have support for TLB management in simulation. UMD will use legacy "
+                "tile_wr_bytes and tile_rd_bytes path.",
+                tt::arch_to_str(arch));
+            return nullptr;
+    }
+}
+
+}  // namespace
 
 // The constructor and destructor are defined out-of-line so that socket_
 // (unique_ptr<SimulationServerSocket>) is constructed/destroyed where the type is complete; the
@@ -253,13 +277,16 @@ void SimulationTTDevice::client_read(CoreCoord core, uint64_t addr, void* mem_pt
 }
 
 void SimulationTTDevice::init_tlb_allocator(uint64_t bar0_base) {
-    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, get_arch());
+    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, get_arch(), simulated_tlb_layout(get_arch()));
 }
 
 void SimulationTTDevice::setup_cached_tlb_window() {
     // Quasar has no real TLBs; the communicator handles all I/O underneath. The 4GB size for Quasar is
     // a dummy value -- it just needs to be large enough so that TlbWindow::validate doesn't reject any
     // valid access (size 0 would cause division by zero in the TLB handle configure).
+    // TODO: these are not the architecture TLB table's cached_window_size. Blackhole agrees at 2MB,
+    // but Wormhole picks 16MB where the table says 1MB, so pointing this at the table would shrink
+    // the Wormhole window -- a behaviour change rather than a cleanup.
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
     static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
@@ -293,9 +320,10 @@ std::unique_ptr<TlbWindow> SimulationTTDevice::get_io_window(tlb_data config, Tl
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
     }
-    // QUASAR bypasses the bitmap allocator (pools are empty by design); pass the requested size
-    // through, since get_tlb_size_from_index has no pool to look up for the bypass index.
-    size_t actual_size = (get_arch() == tt::ARCH::QUASAR) ? size : tlb_allocator_->get_tlb_size_from_index(tlb_index);
+    // An allocator without a layout hands out bookkeeping indices with no pool behind them, so
+    // get_tlb_size_from_index cannot answer for them; pass the requested size through instead.
+    size_t actual_size =
+        tlb_allocator_->uses_window_addressing() ? tlb_allocator_->get_tlb_size_from_index(tlb_index) : size;
     return create_tlb_window(tlb_index, actual_size, mapping, config);
 }
 

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <unordered_set>
 
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 
@@ -22,7 +23,8 @@ constexpr uint64_t TEST_BAR0_BASE = 0x10000000ULL;
 }  // namespace
 
 TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     int idx = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx, -1);
@@ -39,7 +41,8 @@ TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     int idx_1mb = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx_1mb, -1);
@@ -55,7 +58,8 @@ TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     int idx = allocator.allocate_tlb_index(0);
     ASSERT_NE(idx, -1);
@@ -64,7 +68,8 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhausted) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
     for (size_t i = 0; i < 156; ++i) {
@@ -78,7 +83,8 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhau
 }
 
 TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     std::unordered_set<int> seen_indices;
     seen_indices.reserve(156);
@@ -91,7 +97,8 @@ TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
     for (size_t i = 0; i < 156; ++i) {
@@ -105,7 +112,8 @@ TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // Exhaust every size class. allocate_tlb_index(0) picks any available TLB.
     while (allocator.allocate_tlb_index(0) != -1) {
@@ -117,7 +125,8 @@ TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // Wormhole layout from BAR0 base 0x10000000:
     //   indices   0..155: 156 x 1MB  (0x10000000 .. 0x19BFFFFF)
@@ -130,7 +139,8 @@ TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // TLB config registers start at BAR0+0x1FC00000 with 8-byte stride on Wormhole.
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
@@ -138,7 +148,7 @@ TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE, &get_architecture_tlbs(tt::ARCH::BLACKHOLE));
 
     int idx = allocator.allocate_tlb_index(0x200000);
     ASSERT_NE(idx, -1);
@@ -148,7 +158,7 @@ TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE, &get_architecture_tlbs(tt::ARCH::BLACKHOLE));
 
     // Blackhole layout from BAR0 base 0x10000000:
     //   indices 0..201: 202 x 2MB (0x10000000 .. 0x291FFFFF)
@@ -157,7 +167,7 @@ TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE, &get_architecture_tlbs(tt::ARCH::BLACKHOLE));
 
     // TLB config registers start at BAR0+0x1FC00000 with 12-byte stride on Blackhole.
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
@@ -165,7 +175,8 @@ TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, GettersThrowOnInvalidIndex) {
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
 
     // Negative indices are rejected.
     EXPECT_THROW(allocator.get_tlb_size_from_index(-1), std::exception);
@@ -177,4 +188,55 @@ TEST(SimulationTlbAllocator, GettersThrowOnInvalidIndex) {
     EXPECT_THROW(allocator.get_tlb_size_from_index(186), std::exception);
     EXPECT_THROW(allocator.get_tlb_address_from_index(186), std::exception);
     EXPECT_THROW(allocator.get_tlb_reg_address_from_index(186), std::exception);
+}
+
+TEST(SimulationTlbAllocator, WindowedAllocatorAddressesWindows) {
+    SimulationTlbAllocator allocator(
+        TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0, &get_architecture_tlbs(tt::ARCH::WORMHOLE_B0));
+
+    EXPECT_TRUE(allocator.uses_window_addressing());
+}
+
+TEST(SimulationTlbAllocator, WindowlessAllocatorHandsOutDistinctIndices) {
+    // No layout: the simulator models no TLB windows for this device, so indices are bookkeeping
+    // ids only. This is the Quasar path.
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::QUASAR, nullptr);
+
+    EXPECT_FALSE(allocator.uses_window_addressing());
+
+    // Every request succeeds, whatever the size, and no index is handed out twice.
+    std::unordered_set<int> indices;
+    for (int i = 0; i < 4; ++i) {
+        int idx = allocator.allocate_tlb_index(4ULL * 1024 * 1024 * 1024);
+        ASSERT_NE(idx, -1);
+        EXPECT_TRUE(indices.insert(idx).second);
+    }
+
+    // Freeing a bookkeeping index is a no-op rather than an error.
+    EXPECT_NO_THROW(allocator.deallocate_tlb_index(0));
+
+    // There is no window behind the index, so nothing can be said about its address or size.
+    EXPECT_THROW(allocator.get_tlb_size_from_index(0), std::exception);
+    EXPECT_THROW(allocator.get_tlb_address_from_index(0), std::exception);
+    EXPECT_THROW(allocator.get_tlb_reg_address_from_index(0), std::exception);
+}
+
+TEST(SimulationTlbAllocator, ConsumesAnyInjectedLayout) {
+    // The allocator holds no knowledge of which architectures it can serve, so it lays out a layout
+    // it has no code for the same way as the ones it is used with today. Quasar is the case that
+    // matters: the simulator models no windows for it, so nothing but this table entry describes it.
+    const ArchitectureTlbs& tlbs = get_architecture_tlbs(tt::ARCH::QUASAR);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::QUASAR, &tlbs);
+
+    ASSERT_TRUE(allocator.uses_window_addressing());
+
+    const TlbSizeClass& smallest = tlbs.size_classes.front();
+    int idx = allocator.allocate_tlb_index(smallest.size);
+    ASSERT_NE(idx, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), smallest.size);
+    EXPECT_EQ(allocator.get_tlb_address_from_index(idx), TEST_BAR0_BASE + idx * smallest.size);
+
+    // Config register stride comes from the layout, not from a default baked into the allocator.
+    EXPECT_EQ(
+        allocator.get_tlb_reg_address_from_index(1), TEST_BAR0_BASE + tlbs.static_cfg_addr + tlbs.cfg_reg_size_bytes);
 }


### PR DESCRIPTION
### Issue
#2586

### Description
The allocator's last architecture-specific code was the guard in `initialize_architecture_config`: every architecture but Wormhole and Blackhole returned early with empty pools, so supporting a new one meant editing `simulation_tlb_allocator.cpp` even once the architecture TLB table described it. Quasar was the only architecture on that path, and four other files re-tested `== tt::ARCH::QUASAR` to stay off the empty pools.

Which architectures the simulator models windows for belongs to the simulator, not the allocator, so that choice moves up to `SimulationTTDevice`, which hands the allocator a layout — or nullptr for a backend modelling no windows, where a window index is bookkeeping only. The rest of the code asks `uses_window_addressing()` and `TlbHandle::maps_window()` rather than the arch.

### List of the changes
- `SimulationTlbAllocator` takes a `const ArchitectureTlbs*`; `initialize_architecture_config()` becomes `initialize_pools()` with no arch switch.
- The configuration register base comes from `static_cfg_addr` instead of a hard-coded `0x1fc00000`.
- New `uses_window_addressing()` and `TlbHandle::maps_window()` (default true) replace five `== tt::ARCH::QUASAR` checks; `simulated_tlb_layout()` holds the modelled architectures.
- Allocator tests point at the injected layout, plus windowless and unknown-layout cases.

### Testing
257 baremetal tests and `pre-commit` clean. An A/B harness drove main's allocator beside the new one over getters, allocations, partial frees and drain-to-exhaustion: byte-identical for Wormhole, Blackhole and Quasar, and mutation-tested to confirm it detects change. ttsim matches a clean `main` on all three. `ARCH::Invalid` now returns a bookkeeping index instead of -1, on a path no simulation device reaches.

### API Changes
The constructor takes the window layout, `uses_window_addressing()` is new, and `TlbHandle::maps_window()` defaults to true so existing handles need no change.