### PR TITLE
Simulation: classify a socket directory by liveness, not by presence

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -433,13 +433,20 @@ Cluster::Cluster(ClusterOptions options) {
             // chip loop wraps in SimulationChips).
             if (options.chip_type == ChipType::SIMULATION &&
                 SimulationConnector::role_for(options.simulator_directory) == SimulationConnector::Role::Client) {
-                const std::map<ChipId, std::filesystem::path> sockets =
-                    SimulationServerSocket::sockets_in_directory(options.simulator_directory);
+                std::map<ChipId, std::filesystem::path> sockets;
+                for (const auto& [chip_id, socket_path] :
+                     SimulationServerSocket::sockets_in_directory(options.simulator_directory)) {
+                    // Skip sockets a crashed host left behind: role_for() above only guarantees
+                    // that *some* socket here is live, and the probe below has to reach one.
+                    if (SimulationServerSocket::is_live(socket_path)) {
+                        sockets.emplace(chip_id, socket_path);
+                    }
+                }
                 UMD_ASSERT(
                     !sockets.empty(),
                     error::RuntimeError,
                     fmt::format(
-                        "No simulation sockets found in {}; nothing to attach to.",
+                        "No live simulation sockets found in {}; nothing to attach to.",
                         options.simulator_directory.string()));
 
                 // Fetch the topology from one host. Empty YAML => the host has no cluster descriptor,

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -61,11 +61,38 @@ Classification classify(const std::filesystem::path& simulator_path) {
         fmt::format("Simulator path is neither a .so file nor a directory: {}", simulator_path.string()));
     // A directory that holds per-chip simulation sockets means a host is already serving there, so
     // attach as a client; any other directory is an RTL build we host.
-    auto sockets = SimulationServerSocket::sockets_in_directory(simulator_path);
+    const auto sockets = SimulationServerSocket::sockets_in_directory(simulator_path);
     if (sockets.empty()) {
         return {SimulationConnector::Role::Host, SimulationBackendType::RTL, {}};
     }
-    return {SimulationConnector::Role::Client, std::nullopt, std::move(sockets)};
+    // A socket file on disk only proves someone bound the path once, not that anyone is still
+    // serving it: a crashed host leaves one behind that is indistinguishable by stat(). Count only
+    // the sockets with a live listener, so a stale one neither drags a healthy directory's chip
+    // list out of shape nor sends discover() off to connect to nothing.
+    std::map<ChipId, std::filesystem::path> live_sockets;
+    for (const auto& [chip_id, socket_path] : sockets) {
+        if (SimulationServerSocket::is_live(socket_path)) {
+            live_sockets.emplace(chip_id, socket_path);
+        } else {
+            log_warning(
+                LogUMD,
+                "Ignoring simulation socket {} (chip {}): no host is serving it.",
+                socket_path.string(),
+                chip_id);
+        }
+    }
+    // Every socket is stale: the directory belonged to a host that is gone. Say so, rather than
+    // falling through to hosting an RTL build out of a server directory -- which would fail later
+    // with an unrelated message. `sim_server.sh prune` clears these out.
+    UMD_ASSERT(
+        !live_sockets.empty(),
+        error::RuntimeError,
+        fmt::format(
+            "The {} simulation socket(s) in {} are stale -- the host that served them is gone. Run `sim_server.sh "
+            "prune` to clear them, or point at a simulator to host one.",
+            sockets.size(),
+            simulator_path.string()));
+    return {SimulationConnector::Role::Client, std::nullopt, std::move(live_sockets)};
 }
 
 // Host path: bring up the in-process backend (the direct hot path). A null socket means serving is

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -108,8 +108,12 @@ public:
     // The per-chip simulation sockets present in a directory: {chip_id -> socket file}, keyed and
     // ordered by chip id. Only AF_UNIX sockets whose names match the default_socket_path()
     // convention are included; everything else in the directory is ignored. Empty if the path is
-    // not a directory or holds no such sockets. This is how a client turns a socket directory into
-    // the set of hosts to attach to.
+    // not a directory or holds no such sockets.
+    //
+    // Presence only: a socket here may be one a crashed host left behind, so this is not the set of
+    // hosts to attach to. SimulationConnector's classifier narrows it with is_live() and rejects a
+    // directory whose sockets are all stale. Presence is what sim_server's `list` and `prune` need,
+    // since they exist to report and remove exactly those leftovers.
     static std::map<ChipId, std::filesystem::path> sockets_in_directory(const std::filesystem::path& directory);
 
 private:

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -3,13 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "tests/test_utils/simulation_socket_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
@@ -408,4 +413,54 @@ TEST(SimulationConnector, ReportsClientConnection) {
     EXPECT_EQ(client.connection.simulator, host.connection.simulator);
     EXPECT_EQ(client.connection.backend, host.connection.backend);
     EXPECT_EQ(client.connection.arch, host.connection.arch);
+}
+
+// A socket file proves only that someone bound the path once. A directory holding nothing but
+// sockets a crashed host left behind is not a server to attach to, and saying so beats falling
+// through to hosting an RTL build out of a server directory. Needs no simulator.
+TEST(SimulationConnector, ThrowsOnADirectoryOfOnlyStaleSockets) {
+    // Nothing ever hosts this directory, so no server teardown removes it: the guard does.
+    const test_utils::ScopedServerDirectory directory(SimulationServerSocket::allocate_server_directory());
+    test_utils::leave_stale_socket(SimulationServerSocket::default_socket_path(directory.path(), 0));
+
+    // Classification is what rejects it, so both entry points do.
+    EXPECT_THROW(SimulationConnector::role_for(directory.path()), std::exception);
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = directory.path();
+    EXPECT_THROW(SimulationConnector::discover(options), std::exception);
+}
+
+// One stale socket beside a live one must not drag the healthy chip out of the client's device
+// list, nor make the topology probe pick the dead socket. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, IgnoresAStaleSocketBesideALiveOne) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    // The stale socket below keeps the host's teardown from removing the directory (it only rmdir's
+    // an empty one), and the ASSERT_EQ can return before any cleanup line: the guard covers both.
+    const test_utils::ScopedServerDirectory server_directory(SimulationServerSocket::allocate_server_directory());
+
+    SimulationConnectorOptions host_options;
+    host_options.simulator_directory = simulator_path;
+    host_options.serve_over_sockets = true;
+    host_options.server_directory = server_directory.path();
+    const SimulationConnector::Result host = SimulationConnector::discover(host_options);
+    ASSERT_EQ(host.devices.size(), 1u);  // the live host serves chip 0
+
+    // A second chip's socket, left behind by a host that is gone.
+    test_utils::leave_stale_socket(SimulationServerSocket::default_socket_path(server_directory.path(), 1));
+
+    SimulationConnectorOptions client_options;
+    client_options.simulator_directory = server_directory.path();
+    const SimulationConnector::Result client = SimulationConnector::discover(client_options);
+
+    EXPECT_EQ(client.connection.role, SimulationConnector::Role::Client);
+    // Chip 1 is dropped at classification, so it reaches neither the devices nor the reported
+    // sockets -- the client sees exactly the chips actually being served.
+    EXPECT_EQ(client.devices.size(), 1u);
+    EXPECT_EQ(client.devices.count(1), 0u);
+    EXPECT_EQ(client.connection.sockets, host.connection.sockets);
 }

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -17,6 +17,7 @@
 
 #include "simulation/simulation_server_socket.hpp"
 #include "simulation/simulation_server_transport.hpp"
