### PR TITLE
Add CoreType::SMC and the single-Mimir SoC descriptor

### DIFF
--- a/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
@@ -37,7 +37,8 @@ public:
         const std::vector<tt_xy_pair>& l2cpu_cores,
         const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
-        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {},
+        const std::vector<tt_xy_pair>& smc_cores = {});
 
 protected:
     void assert_coordinate_manager_constructor() override;

--- a/device/api/umd/device/coordinates/coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/coordinate_manager.hpp
@@ -51,7 +51,8 @@ public:
         const std::vector<tt_xy_pair>& l2cpu_cores,
         const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
-        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {},
+        const std::vector<tt_xy_pair>& smc_cores = {});
 
     /**
      * Create CoordinateManager object. Generally, main function for creating CoordinateManager is the one above,
@@ -228,7 +229,8 @@ protected:
         const std::vector<tt_xy_pair>& l2cpu_cores,
         const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
-        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {},
+        const std::vector<tt_xy_pair>& smc_cores = {});
 
     void initialize();
 
@@ -359,6 +361,10 @@ protected:
     const std::vector<tt_xy_pair> l2cpu_cores;
 
     const std::vector<tt_xy_pair> dispatch_cores;
+
+    // System Management Complex cores. Like router/security/l2cpu/dispatch cores they are not laid
+    // out in a grid and are never harvested.
+    const std::vector<tt_xy_pair> smc_cores;
 
     const std::vector<uint32_t> noc0_x_to_noc1_x;
     const std::vector<uint32_t> noc0_y_to_noc1_y;

--- a/device/api/umd/device/coordinates/quasar_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/quasar_coordinate_manager.hpp
@@ -42,7 +42,8 @@ public:
         const std::vector<tt_xy_pair>& l2cpu_cores,
         const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
-        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {},
+        const std::vector<tt_xy_pair>& smc_cores = {});
 
 protected:
     void fill_tensix_noc0_translated_mapping() override;

--- a/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
@@ -36,7 +36,8 @@ public:
         const std::vector<tt_xy_pair>& l2cpu_cores,
         const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
-        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {},
+        const std::vector<tt_xy_pair>& smc_cores = {});
 
 protected:
     void fill_tensix_noc0_translated_mapping() override;

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -86,6 +86,8 @@ public:
 
     const std::vector<tt_xy_pair>& get_dispatch_cores() const { return dispatch_cores_; }
 
+    const std::vector<tt_xy_pair>& get_smc_cores() const { return smc_cores_; }
+
     // Memory sizes.
     uint32_t get_worker_l1_size() const { return worker_l1_size_; }
 
@@ -155,6 +157,7 @@ private:
     std::vector<tt_xy_pair> security_cores_;
     std::vector<tt_xy_pair> l2cpu_cores_;
     std::vector<tt_xy_pair> dispatch_cores_;
+    std::vector<tt_xy_pair> smc_cores_;
     uint32_t worker_l1_size_ = 0;
     uint32_t eth_l1_size_ = 0;
     uint64_t dram_bank_size_ = 0;

--- a/device/api/umd/device/types/arch.hpp
+++ b/device/api/umd/device/types/arch.hpp
@@ -21,6 +21,10 @@ enum class ARCH {
     WORMHOLE_B0 = 2,
     BLACKHOLE = 3,
     QUASAR = 4,
+    // A Grendel multi-chiplet package (Quasar/Mimir/Keraunos). Grendel packages have no fixed
+    // floorplan, so their descriptors always come from a YAML SoC descriptor rather than from
+    // hardcoded architecture constants.
+    GRENDEL = 5,
     Invalid = 0xFF,
 };
 
@@ -33,6 +37,8 @@ static inline tt::ARCH arch_from_str(const std::string &arch_str) {
         return tt::ARCH::BLACKHOLE;
     } else if (arch_str_lower == "quasar") {
         return tt::ARCH::QUASAR;
+    } else if (arch_str_lower == "grendel") {
+        return tt::ARCH::GRENDEL;
     } else {
         return tt::ARCH::Invalid;
     }
@@ -46,6 +52,8 @@ static inline std::string arch_to_str(const tt::ARCH arch) {
             return "blackhole";
         case tt::ARCH::QUASAR:
             return "quasar";
+        case tt::ARCH::GRENDEL:
+            return "grendel";
         case tt::ARCH::Invalid:
         default:
             return "Invalid";

--- a/device/api/umd/device/types/core_coordinates.hpp
+++ b/device/api/umd/device/types/core_coordinates.hpp
@@ -31,6 +31,9 @@ enum class CoreType {
     SECURITY,
     L2CPU,
     DISPATCH,
+    // System Management Complex: the on-die management CPU of a Grendel chiplet, and the surface a
+    // JTAG bring-up client reaches first.
+    SMC,
     // TODO: this keeps compatibility with existing code in SocDescriptor
     // but it won't be needed later on
     HARVESTED,
@@ -75,6 +78,8 @@ static inline std::string to_str(const CoreType core_type) {
             return "L2CPU";
         case CoreType::DISPATCH:
             return "DISPATCH";
+        case CoreType::SMC:
+            return "SMC";
         case CoreType::HARVESTED:
             return "HARVESTED";
         case CoreType::ETH:
@@ -110,6 +115,8 @@ static inline char type_shorthand(const CoreType type) {
             return 's';
         case CoreType::L2CPU:
             return 'l';
+        case CoreType::SMC:
+            return 'm';
         case CoreType::UNSPECIFIED:
             return '\0';
         default:

--- a/device/arch/architecture_implementation.cpp
+++ b/device/arch/architecture_implementation.cpp
@@ -15,6 +15,7 @@ namespace tt::umd {
 std::unique_ptr<ArchitectureImplementation> ArchitectureImplementation::create(tt::ARCH architecture) {
     switch (architecture) {
         case tt::ARCH::QUASAR:
+        case tt::ARCH::GRENDEL:
             return std::make_unique<GrendelImplementation>();
         case tt::ARCH::BLACKHOLE:
             return std::make_unique<BlackholeImplementation>();

--- a/device/coordinates/blackhole_coordinate_manager.cpp
+++ b/device/coordinates/blackhole_coordinate_manager.cpp
@@ -34,7 +34,8 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
     const std::vector<tt_xy_pair>& l2cpu_cores,
     const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
-    const std::vector<uint32_t>& noc0_y_to_noc1_y) :
+    const std::vector<uint32_t>& noc0_y_to_noc1_y,
+    const std::vector<tt_xy_pair>& smc_cores) :
     CoordinateManager(
         noc_translation_enabled,
         harvesting_masks,
@@ -52,7 +53,8 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         l2cpu_cores,
         dispatch_cores,
         noc0_x_to_noc1_x,
-        noc0_y_to_noc1_y) {
+        noc0_y_to_noc1_y,
+        smc_cores) {
     initialize();
 }
 

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -42,7 +42,8 @@ CoordinateManager::CoordinateManager(
     const std::vector<tt_xy_pair>& l2cpu_cores,
     const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
-    const std::vector<uint32_t>& noc0_y_to_noc1_y) :
+    const std::vector<uint32_t>& noc0_y_to_noc1_y,
+    const std::vector<tt_xy_pair>& smc_cores) :
     noc_translation_enabled(noc_translation_enabled),
     harvesting_masks(harvesting_masks),
     tensix_grid_size(tensix_grid_size),
@@ -59,6 +60,7 @@ CoordinateManager::CoordinateManager(
     security_cores(security_cores),
     l2cpu_cores(l2cpu_cores),
     dispatch_cores(dispatch_cores),
+    smc_cores(smc_cores),
     noc0_x_to_noc1_x(noc0_x_to_noc1_x),
     noc0_y_to_noc1_y(noc0_y_to_noc1_y) {}
 
@@ -138,6 +140,11 @@ void CoordinateManager::identity_map_noc0_cores() {
 
     for (auto& core : dispatch_cores) {
         const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::DISPATCH, CoordSystem::NOC0);
+        add_core_translation(core_coord, core);
+    }
+
+    for (auto& core : smc_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::SMC, CoordSystem::NOC0);
         add_core_translation(core_coord, core);
     }
 }
@@ -482,6 +489,8 @@ const std::vector<tt_xy_pair>& CoordinateManager::get_noc0_pairs(const CoreType 
             return l2cpu_cores;
         case CoreType::DISPATCH:
             return dispatch_cores;
+        case CoreType::SMC:
+            return smc_cores;
         default:
             UMD_THROW(error::RuntimeError, "Core type is not supported for getting NOC0 pairs.");
     }
@@ -566,6 +575,7 @@ std::vector<CoreCoord> CoordinateManager::get_cores(const CoreType core_type) co
         case CoreType::ARC:
         case CoreType::ROUTER_ONLY:
         case CoreType::SECURITY:
+        case CoreType::SMC:
             return get_all_noc0_cores(core_type);
         default:
             UMD_THROW(error::RuntimeError, "Unsupported core type for get_cores().");
@@ -589,6 +599,7 @@ tt_xy_pair CoordinateManager::get_grid_size(const CoreType core_type) const {
         case CoreType::SECURITY:
         case CoreType::L2CPU:
         case CoreType::DISPATCH:
+        case CoreType::SMC:
             // These cores are not arranged in a regular grid.
             return {0, 0};
         default:
@@ -611,6 +622,7 @@ std::vector<CoreCoord> CoordinateManager::get_harvested_cores(const CoreType cor
         case CoreType::SECURITY:
         case CoreType::L2CPU:
         case CoreType::DISPATCH:
+        case CoreType::SMC:
             return {};
         default:
             UMD_THROW(error::RuntimeError, "Unsupported core type for get_harvested_cores().");
@@ -636,6 +648,7 @@ tt_xy_pair CoordinateManager::get_harvested_grid_size(const CoreType core_type) 
         case CoreType::SECURITY:
         case CoreType::L2CPU:
         case CoreType::DISPATCH:
+        case CoreType::SMC:
             // These cores are not arranged in a regular grid.
             return {0, 0};
         default:
@@ -746,7 +759,8 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
     const std::vector<tt_xy_pair>& l2cpu_cores,
     const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
-    const std::vector<uint32_t>& noc0_y_to_noc1_y) {
+    const std::vector<uint32_t>& noc0_y_to_noc1_y,
+    const std::vector<tt_xy_pair>& smc_cores) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             return std::make_shared<WormholeCoordinateManager>(
@@ -766,7 +780,9 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 l2cpu_cores,
                 dispatch_cores,
                 noc0_x_to_noc1_x,
-                noc0_y_to_noc1_y);
+                noc0_y_to_noc1_y,
+                smc_cores);
+        case tt::ARCH::GRENDEL:
         case tt::ARCH::QUASAR:
             // TODO (#2494): QuasarCoordinateManager currently maps NOC0 -> TRANSLATED as identity.
             // Replace with real Quasar NOC translation tables once the hardware spec is finalized.
@@ -787,7 +803,8 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 l2cpu_cores,
                 dispatch_cores,
                 noc0_x_to_noc1_x,
-                noc0_y_to_noc1_y);
+                noc0_y_to_noc1_y,
+                smc_cores);
         case tt::ARCH::BLACKHOLE:
             return std::make_shared<BlackholeCoordinateManager>(
                 noc_translation_enabled,
@@ -806,7 +823,8 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 l2cpu_cores,
                 dispatch_cores,
                 noc0_x_to_noc1_x,
-                noc0_y_to_noc1_y);
+                noc0_y_to_noc1_y,
+                smc_cores);
         default:
             UMD_THROW(
                 error::RuntimeError, fmt::format("Unexpected architecture: {} ({})", arch_to_str(arch), (int)arch));

--- a/device/coordinates/quasar_coordinate_manager.cpp
+++ b/device/coordinates/quasar_coordinate_manager.cpp
@@ -25,7 +25,8 @@ QuasarCoordinateManager::QuasarCoordinateManager(
     const std::vector<tt_xy_pair>& l2cpu_cores,
     const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
-    const std::vector<uint32_t>& noc0_y_to_noc1_y) :
+    const std::vector<uint32_t>& noc0_y_to_noc1_y,
+    const std::vector<tt_xy_pair>& smc_cores) :
     CoordinateManager(
         noc_translation_enabled,
         harvesting_masks,
@@ -43,7 +44,8 @@ QuasarCoordinateManager::QuasarCoordinateManager(
         l2cpu_cores,
         dispatch_cores,
         noc0_x_to_noc1_x,
-        noc0_y_to_noc1_y) {
+        noc0_y_to_noc1_y,
+        smc_cores) {
     initialize();
 }
 

--- a/device/coordinates/wormhole_coordinate_manager.cpp
+++ b/device/coordinates/wormhole_coordinate_manager.cpp
@@ -31,7 +31,8 @@ WormholeCoordinateManager::WormholeCoordinateManager(
     const std::vector<tt_xy_pair>& l2cpu_cores,
     const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
-    const std::vector<uint32_t>& noc0_y_to_noc1_y) :
+    const std::vector<uint32_t>& noc0_y_to_noc1_y,
+    const std::vector<tt_xy_pair>& smc_cores) :
     CoordinateManager(
         noc_translation_enabled,
         harvesting_masks,
@@ -49,7 +50,8 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         l2cpu_cores,
         dispatch_cores,
         noc0_x_to_noc1_x,
-        noc0_y_to_noc1_y) {
+        noc0_y_to_noc1_y,
+        smc_cores) {
     initialize();
 }
 

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -100,6 +100,13 @@ void SocArchDescriptor::init() {
             noc0_x_to_noc1_x_ = grendel::NOC0_X_TO_NOC1_X;
             noc0_y_to_noc1_y_ = grendel::NOC0_Y_TO_NOC1_Y;
             break;
+        case tt::ARCH::GRENDEL:
+            // A Grendel package's floorplan depends on which chiplets it holds, so there are no
+            // architecture constants to select here.
+            UMD_THROW(
+                error::RuntimeError,
+                "Grendel packages have no fixed floorplan; construct SocArchDescriptor from a YAML SoC descriptor "
+                "instead.");
         default:
             UMD_THROW(error::RuntimeError, "Invalid architecture for creating SocArchDescriptor.");
     }
@@ -213,6 +220,13 @@ void SocArchDescriptor::build_derived_data() {
         core_descriptor.type = CoreType::DISPATCH;
         cores_.insert({core_descriptor.coord, core_descriptor});
     }
+
+    for (const auto& smc_core : smc_cores_) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = smc_core;
+        core_descriptor.type = CoreType::SMC;
+        cores_.insert({core_descriptor.coord, core_descriptor});
+    }
 }
 
 tt_xy_pair format_node(const std::string& str) {
@@ -291,6 +305,11 @@ void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
     if (device_descriptor_yaml["dispatch"].IsDefined()) {
         dispatch_cores_ =
             SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["dispatch"].as<std::vector<std::string>>());
+    }
+
+    if (device_descriptor_yaml["smc"].IsDefined()) {
+        smc_cores_ =
+            SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["smc"].as<std::vector<std::string>>());
     }
 
     if (device_descriptor_yaml["noc0_x_to_noc1_x"].IsDefined()) {

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -176,7 +176,8 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         arch_desc_->get_l2cpu_cores(),
         arch_desc_->get_dispatch_cores(),
         arch_desc_->get_noc0_x_to_noc1_x(),
-        arch_desc_->get_noc0_y_to_noc1_y());
+        arch_desc_->get_noc0_y_to_noc1_y(),
+        arch_desc_->get_smc_cores());
 }
 
 SocDescriptor::SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info) :
@@ -376,6 +377,10 @@ std::string SocDescriptor::serialize() const {
     write_core_locations(&out, CoreType::DISPATCH);
     out << YAML::EndSeq;
 
+    out << YAML::Key << "smc" << YAML::Value << YAML::BeginSeq;
+    write_core_locations(&out, CoreType::SMC);
+    out << YAML::EndSeq;
+
     // Fill in the rest that are static to our device.
     out << YAML::Key << "worker_l1_size" << YAML::Value << worker_l1_size;
     out << YAML::Key << "dram_bank_size" << YAML::Value << dram_bank_size;
@@ -496,7 +501,8 @@ std::vector<CoreCoord> SocDescriptor::get_all_cores(const CoordSystem coord_syst
           CoreType::ROUTER_ONLY,
           CoreType::SECURITY,
           CoreType::L2CPU,
-          CoreType::DISPATCH}) {
+          CoreType::DISPATCH,
+          CoreType::SMC}) {
         auto cores = get_cores(core_type, coord_system);
         all_cores.insert(all_cores.end(), cores.begin(), cores.end());
     }
@@ -514,7 +520,8 @@ std::vector<CoreCoord> SocDescriptor::get_all_harvested_cores(const CoordSystem 
           CoreType::ROUTER_ONLY,
           CoreType::SECURITY,
           CoreType::L2CPU,
-          CoreType::DISPATCH}) {
+          CoreType::DISPATCH,
+          CoreType::SMC}) {
         auto harvested_cores = get_harvested_cores(core_type, coord_system);
         all_harvested_cores.insert(all_harvested_cores.end(), harvested_cores.begin(), harvested_cores.end());
     }

--- a/docs/yaml_schemas/soc_descriptor.yaml
+++ b/docs/yaml_schemas/soc_descriptor.yaml
@@ -19,7 +19,6 @@ required:
   - dram_bank_size
   - eth_l1_size
   - arch_name
-  - features
 
 properties:
   grid:
@@ -114,6 +113,14 @@ properties:
       pattern: ^[0-9]+-[0-9]+$
       description: Coordinate in format "x-y"
 
+  smc:
+    type: array
+    description: List of SMC (System Management Complex) core coordinates
+    items:
+      type: string
+      pattern: ^[0-9]+-[0-9]+$
+      description: Coordinate in format "x-y"
+
   noc0_x_to_noc1_x:
     type: array
     description: Mapping from NOC0 X coordinates to NOC1 X coordinates
@@ -150,6 +157,7 @@ properties:
       - WORMHOLE_B0
       - wormhole_b0
       - QUASAR
+      - GRENDEL
     description: Architecture name of the chip
 
   features:
@@ -223,5 +231,19 @@ properties:
         additionalProperties: false
 
     additionalProperties: false
+
+# The compute-unit feature block describes unpacker/math/packer/overlay, which only exist on a
+# chiplet with compute. A Grendel package need not have any: Mimir is DRAM plus the SMC. So features
+# is required for every other architecture, and optional for GRENDEL.
+if:
+  required:
+    - arch_name
+  properties:
+    arch_name:
+      not:
+        const: GRENDEL
+then:
+  required:
+    - features
 
 additionalProperties: true

--- a/nanobind/py_api_basic_types.cpp
+++ b/nanobind/py_api_basic_types.cpp
@@ -54,6 +54,7 @@ void bind_basic_types(nb::module_ &m) {
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
         .value("BLACKHOLE", tt::ARCH::BLACKHOLE)
         .value("QUASAR", tt::ARCH::QUASAR)
+        .value("GRENDEL", tt::ARCH::GRENDEL)
         .value("Invalid", tt::ARCH::Invalid)
         .def("__str__", &tt::arch_to_str)
         .def("__int__", [](tt::ARCH tag) { return static_cast<int>(tag); })

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -41,6 +41,7 @@ void bind_soc_descriptor(nb::module_ &m) {
         .value("ROUTER_ONLY", CoreType::ROUTER_ONLY)
         .value("SECURITY", CoreType::SECURITY)
         .value("L2CPU", CoreType::L2CPU)
+        .value("SMC", CoreType::SMC)
         .value("HARVESTED", CoreType::HARVESTED)
         .value("ETH", CoreType::ETH)
         .value("WORKER", CoreType::WORKER)

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -13,7 +13,9 @@
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -61,4 +63,45 @@ TEST(TestSocDescriptor, LiteralCoordSystem) {
         EXPECT_ANY_THROW(
             soc_descriptor.translate_coord_to(literal_dram_pair, tt::CoordSystem::LITERAL, tt::CoordSystem::NOC0));
     }
+}
+
+// A Mimir chiplet carries DRAM and the SMC, and no compute. These tests need no device: they only
+// exercise the descriptor.
+TEST(TestSocDescriptor, MimirDescriptorEnumeratesDramAndSmcCores) {
+    SocDescriptor soc_descriptor(std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("mimir_1x1.yaml")));
+
+    EXPECT_EQ(soc_descriptor.get_arch_descriptor().get_arch(), tt::ARCH::GRENDEL);
+
+    // Two DRAM cores, one per chippy GDDR instance.
+    EXPECT_EQ(soc_descriptor.get_cores(tt::CoreType::DRAM).size(), 2);
+
+    std::vector<CoreCoord> smc_cores = soc_descriptor.get_cores(tt::CoreType::SMC);
+    ASSERT_EQ(smc_cores.size(), 1);
+    EXPECT_EQ(smc_cores.front().x, 0);
+    EXPECT_EQ(smc_cores.front().y, 1);
+    EXPECT_EQ(smc_cores.front().core_type, tt::CoreType::SMC);
+
+    // Mimir has no compute or ethernet.
+    EXPECT_TRUE(soc_descriptor.get_cores(tt::CoreType::TENSIX).empty());
+    EXPECT_TRUE(soc_descriptor.get_cores(tt::CoreType::ETH).empty());
+
+    // Like the other irregular core types, SMC cores are never harvested and have no grid.
+    EXPECT_TRUE(soc_descriptor.get_harvested_cores(tt::CoreType::SMC).empty());
+    EXPECT_EQ(soc_descriptor.get_grid_size(tt::CoreType::SMC), tt_xy_pair(0, 0));
+
+    // The SMC core is reachable through the coordinate manager, not just the type query.
+    EXPECT_EQ(soc_descriptor.get_coord_at(tt_xy_pair(0, 1), tt::CoordSystem::NOC0).core_type, tt::CoreType::SMC);
+
+    std::vector<CoreCoord> all_cores = soc_descriptor.get_all_cores();
+    EXPECT_EQ(all_cores.size(), 3);
+}
+
+TEST(TestSocDescriptor, SmcCoresSurviveSerializationRoundTrip) {
+    SocDescriptor soc_descriptor(std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("mimir_1x1.yaml")));
+
+    std::filesystem::path file_path = soc_descriptor.serialize_to_file();
+    SocDescriptor reloaded(std::make_shared<SocArchDescriptor>(file_path.string()));
+
+    EXPECT_EQ(reloaded.get_cores(tt::CoreType::SMC).size(), soc_descriptor.get_cores(tt::CoreType::SMC).size());
+    EXPECT_EQ(reloaded.get_cores(tt::CoreType::SMC).front(), soc_descriptor.get_cores(tt::CoreType::SMC).front());
 }

--- a/tests/soc_descs/mimir_1x1.yaml
+++ b/tests/soc_descs/mimir_1x1.yaml
@@ -1,0 +1,50 @@
+# One Mimir chiplet reached over JTAG, as a single UMD chip.
+#
+# Mimir carries no compute: it is DRAM plus the SMC (System Management Complex), the on-die
+# management CPU that a JTAG bring-up client reaches first. The two DRAM cores mirror chippy's two
+# GDDR instances per Mimir (kMimirGddrDramTile0SpaBaseAddr / Tile1SpaBaseAddr).
+#
+# The (x, y) coordinates are UMD-side handles, not hardware NOC coordinates: chippy addresses a
+# Mimir chiplet flat, with no coordinate component, so the routing protocol maps a core to a
+# transport and an address base rather than to a NOC endpoint. They are provisional pending the
+# product/chippy answer on the DRAM instance and tile layout.
+
+grid:
+  x_size: 2
+  y_size: 2
+
+arc:
+  []
+
+pcie:
+  []
+
+dram:
+  [[0-0],
+  [1-0]]
+
+eth:
+  []
+
+functional_workers:
+  []
+
+router_only:
+  []
+
+dispatch:
+  []
+
+smc:
+  [0-1]
+
+worker_l1_size:
+  0
+
+dram_bank_size:
+  8589934592
+
+eth_l1_size:
+  0
+
+arch_name: GRENDEL


### PR DESCRIPTION
### Issue
Part of Grendel JTAG integration (internal tracking: tenstorrent/tt-umd-internal#22).

### Description
Adds the SoC descriptor for a single Mimir chiplet, the first Grendel package UMD will open over JTAG. Mimir carries no compute — it is DRAM plus the SMC (System Management Complex), the on-die management CPU a JTAG bring-up client reaches first — so describing it needs a new `CoreType::SMC` and a `GRENDEL` arch.

`ARCH::GRENDEL` names the package rather than a chiplet, matching the one-UMD-chip-per-package model: one Mimir, two Mimirs, or Quasar plus Mimir are all Grendel. Such packages have no fixed floorplan, so they are described by YAML with no hardcoded architecture constants. Core `(x, y)` values are UMD-side handles, not hardware NOC coordinates, since chippy addresses a Mimir flat; they are provisional pending the product answer on DRAM instance and tile layout.

### List of the changes
- New `CoreType::SMC`, threaded through `SocArchDescriptor` (`smc:` YAML key, `get_smc_cores()`), `CoordinateManager` (core list, NOC0 identity mapping, per-core-type queries) and `SocDescriptor`. It behaves like the other irregular core types: never harvested, no grid.
- New `ARCH::GRENDEL`, mapped to the Grendel architecture implementation and the Quasar coordinate manager.
- New `tests/soc_descs/mimir_1x1.yaml`: two DRAM cores (mirroring chippy's two GDDR instances) plus one SMC core.
- Device-free tests for enumeration, harvesting, coordinate lookup and a serialization round-trip.

### Testing
CI

### API Changes
Adds `CoreType::SMC` (inserted before the compatibility entries, so `HARVESTED`, `ETH`, `WORKER`, `COUNT` and `UNSPECIFIED` shift by one; nothing serializes `CoreType` numerically), `ARCH::GRENDEL = 5` with its `arch_from_str`/`arch_to_str` spellings, `SocArchDescriptor::get_smc_cores()`, and a trailing defaulted `smc_cores` parameter on `create_coordinate_manager` and the four coordinate-manager constructors.