### PR TITLE
Simulation: make try_create() private and add a static is_live(path)

### DIFF
--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <optional>
 #include <system_error>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
@@ -26,28 +27,33 @@ namespace tt::umd {
 
 namespace {
 
-// The role a UMD process takes for a given simulator_path -- decided purely from what the path is,
-// with no socket bind-race:
-//   - a ".so" file                 -> host running the TTSim backend for that library;
+// What a given simulator_path means, decided purely from what the path is, with no socket
+// bind-race:
+//   - a ".so" file                 -> host, running the TTSim backend for that library;
 //   - a directory holding per-chip  -> client: a host already serves there, so attach to each
 //     simulation sockets               socket in it (one device per socket), sourcing device
 //                                      identity from the host over the wire;
-//   - any other directory          -> host running the RTL backend from that build directory.
-enum class PathKind { HOST_TTSIM, HOST_RTL, CLIENT };
-
-// The path kind and, for CLIENT, the sockets found in the directory -- returned together so
-// discover() doesn't scan the directory a second time. The second scan would also be a TOCTOU race:
-// if the host exited between the two scans, the kind would still be CLIENT but discover() would
-// build zero devices from a now-empty listing and return silently.
+//   - any other directory          -> host, running the RTL backend from that build directory.
+//
+// Role and backend are orthogonal -- a client can attach to either backend -- so they are kept as
+// separate fields rather than collapsed into one enum. The sockets are carried alongside so
+// discover() doesn't scan the directory a second time; a second scan would also be a TOCTOU race,
+// since a host that exited in between would leave the role at Client while discover() built zero
+// devices from a now-empty listing and returned silently.
 struct Classification {
-    PathKind kind;
+    SimulationConnector::Role role = SimulationConnector::Role::Host;
+    // Which backend this process would host. Empty for a client: a client runs no local backend,
+    // and takes the host's backend_type from the device info it fetches over the wire (see
+    // make_client_device).
+    std::optional<SimulationBackendType> backend;
+    // Client only: the per-chip sockets found in the directory.
     std::map<ChipId, std::filesystem::path> sockets;
 };
 
 Classification classify(const std::filesystem::path& simulator_path) {
     std::error_code ec;
     if (std::filesystem::is_regular_file(simulator_path, ec) && simulator_path.extension() == ".so") {
-        return {PathKind::HOST_TTSIM, {}};
+        return {SimulationConnector::Role::Host, SimulationBackendType::TTSIM, {}};
     }
     UMD_ASSERT(
         std::filesystem::is_directory(simulator_path, ec),
@@ -57,20 +63,20 @@ Classification classify(const std::filesystem::path& simulator_path) {
     // attach as a client; any other directory is an RTL build we host.
     auto sockets = SimulationServerSocket::sockets_in_directory(simulator_path);
     if (sockets.empty()) {
-        return {PathKind::HOST_RTL, {}};
+        return {SimulationConnector::Role::Host, SimulationBackendType::RTL, {}};
     }
-    return {PathKind::CLIENT, std::move(sockets)};
+    return {SimulationConnector::Role::Client, std::nullopt, std::move(sockets)};
 }
 
 // Host path: bring up the in-process backend (the direct hot path). A null socket means serving is
 // off, so the device stays a private in-process host; a non-null socket is adopted so clients can
 // attach.
 std::unique_ptr<TTDevice> make_host_device(
-    PathKind role,
+    SimulationBackendType backend,
     const std::filesystem::path& simulator_directory,
     int num_host_mem_channels,
     std::unique_ptr<SimulationServerSocket> socket) {
-    if (role == PathKind::HOST_TTSIM) {
+    if (backend == SimulationBackendType::TTSIM) {
         auto device = TTSimTTDevice::create(simulator_directory, num_host_mem_channels);
         if (socket) {
             device->adopt_socket(std::move(socket));
@@ -105,8 +111,7 @@ std::unique_ptr<TTDevice> make_client_device(
 }  // namespace
 
 SimulationConnector::Role SimulationConnector::role_for(const std::filesystem::path& simulator_directory) {
-    // The two host backends collapse to Host for callers that only care host-vs-client.
-    return classify(simulator_directory).kind == PathKind::CLIENT ? Role::Client : Role::Host;
+    return classify(simulator_directory).role;
 }
 
 std::filesystem::path SimulationConnector::allocate_server_directory() {
@@ -131,7 +136,7 @@ SimulationConnector::Result SimulationConnector::discover(const SimulationConnec
 
     const Classification classification = classify(simulator_path);
 
-    if (classification.kind == PathKind::CLIENT) {
+    if (classification.role == Role::Client) {
         // Multi-chip: one client device per per-chip socket in the directory (enumerated by
         // classify()). Chip ids come from the socket names, so they match the host's. A failure on
         // one socket (a dead or wedged host) only skips that chip -- it must not abort attaching to
@@ -211,14 +216,15 @@ SimulationConnector::Result SimulationConnector::discover(const SimulationConnec
         result.connection.server_directory = server_directory;
         result.connection.sockets.emplace(chip_id, socket_path);
     }
+    // value() rather than operator*: classify() always sets a backend for the host role, and this
+    // makes that invariant explicit instead of reading an empty optional if it ever stops holding.
+    const SimulationBackendType backend = classification.backend.value();
     devices.emplace(
-        chip_id,
-        make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));
+        chip_id, make_host_device(backend, simulator_path, options.num_host_mem_channels, std::move(socket)));
 
     result.connection.role = Role::Host;
     result.connection.simulator = simulator_path;
-    result.connection.backend =
-        classification.kind == PathKind::HOST_TTSIM ? SimulationBackendType::TTSIM : SimulationBackendType::RTL;
+    result.connection.backend = backend;
     result.connection.arch = devices.at(chip_id)->get_soc_descriptor().arch;
     return result;
 }

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -165,17 +165,18 @@ void SimulationServerSocket::do_accept() {
     });
 }
 
-bool SimulationServerSocket::is_live() {
+bool SimulationServerSocket::is_live(const std::filesystem::path& socket_path) {
     // is_live() is a predicate; a path too long to name a reachable listener can't have one,
     // so report not-live rather than letting make_endpoint() throw.
-    if (socket_path_.string().size() >= sizeof(sockaddr_un::sun_path)) {
+    if (socket_path.string().size() >= sizeof(sockaddr_un::sun_path)) {
         return false;
     }
-    // Reuse impl_->io rather than spin up a throwaway io_context: a synchronous connect()
-    // doesn't run the event loop, so the shared context is untouched (cf. warm_reset.cpp).
-    stream_protocol::socket probe(impl_->io);
+    // A synchronous connect() doesn't run the event loop, so this context exists only to own the
+    // probe socket and never processes anything (cf. warm_reset.cpp).
+    asio::io_context io;
+    stream_protocol::socket probe(io);
     std::error_code ec;
-    probe.connect(make_endpoint(socket_path_), ec);
+    probe.connect(make_endpoint(socket_path), ec);
     return !ec;
 }
 
@@ -219,7 +220,7 @@ bool SimulationServerSocket::bind_and_listen() {
         // the gap) is undefined. The socket dir is assumed trusted (see
         // default_socket_path), which is what makes this acceptable. Note a stale socket
         // owned by another user may not be removable under a sticky dir (e.g. /tmp).
-        if (is_live()) {
+        if (is_live(socket_path_)) {
             return false;
         }
         // Reclaim only an actual stale socket. A non-socket object squatting the path (regular

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -20,16 +20,18 @@ namespace tt::umd {
 // ("the card"). One socket per simulated chip, kept in a per-server directory
 // (allocate_server_directory) so distinct hosts on the same machine never collide.
 //
-// The socket acts as a presence indicator: if a process can bind the path it becomes the
-// host; if a live host already exists, try_create() returns nullptr so the caller
-// (SimulationConnector) can attach as a client instead, while create() throws. Stale
+// The socket acts as a presence indicator: if a process can bind the path it becomes the host,
+// and create() throws if a live host already holds it. Which role a process takes is decided
+// from the path by SimulationConnector, not by racing for the bind; is_live() answers whether a
+// host has the path bound and listening, which the socket file's presence alone does not (it says
+// nothing about whether that host is still alive, only that one bound it once). Stale
 // sockets left by crashed owners are automatically reclaimed. On destruction the host closes
 // the socket and removes the file.
 //
 // Request handling is split from binding, so the owner can claim the socket first and begin
 // serving only once its backend is ready (the handler dispatches into that backend, which does
 // not exist at bind time -- see the host device's adopt_socket()):
-//   - bind (try_create/create): the socket is bound and connectable -- pure presence/liveness --
+//   - bind (create): the socket is bound and connectable -- pure presence/liveness --
 //     but accepts nothing until serve() is called.
 //   - serve(handler): starts the accept loop; each accepted connection is served on its own
 //     thread, which reads one length-prefixed request at a time (see simulation_server_transport),
@@ -55,14 +57,19 @@ public:
     SimulationServerSocket(const SimulationServerSocket&) = delete;
     SimulationServerSocket& operator=(const SimulationServerSocket&) = delete;
 
-    // Binds and listens, reclaiming a stale socket. Returns nullptr if a *live* owner already
-    // holds the path (so the caller can attach as a client). Throws on real socket errors. The
-    // socket is presence-only (bound + connectable) until serve() installs a handler.
-    static std::unique_ptr<SimulationServerSocket> try_create(const std::filesystem::path& socket_path);
-
-    // Like try_create(), but throws (instead of returning nullptr) when a live owner already
-    // holds the path. For callers that require ownership and have no client path to fall back to.
+    // Binds and listens, reclaiming a socket left behind by a crashed owner, and throws when a
+    // *live* owner already holds the path. Throws on real socket errors too. The socket is
+    // presence-only (bound + connectable) until serve() installs a handler.
     static std::unique_ptr<SimulationServerSocket> create(const std::filesystem::path& socket_path);
+
+    // True if a listener is currently reachable at socket_path -- i.e. a host holds it bound and
+    // listening, as opposed to the path being free or holding a socket file a crashed owner left
+    // behind, which are indistinguishable on disk. Does not claim the path.
+    //
+    // Note this is liveness of the bind, not of request handling: a host binds before serve()
+    // installs its handler (see the split described above), so a host still coming up reads as
+    // live and a client attaching to it will wait on the accept that has not started yet.
+    static bool is_live(const std::filesystem::path& socket_path);
 
     // Starts serving accepted connections through request_handler (see the class comment). Call
     // once, after the backend the handler dispatches into is ready. The handler is installed
@@ -110,13 +117,15 @@ private:
     // the try_create()/create() factories.
     explicit SimulationServerSocket(const std::filesystem::path& socket_path);
 
+    // Like create(), but returns nullptr instead of throwing when a live owner already holds the
+    // path. An implementation detail of create(): nothing outside needs the null return, since the
+    // role a process takes is decided from the path rather than by racing for the bind.
+    static std::unique_ptr<SimulationServerSocket> try_create(const std::filesystem::path& socket_path);
+
     // Binds + listens (claims the path; connectable for liveness). Does not accept yet -- the
     // accept loop starts in serve(). Returns false if a live owner holds the path; throws on real
     // socket errors.
     bool bind_and_listen();
-
-    // True if a listener is currently reachable at socket_path_.
-    bool is_live();
 
     // Re-arms the async accept; each accepted connection is handed to a serving thread. Only ever
     // runs while serving (serve() started it), so request_handler_ is always set here.

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -112,23 +112,15 @@ TEST_F(SimulationServerSocketTest, ThrowsWhenLiveServerAlreadyExists) {
     EXPECT_ANY_THROW(SimulationServerSocket::create(path_));
 }
 
-TEST_F(SimulationServerSocketTest, TryCreateReturnsNullWhenLiveHostExists) {
-    auto host = SimulationServerSocket::try_create(path_);
-    ASSERT_NE(host, nullptr);
-    EXPECT_EQ(SimulationServerSocket::try_create(path_), nullptr);  // live host -> null, no throw
+// A failed create() builds and destroys a socket object that never won the bind; ownership-gated
+// teardown must stop it removing the live host's socket on the way out.
+TEST_F(SimulationServerSocketTest, FailedCreateLeavesTheLiveHostAlone) {
+    auto host = SimulationServerSocket::create(path_);
 
-    // The throwaway object from the failed try_create above must not remove the live
-    // host's socket on destruction (ownership-gated teardown).
+    EXPECT_ANY_THROW(SimulationServerSocket::create(path_));
+
     EXPECT_TRUE(std::filesystem::exists(path_));
-    EXPECT_TRUE(can_connect(path_));
-}
-
-TEST_F(SimulationServerSocketTest, TryCreateReclaimsStaleSocket) {
-    leave_stale_socket(path_);
-
-    auto host = SimulationServerSocket::try_create(path_);
-    EXPECT_NE(host, nullptr);  // stale leftover reclaimed
-    EXPECT_TRUE(can_connect(path_));
+    EXPECT_TRUE(SimulationServerSocket::is_live(path_));
 }
 
 // A non-socket file squatting the path also yields EADDRINUSE on bind; the reclaim path
@@ -136,8 +128,29 @@ TEST_F(SimulationServerSocketTest, TryCreateReclaimsStaleSocket) {
 TEST_F(SimulationServerSocketTest, RefusesToReclaimNonSocketFile) {
     { std::ofstream(path_) << "not a socket"; }
 
-    EXPECT_THROW(SimulationServerSocket::try_create(path_), std::exception);
+    EXPECT_THROW(SimulationServerSocket::create(path_), std::exception);
     EXPECT_TRUE(std::filesystem::exists(path_));  // the regular file was left untouched
+}
+
+// is_live() is the liveness question the socket file's presence cannot answer: nothing there and a
+// socket left by a crashed owner both read as "no host", only a bound-and-listening owner as live.
+TEST_F(SimulationServerSocketTest, IsLiveDistinguishesAHostFromAnAbsentOrStaleSocket) {
+    EXPECT_FALSE(SimulationServerSocket::is_live(path_));  // nothing there at all
+
+    leave_stale_socket(path_);
+    ASSERT_TRUE(std::filesystem::exists(path_));           // the file is on disk...
+    EXPECT_FALSE(SimulationServerSocket::is_live(path_));  // ...but nothing is serving on it
+
+    auto host = SimulationServerSocket::create(path_);  // reclaims the stale file and binds
+    EXPECT_TRUE(SimulationServerSocket::is_live(path_));
+}
+
+// A path too long for sockaddr_un cannot name a reachable listener, so is_live() answers the
+// predicate rather than throwing out of make_endpoint().
+TEST_F(SimulationServerSocketTest, IsLiveIsFalseForAnOverlongPath) {
+    const std::filesystem::path too_long =
+        std::filesystem::temp_directory_path() / (std::string(sizeof(sockaddr_un::sun_path), 'x') + ".sock");
+    EXPECT_FALSE(SimulationServerSocket::is_live(too_long));
 }
 
 // Inverts every byte, so a served reply is distinguishable from the request that produced it.


### PR DESCRIPTION
### Issue

#3081, item 2. Stacked on #3337.

Second of three; the last one uses `is_live()` to make classification liveness-aware.

### Description

`try_create()`'s nullptr return dates from when a process discovered its role by racing for the bind. That role now comes from the path, so nothing in production consumes the null -- `create()` is its only caller. The tests were using it as a liveness oracle instead: binding a socket and destroying it just to learn whether someone else held the path, which is both indirect and a write where a read would do.

So `try_create()` becomes a private implementation detail of `create()`, and callers get the question they were actually asking: a static `is_live(path)` that probes for a listener without claiming anything. The private member `is_live()` folds into it.

### List of the changes

- `try_create()` moved to `private`; `create()` unchanged for callers.
- New `static bool is_live(const std::filesystem::path&)`; the member overload folds into it.
- The three tests that drove `try_create()` rewritten against `create()` and `is_live()`, plus coverage that `is_live()` separates absent, stale and live sockets.

### Testing

CI

### API Changes

`SimulationServerSocket::try_create()` is no longer public and `SimulationServerSocket::is_live(path)` is new. Both are internal to the simulation subsystem, not part of the public UMD API.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/simulation-live-classification