+#include "tests/test_utils/simulation_socket_test_utils.hpp"
 
 using namespace tt::umd;
 using stream_protocol = asio::local::stream_protocol;
@@ -52,21 +53,6 @@ stream_protocol::socket connect_client(asio::io_context& io, const std::filesyst
     return socket;
 }
 
-// Binds a UNIX socket to path then closes it without listening, leaving a stale
-// socket file behind (connect() to it yields ECONNREFUSED) — what a crashed
-// owner leaves on disk.
-void leave_stale_socket(const std::filesystem::path& path) {
-    std::filesystem::remove(path);
-    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
-    ASSERT_GE(fd, 0);
-    sockaddr_un addr{};
-    addr.sun_family = AF_UNIX;
-    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
-    ASSERT_EQ(::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
-    ::close(fd);
-    ASSERT_TRUE(std::filesystem::exists(path));
-}
-
 // Provides a fresh socket path that is removed before and after each test, so cases share a
 // fixed name without leaking sockets between runs.
 class SimulationServerSocketTest : public ::testing::Test {
@@ -98,7 +84,7 @@ TEST_F(SimulationServerSocketTest, RemovesSocketOnDestruction) {
 }
 
 TEST_F(SimulationServerSocketTest, ReclaimsStaleSocketFile) {
-    leave_stale_socket(path_);
+    test_utils::leave_stale_socket(path_);
     EXPECT_FALSE(can_connect(path_));
 
     auto server = SimulationServerSocket::create(path_);
@@ -137,7 +123,7 @@ TEST_F(SimulationServerSocketTest, RefusesToReclaimNonSocketFile) {
 TEST_F(SimulationServerSocketTest, IsLiveDistinguishesAHostFromAnAbsentOrStaleSocket) {
     EXPECT_FALSE(SimulationServerSocket::is_live(path_));  // nothing there at all
 
-    leave_stale_socket(path_);
+    test_utils::leave_stale_socket(path_);
     ASSERT_TRUE(std::filesystem::exists(path_));           // the file is on disk...
     EXPECT_FALSE(SimulationServerSocket::is_live(path_));  // ...but nothing is serving on it
 
@@ -334,9 +320,9 @@ TEST(SimulationServerSocket, SocketsInDirectoryPicksPerChipSockets) {
     fs::remove_all(dir);
     fs::create_directories(dir);
 
-    leave_stale_socket(dir / "tt-umd-sim-0.sock");                   // per-chip socket -> included
-    leave_stale_socket(dir / "tt-umd-sim-2.sock");                   // per-chip socket -> included
-    leave_stale_socket(dir / "unrelated.sock");                      // socket, wrong name -> excluded
+    test_utils::leave_stale_socket(dir / "tt-umd-sim-0.sock");       // per-chip socket -> included
+    test_utils::leave_stale_socket(dir / "tt-umd-sim-2.sock");       // per-chip socket -> included
+    test_utils::leave_stale_socket(dir / "unrelated.sock");          // socket, wrong name -> excluded
     { std::ofstream(dir / "tt-umd-sim-9.sock") << "not a socket"; }  // right name, not a socket -> excluded
 
     const auto sockets = SimulationServerSocket::sockets_in_directory(dir);

--- a/tests/test_utils/simulation_socket_test_utils.hpp
+++ b/tests/test_utils/simulation_socket_test_utils.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace test_utils {
+
+// Leaves a socket file at path that nothing is serving: bound, never listened on, and closed --
+// exactly what a crashed simulation host leaves on disk. connect() to it yields ECONNREFUSED, so it
+// is indistinguishable from a live host's socket by stat() alone, which is what makes it useful for
+// exercising liveness-aware code paths.
+inline void leave_stale_socket(const std::filesystem::path& path) {
+    const std::string path_str = path.string();
+    // sun_path is fixed-size and strncpy truncates silently, which would bind some other path;
+    // refuse rather than test the wrong thing.
+    ASSERT_LT(path_str.size(), sizeof(sockaddr_un::sun_path)) << "socket path too long for sockaddr_un: " << path_str;
+    // A leftover from an earlier run would make bind() fail with EADDRINUSE.
+    std::filesystem::remove(path);
+
+    const int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    ASSERT_GE(fd, 0);
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::memcpy(addr.sun_path, path_str.c_str(), path_str.size() + 1);
+    const int bind_result = ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    // Closed before asserting, so a failed bind doesn't leak the descriptor out of the helper.
+    ::close(fd);
+    ASSERT_EQ(bind_result, 0);
+    ASSERT_TRUE(std::filesystem::exists(path));
+}
+
+// Removes a simulation server directory and everything left in it when the scope ends. A directory
+// survives a test only when something in it is unowned -- a stale socket no host will tear down --
+// and a remove_all() on the last line of the test body is exactly what a fatal assertion skips,
+// since GTEST_ASSERT_* returns from the body. Leftovers are not inert: they enumerate in
+// list_servers() and are what classify() now rejects, so one bailed-out test poisons the next run.
+class ScopedServerDirectory {
+public:
+    explicit ScopedServerDirectory(std::filesystem::path directory) : directory_(std::move(directory)) {}
+
+    ScopedServerDirectory(const ScopedServerDirectory&) = delete;
+    ScopedServerDirectory& operator=(const ScopedServerDirectory&) = delete;
+
+    // Non-throwing overload: a destructor is implicitly noexcept, so a filesystem_error would call
+    // std::terminate. Cleanup is best-effort.
+    ~ScopedServerDirectory() {
+        std::error_code ec;
+        std::filesystem::remove_all(directory_, ec);
+    }
+
+    const std::filesystem::path& path() const { return directory_; }
+
+private:
+    std::filesystem::path directory_;
+};
+
+}  // namespace test_utils


### PR DESCRIPTION
### Issue
Closes #3081 (item 3; items 1 and 2 are #3337 and #3339). Stacked on #3339. The only one of the three that changes behaviour.

### Description
`sockets_in_directory()` answers presence — a socket file is on disk. Classification needs a different question, because a crashed host leaves behind a socket that `stat()` cannot tell from a live one. One such leftover marked a directory as a client target for good, and discovery then failed on connect. Where a live socket sat beside a stale one it was worse than an error: the stale chip still entered the client's device list, and `Cluster` could pick it as the socket to fetch the topology from.

`classify()` now counts only sockets with a live listener (#3339's `is_live()`), and `Cluster`'s topology probe picks a live socket rather than the first one. A directory whose sockets are *all* stale is reported as such — the alternative was falling through to "any other directory -> host RTL", which would try to start an RTL simulator out of a server directory and fail later with an unrelated message. The error names `sim_server.sh prune`, which is how those directories are meant to be cleared. `sockets_in_directory()` keeps its presence semantics, since `list` needs stale sockets to report them and `prune` needs them to remove them.

### List of the changes
- `classify()` filters to live sockets and rejects an all-stale directory with a message pointing at `prune`.
- `Cluster`'s client path probes a live socket for the topology instead of the first one present.
- Tests for the all-stale directory (no simulator needed) and for a stale socket beside a live one.

### Testing
CI

### API Changes
Behavioural: pointing UMD at a directory whose simulation sockets are all stale now throws a message naming the directory, where it previously failed on connect or attempted to host an RTL build from it. A stale socket beside a live one is ignored rather than surfacing as an unreachable chip.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/simulation-live-classification