### PR TITLE
Simulation: report the role and simulator link of an opened connection

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -26,6 +26,9 @@
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/simulation_connector.hpp"
+#endif  // TT_UMD_BUILD_SIMULATION
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
@@ -329,6 +332,15 @@ public:
     // the library is built with TT_UMD_BUILD_SIMULATION=ON.
     void register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction);
     void register_sim_fabric_node_id(ChipId chip_id, uint32_t mesh_id, uint32_t fabric_chip_id);
+
+    /**
+     * What simulation this cluster is connected to: whether this process hosts the simulation or
+     * attached to one another process hosts, which simulator sits behind it, and -- for a host that
+     * serves -- the directory and sockets it serves on, including one UMD allocated itself.
+     *
+     * std::nullopt for a cluster that is not a simulation cluster.
+     */
+    std::optional<SimulationConnector::Connection> get_simulation_connection() const;
 #endif  // TT_UMD_BUILD_SIMULATION
 
     //---------- Start and stop the device and tensix cores.
@@ -808,6 +820,11 @@ private:
     std::unique_ptr<RemoteChip> create_simulation_remote_chip(
         ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc);
 
+    // Host simulation Cluster only: describes the simulation this process runs, for
+    // get_simulation_connection(). Called once the chips exist, so the arch is known. The serving
+    // directory and sockets are filled in afterwards by serve_simulation_devices_over_sockets().
+    SimulationConnector::Connection describe_simulation_host(const std::filesystem::path& simulator_directory) const;
+
     // Host simulation Cluster only: exposes each simulation chip's device on its per-chip socket so a
     // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A
     // no-op for a client Cluster. Called once from the constructor after the chips are built.
@@ -832,6 +849,11 @@ private:
     tt::ARCH arch_name;
 
     std::unique_ptr<ClusterDescriptor> cluster_desc;
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Filled during construction for a simulation cluster: by discovery on the client path, by
+    // describe_simulation_host() plus serve_simulation_devices_over_sockets() on the host path.
+    std::optional<SimulationConnector::Connection> simulation_connection_;
+#endif  // TT_UMD_BUILD_SIMULATION
 
     // Options used to construct this cluster, needed to re-run topology discovery on refresh.
     ClusterOptions options_;

--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -9,6 +9,8 @@
 #include <memory>
 #include <vector>
 
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
 namespace tt::umd {
@@ -59,7 +61,36 @@ public:
     enum class Role { Host, Client };
     static Role role_for(const std::filesystem::path& simulator_directory);
 
-    static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);
+    // What a discover() call actually opened: which side of the connection this process ended up
+    // on, and what simulator sits behind it. Reported alongside the devices because none of it is
+    // recoverable afterwards -- re-classifying the path answers only the role, and races a host
+    // that has since exited, while a server directory discover() allocated itself is otherwise
+    // never told to the caller at all.
+    struct Connection {
+        Role role = Role::Host;
+        // The simulator behind the devices: a libttsim .so path or an RTL build directory. As a
+        // host, the build this process opened; as a client, the build the host reports it runs --
+        // empty when talking to a host that predates serving that field.
+        std::filesystem::path simulator;
+        // Which kind of simulator that is, and the architecture it simulates.
+        SimulationBackendType backend = SimulationBackendType::TTSIM;
+        tt::ARCH arch = tt::ARCH::Invalid;
+        // As a host, the directory this process serves its sockets in: empty when serving is off,
+        // and the freshly allocated directory when the caller left server_directory empty. As a
+        // client, the directory it attached to.
+        std::filesystem::path server_directory;
+        // The per-chip sockets in that directory ({chip_id -> socket path}). Empty for a host that
+        // is not serving.
+        std::map<ChipId, std::filesystem::path> sockets;
+    };
+
+    // The devices discover() opened, and the connection it opened them over.
+    struct Result {
+        Connection connection;
+        std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+    };
+
+    static Result discover(const SimulationConnectorOptions& options);
 
     // Claims a fresh directory for one simulation server (the lowest free index) and returns it, so
     // a caller can report the location before it starts serving there (pass it back as

--- a/device/api/umd/device/simulation/simulation_device_identity.hpp
+++ b/device/api/umd/device/simulation/simulation_device_identity.hpp
@@ -18,8 +18,12 @@ namespace tt::umd {
 // topology without a local simulator build.
 
 // Host side: package this device's SocDescriptor into a wire message, so a client can receive it
-// and build its own matching SocDescriptor. backend_type records which simulator the host runs.
-SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type);
+// and build its own matching SocDescriptor. backend_type records which kind of simulator the host
+// runs, simulator_path which build of it -- together they let a client report what it is attached to.
+SimulationServerDeviceInfo describe_device(
+    const SocDescriptor& soc_descriptor,
+    SimulationBackendType backend_type,
+    const std::filesystem::path& simulator_path);
 
 // Client side: build a SocDescriptor from a wire message served by the host.
 SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info);

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -80,6 +80,9 @@ struct SimulationServerDeviceInfo {
     uint32_t eth_harvesting_mask = 0;
     uint32_t l2cpu_harvesting_mask = 0;
     uint32_t pcie_harvesting_mask = 0;
+    // The simulator the host runs (its .so path or RTL build directory), so a client can report
+    // what it is attached to. Empty from a host that predates the field.
+    std::string simulator_path;
 };
 
 // Cluster topology a host serves in reply to a GetClusterDescriptor request; mirrors

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -84,6 +84,11 @@ public:
 
     std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
 
+    // Which simulator this device runs (TTSim vs RTL). Served as part of the device identity so a
+    // remote client can build the matching device class, and reported by Cluster so a caller can
+    // tell what its simulation is backed by.
+    virtual SimulationBackendType backend_type() const = 0;
+
 protected:
     SimulationTTDevice(
         std::unique_ptr<TTDeviceModel> model,
@@ -116,10 +121,6 @@ protected:
     // read_from_device/write_to_device translate the CoreCoord once (via
     // translate_chip_coord_to_translated) before dispatching, so the `core` handed to every hook
     // below is already a TRANSLATED coordinate -- do not translate it again.
-
-    // Which simulator this device runs (TTSim vs RTL). Served as part of the device identity so a
-    // remote client can build the matching device class.
-    virtual SimulationBackendType backend_type() const = 0;
 
     // Direct tile (NOC unicast) access through the backend communicator.
     virtual void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) = 0;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -465,7 +465,9 @@ Cluster::Cluster(ClusterOptions options) {
                 connector_options.simulator_directory = options.simulator_directory;
                 connector_options.num_host_mem_channels =
                     static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(0));
-                tt_devices = SimulationConnector::discover(connector_options);
+                auto discovered = SimulationConnector::discover(connector_options);
+                simulation_connection_ = std::move(discovered.connection);
+                tt_devices = std::move(discovered.devices);
 
                 // Every chip the topology names must have a socket-backed device (single-chip today;
                 // a multichip host will publish one socket per chip). Fail clearly rather than later
@@ -654,9 +656,16 @@ Cluster::Cluster(ClusterOptions options) {
 #endif  // TT_UMD_BUILD_SIMULATION
 
 #ifdef TT_UMD_BUILD_SIMULATION
-    if (options.chip_type == ChipType::SIMULATION && options.serve_simulation_devices_over_sockets) {
-        serve_simulation_devices_over_sockets(
-            options.simulator_directory, options.simulator_server_directory, options.simulation_shutdown_handler);
+    if (options.chip_type == ChipType::SIMULATION) {
+        // The client path recorded its connection during discovery, so reaching here without one
+        // means this process runs the simulation itself.
+        if (!simulation_connection_.has_value()) {
+            simulation_connection_ = describe_simulation_host(options.simulator_directory);
+        }
+        if (options.serve_simulation_devices_over_sockets) {
+            serve_simulation_devices_over_sockets(
+                options.simulator_directory, options.simulator_server_directory, options.simulation_shutdown_handler);
+        }
     }
 #endif  // TT_UMD_BUILD_SIMULATION
 
@@ -668,6 +677,28 @@ Cluster::Cluster(ClusterOptions options) {
 }
 
 #ifdef TT_UMD_BUILD_SIMULATION
+std::optional<SimulationConnector::Connection> Cluster::get_simulation_connection() const {
+    return simulation_connection_;
+}
+
+SimulationConnector::Connection Cluster::describe_simulation_host(
+    const std::filesystem::path& simulator_directory) const {
+    SimulationConnector::Connection connection;
+    connection.role = SimulationConnector::Role::Host;
+    connection.simulator = simulator_directory;
+    // Take the backend and arch from a device rather than re-deriving them from the path, so this
+    // reports what was actually built. server_directory and sockets stay empty until (and unless)
+    // serve_simulation_devices_over_sockets() fills them.
+    for (const auto& [chip_id, chip] : chips_) {
+        if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
+            connection.backend = sim_device->backend_type();
+            connection.arch = sim_device->get_soc_descriptor().arch;
+            break;
+        }
+    }
+    return connection;
+}
+
 void Cluster::serve_simulation_devices_over_sockets(
     const std::filesystem::path& simulator_directory,
     const std::filesystem::path& simulator_server_directory,
@@ -688,11 +719,21 @@ void Cluster::serve_simulation_devices_over_sockets(
                                                        ? SimulationServerSocket::allocate_server_directory()
                                                        : simulator_server_directory;
     log_info(LogUMD, "Simulation host serving sockets in {}", server_directory.string());
+    // Report where this host serves. When the caller left simulator_server_directory empty the
+    // directory was allocated just above, so this is the only way it learns of it -- recorded here
+    // rather than per chip, so a host that turns out to have no simulation devices still reports
+    // the directory it claimed instead of reading as "not serving".
+    if (simulation_connection_.has_value()) {
+        simulation_connection_->server_directory = server_directory;
+    }
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
-            sim_device->adopt_socket(
-                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id)),
-                shutdown_handler);
+            const std::filesystem::path socket_path =
+                SimulationServerSocket::default_socket_path(server_directory, chip_id);
+            sim_device->adopt_socket(SimulationServerSocket::create(socket_path), shutdown_handler);
+            if (simulation_connection_.has_value()) {
+                simulation_connection_->sockets.emplace(chip_id, socket_path);
+            }
         }
     }
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -689,12 +689,26 @@ SimulationConnector::Connection Cluster::describe_simulation_host(
     // Take the backend and arch from a device rather than re-deriving them from the path, so this
     // reports what was actually built. server_directory and sockets stay empty until (and unless)
     // serve_simulation_devices_over_sockets() fills them.
+    bool described = false;
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             connection.backend = sim_device->backend_type();
             connection.arch = sim_device->get_soc_descriptor().arch;
+            described = true;
             break;
         }
+    }
+    // A simulation Cluster with no simulation device is degenerate but legal -- an empty
+    // target_devices with no cluster_descriptor.yaml beside the simulator yields zero chips -- so
+    // warn instead of asserting. Say so rather than reporting the defaults (TTSim/Invalid) as if
+    // they had been read off a device, which is also how a future regression that describes the
+    // host before the chips exist would surface.
+    if (!described) {
+        log_warning(
+            LogUMD,
+            "Simulation host {} has no simulation device to describe; reporting an unknown backend and "
+            "architecture.",
+            simulator_directory.string());
     }
     return connection;
 }
@@ -713,6 +727,13 @@ void Cluster::serve_simulation_devices_over_sockets(
     if (SimulationConnector::role_for(simulator_directory) != SimulationConnector::Role::Host) {
         return;
     }
+    // The constructor describes the host connection before it starts serving, so there is always
+    // one to record into here. Asserted rather than guarded, so a future reordering fails loudly
+    // instead of quietly serving sockets it never reports.
+    UMD_ASSERT(
+        simulation_connection_.has_value(),
+        error::RuntimeError,
+        "Simulation host started serving sockets before its connection was described.");
     // Serve in a dedicated directory -- the caller's, or a fresh one -- so two hosts on the same
     // machine never collide even when they serve the same chip id.
     const std::filesystem::path server_directory = simulator_server_directory.empty()
@@ -723,17 +744,13 @@ void Cluster::serve_simulation_devices_over_sockets(
     // directory was allocated just above, so this is the only way it learns of it -- recorded here
     // rather than per chip, so a host that turns out to have no simulation devices still reports
     // the directory it claimed instead of reading as "not serving".
-    if (simulation_connection_.has_value()) {
-        simulation_connection_->server_directory = server_directory;
-    }
+    simulation_connection_->server_directory = server_directory;
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             const std::filesystem::path socket_path =
                 SimulationServerSocket::default_socket_path(server_directory, chip_id);
             sim_device->adopt_socket(SimulationServerSocket::create(socket_path), shutdown_handler);
-            if (simulation_connection_.has_value()) {
-                simulation_connection_->sockets.emplace(chip_id, socket_path);
-            }
+            simulation_connection_->sockets.emplace(chip_id, socket_path);
         }
     }
 }

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -124,8 +124,9 @@ std::vector<SimulationServerInfo> SimulationConnector::list_servers() {
     return servers;
 }
 
-std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
-    std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+SimulationConnector::Result SimulationConnector::discover(const SimulationConnectorOptions& options) {
+    Result result;
+    std::map<ChipId, std::unique_ptr<TTDevice>>& devices = result.devices;
     const std::filesystem::path& simulator_path = options.simulator_directory;
 
     const Classification classification = classify(simulator_path);
@@ -142,7 +143,40 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
                 // pick the device class, and passes the fetched identity into create_client so it is
                 // not fetched again.
                 const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
+                // A server directory is claimed atomically by one host (see
+                // allocate_server_directory), so every socket in it is served by one process
+                // running one simulator: the first socket that answers describes the whole
+                // directory. Warn rather than silently describing only the first if that ever
+                // fails to hold -- a hand-assembled directory mixing two servers' sockets is the
+                // only way it can, and it should not pass unnoticed.
+                if (result.devices.empty()) {
+                    result.connection.simulator = info.simulator_path;
+                    result.connection.backend = info.backend_type;
+                    result.connection.arch = static_cast<tt::ARCH>(info.arch);
+                } else if (
+                    info.simulator_path != result.connection.simulator.string() ||
+                    info.backend_type != result.connection.backend ||
+                    static_cast<tt::ARCH>(info.arch) != result.connection.arch) {
+                    log_warning(
+                        LogUMD,
+                        "Simulation socket {} (chip {}) reports a different simulation than the rest of {}: "
+                        "{} ({}/{}) instead of {} ({}/{}). Reporting the first; the directory is serving more "
+                        "than one host.",
+                        socket_file.string(),
+                        chip_id,
+                        simulator_path.string(),
+                        info.simulator_path,
+                        arch_to_str(static_cast<tt::ARCH>(info.arch)),
+                        info.backend_type == SimulationBackendType::TTSIM ? "ttsim" : "rtl",
+                        result.connection.simulator.string(),
+                        arch_to_str(result.connection.arch),
+                        result.connection.backend == SimulationBackendType::TTSIM ? "ttsim" : "rtl");
+                }
                 devices.emplace(chip_id, make_client_device(chip_id, std::move(client), info));
+                // Only once the device is in: make_client_device() throws on a backend kind this
+                // build doesn't know, and the catch below skips the chip. Recording the socket
+                // first would leave connection.sockets naming a chip that has no device.
+                result.connection.sockets.emplace(chip_id, socket_file);
             } catch (const std::exception& e) {
                 log_warning(
                     LogUMD, "Skipping simulation socket {} (chip {}): {}", socket_file.string(), chip_id, e.what());
@@ -154,7 +188,9 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
             !devices.empty(),
             error::RuntimeError,
             fmt::format("No reachable simulation hosts among the sockets in {}", simulator_path.string()));
-        return devices;
+        result.connection.role = Role::Client;
+        result.connection.server_directory = simulator_path;
+        return result;
     }
 
     // Host: single chip for now. Serving over sockets is opt-in: by default the host device stays
@@ -167,12 +203,24 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
         const std::filesystem::path server_directory = options.server_directory.empty()
                                                            ? SimulationServerSocket::allocate_server_directory()
                                                            : options.server_directory;
-        socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id));
+        const std::filesystem::path socket_path =
+            SimulationServerSocket::default_socket_path(server_directory, chip_id);
+        socket = SimulationServerSocket::create(socket_path);
+        // Report where this host ended up serving -- the allocated directory is otherwise known
+        // only in here, so a caller that did not pre-allocate one could never name it.
+        result.connection.server_directory = server_directory;
+        result.connection.sockets.emplace(chip_id, socket_path);
     }
     devices.emplace(
         chip_id,
         make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));
-    return devices;
+
+    result.connection.role = Role::Host;
+    result.connection.simulator = simulator_path;
+    result.connection.backend =
+        classification.kind == PathKind::HOST_TTSIM ? SimulationBackendType::TTSIM : SimulationBackendType::RTL;
+    result.connection.arch = devices.at(chip_id)->get_soc_descriptor().arch;
+    return result;
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -58,7 +58,10 @@ ScopedTempFile write_temp_file(const std::string& contents, const char* suffix) 
 
 }  // namespace
 
-SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type) {
+SimulationServerDeviceInfo describe_device(
+    const SocDescriptor& soc_descriptor,
+    SimulationBackendType backend_type,
+    const std::filesystem::path& simulator_path) {
     const std::string& yaml_path = soc_descriptor.get_arch_descriptor().get_device_descriptor_file_path();
     UMD_ASSERT(
         !yaml_path.empty(),
@@ -81,6 +84,7 @@ SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, 
     info.eth_harvesting_mask = soc_descriptor.harvesting_masks.eth_harvesting_mask;
     info.l2cpu_harvesting_mask = soc_descriptor.harvesting_masks.l2cpu_harvesting_mask;
     info.pcie_harvesting_mask = soc_descriptor.harvesting_masks.pcie_harvesting_mask;
+    info.simulator_path = simulator_path.string();
     return info;
 }
 

--- a/device/simulation/simulation_server_protocol.cpp
+++ b/device/simulation/simulation_server_protocol.cpp
@@ -58,6 +58,11 @@ std::vector<uint8_t> encode(const SimulationServerResponse& response) {
 std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
     flatbuffers::FlatBufferBuilder builder;
     auto yaml = builder.CreateString(device_info.soc_descriptor_yaml);
+    // Left absent when empty rather than written as an empty string, so a message carrying no
+    // simulator path is indistinguishable from one produced before the field existed. decode()
+    // reads both as empty.
+    auto simulator_path = device_info.simulator_path.empty() ? flatbuffers::Offset<flatbuffers::String>()
+                                                             : builder.CreateString(device_info.simulator_path);
     builder.Finish(wire::CreateSimulationServerDeviceInfo(
         builder,
         device_info.status,
@@ -69,7 +74,8 @@ std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
         device_info.dram_harvesting_mask,
         device_info.eth_harvesting_mask,
         device_info.l2cpu_harvesting_mask,
-        device_info.pcie_harvesting_mask));
+        device_info.pcie_harvesting_mask,
+        simulator_path));
     return to_bytes(builder);
 }
 
@@ -119,6 +125,9 @@ SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size) 
     info.eth_harvesting_mask = fb->eth_harvesting_mask();
     info.l2cpu_harvesting_mask = fb->l2cpu_harvesting_mask();
     info.pcie_harvesting_mask = fb->pcie_harvesting_mask();
+    if (fb->simulator_path() != nullptr) {
+        info.simulator_path = fb->simulator_path()->str();
+    }
     return info;
 }
 

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -55,7 +55,8 @@ table SimulationServerResponse {
 
 // Device identity served in response to a GET_DEVICE_INFO request. Carries everything a client
 // needs to build a SocDescriptor matching the host's without reading a local simulator build:
-// the arch, the full SoC-descriptor YAML text, and the per-chip harvesting masks.
+// the arch, the full SoC-descriptor YAML text, and the per-chip harvesting masks. It also names
+// the simulator the host runs, so a client can report what it is attached to.
 table SimulationServerDeviceInfo {
     status : int32;
     arch : int32;
@@ -67,6 +68,9 @@ table SimulationServerDeviceInfo {
     eth_harvesting_mask : uint32;
     l2cpu_harvesting_mask : uint32;
     pcie_harvesting_mask : uint32;
+    // The simulator the host runs: its libttsim .so path, or its RTL build directory. Appended last
+    // so a host built before this field still decodes -- the client then reads it as empty.
+    simulator_path : string;
 }
 
 // Cluster topology served in response to a GET_CLUSTER_DESCRIPTOR request. `yaml` is the host's

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     // read/write skeleton below (SimulationServerResponse), so it is handled up front.
     if (request.command == SimulationServerCommand::GET_DEVICE_INFO) {
         try {
-            return encode(describe_device(get_soc_descriptor(), backend_type()));
+            return encode(describe_device(get_soc_descriptor(), backend_type(), simulator_directory_));
         } catch (const std::exception& e) {
             log_warning(tt::LogUMD, "Simulation host failed to serve device info: {}", e.what());
             SimulationServerDeviceInfo info;

--- a/docs/SIMULATION_SERVER.md
+++ b/docs/SIMULATION_SERVER.md
@@ -204,13 +204,19 @@ using namespace tt::umd;
 
 SimulationConnectorOptions options;
 options.simulator_directory = "/tmp/tt-umd-sim-server-0";  // same server directory
-std::map<ChipId, std::unique_ptr<TTDevice>> devices = SimulationConnector::discover(options);
+SimulationConnector::Result result = SimulationConnector::discover(options);
 
 // Each device is a client already attached to the running host.
-for (auto& [chip_id, device] : devices) {
+for (auto& [chip_id, device] : result.devices) {
     // use `device` directly, or hand it to higher-level UMD code
 }
 ```
+
+`result.connection` says what you actually opened: the role this process took, the simulator behind
+it (as a host, the build you named; as a client, the one the host reports it runs), its backend and
+arch, and -- for a host that serves -- the directory and per-chip sockets it serves on. That last
+part matters when you leave `server_directory` empty: UMD allocates one, and this is the only place
+it tells you which. `Cluster::get_simulation_connection()` reports the same thing for a cluster.
 
 In both cases the target is the server directory, and pointing at it is what makes your process a
 client — there is no separate "connect" call.

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -41,7 +41,7 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
     options.server_directory = server_directory;
 
     {
-        auto devices = SimulationConnector::discover(options);
+        auto devices = SimulationConnector::discover(options).devices;
         ASSERT_EQ(devices.size(), 1u);
         ASSERT_NE(devices.at(0), nullptr);
         EXPECT_TRUE(std::filesystem::exists(socket));  // host exposed it
@@ -70,7 +70,7 @@ TEST(SimulationConnector, CreatesPrivateHostDeviceWhenNotServing) {
     // serve_over_sockets defaults to false: a private in-process host, no socket published.
     options.server_directory = server_directory;
 
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     EXPECT_NE(devices.at(0), nullptr);              // a usable host device...
     EXPECT_FALSE(std::filesystem::exists(socket));  // ...that published no socket
@@ -105,7 +105,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     options.simulator_directory = simulator_path;
     options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
     ASSERT_NE(host, nullptr);
@@ -166,7 +166,7 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     options.simulator_directory = simulator_path;
     options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
-    auto devices = SimulationConnector::discover(options);
+    auto devices = SimulationConnector::discover(options).devices;
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
     ASSERT_NE(host, nullptr);
@@ -210,14 +210,14 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
 
     // The .so path hosts and publishes its per-chip socket; pointing discovery at that server's
     // directory takes the client path, attaching one client device per socket.
-    auto host_devices = SimulationConnector::discover(host_options);
+    auto host_devices = SimulationConnector::discover(host_options).devices;
     ASSERT_EQ(host_devices.size(), 1u);
     TTDevice* host = host_devices.at(0).get();
     ASSERT_NE(host, nullptr);
 
     SimulationConnectorOptions client_options;
     client_options.simulator_directory = server_directory;
-    auto client_devices = SimulationConnector::discover(client_options);
+    auto client_devices = SimulationConnector::discover(client_options).devices;
     ASSERT_EQ(client_devices.count(0), 1u);
     TTDevice* client = client_devices.at(0).get();
     ASSERT_NE(client, nullptr);
@@ -277,6 +277,24 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     // The client reconstructed the same chips the host serves.
     EXPECT_EQ(client_cluster.get_target_device_ids(), host_cluster.get_target_device_ids());
 
+    // Each Cluster can say what it is connected to: the host names the simulator it runs and the
+    // directory it serves in; the client names the directory it attached to and the simulator the
+    // host reported over the wire.
+    const auto host_connection = host_cluster.get_simulation_connection();
+    ASSERT_TRUE(host_connection.has_value());
+    EXPECT_EQ(host_connection->role, SimulationConnector::Role::Host);
+    EXPECT_EQ(host_connection->simulator, std::filesystem::path(simulator_path));
+    EXPECT_EQ(host_connection->server_directory, server_directory);
+    EXPECT_FALSE(host_connection->sockets.empty());
+
+    const auto client_connection = client_cluster.get_simulation_connection();
+    ASSERT_TRUE(client_connection.has_value());
+    EXPECT_EQ(client_connection->role, SimulationConnector::Role::Client);
+    EXPECT_EQ(client_connection->server_directory, server_directory);
+    EXPECT_EQ(client_connection->simulator, std::filesystem::path(simulator_path));
+    EXPECT_EQ(client_connection->backend, host_connection->backend);
+    EXPECT_EQ(client_connection->arch, host_connection->arch);
+
     const tt::ChipId chip = 0;
     const SocDescriptor& soc = host_cluster.get_soc_descriptor(chip);
     const CoreCoord tensix = soc.get_cores(tt::CoreType::TENSIX).at(0);
@@ -288,4 +306,106 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     std::vector<uint8_t> readback(pattern.size());
     client_cluster.read_from_device(readback.data(), chip, tensix, addr, pattern.size());
     EXPECT_EQ(readback, pattern);
+}
+
+// discover() reports the connection it opened, not just the devices: as a serving host, the
+// simulator it runs, the backend and arch behind it, and the directory and per-chip sockets it
+// serves on. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsServingHostConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;
+    options.server_directory = server_directory;
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+    const SimulationConnector::Connection& connection = result.connection;
+
+    EXPECT_EQ(connection.role, SimulationConnector::Role::Host);
+    EXPECT_EQ(connection.simulator, std::filesystem::path(simulator_path));
+    const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
+    EXPECT_EQ(connection.backend, is_ttsim ? SimulationBackendType::TTSIM : SimulationBackendType::RTL);
+    EXPECT_EQ(connection.arch, result.devices.at(0)->get_soc_descriptor().arch);
+    EXPECT_EQ(connection.server_directory, server_directory);
+    EXPECT_EQ(connection.sockets.size(), result.devices.size());
+    EXPECT_EQ(connection.sockets.at(0), SimulationServerSocket::default_socket_path(server_directory, 0));
+}
+
+// The point of reporting the connection on the host side: with server_directory left empty the
+// connector allocates one internally, and the caller has no other way to learn which. Requires
+// TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsTheServerDirectoryItAllocated) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;
+    // server_directory deliberately left empty: the connector allocates one.
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+
+    ASSERT_FALSE(result.connection.server_directory.empty());
+    EXPECT_TRUE(std::filesystem::is_directory(result.connection.server_directory));
+    ASSERT_EQ(result.connection.sockets.count(0), 1u);
+    EXPECT_EQ(result.connection.sockets.at(0).parent_path(), result.connection.server_directory);
+    EXPECT_TRUE(std::filesystem::exists(result.connection.sockets.at(0)));
+}
+
+// A private in-process host still reports its role and simulator; an empty server_directory is how
+// "not serving" reads. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsPrivateHostConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    // serve_over_sockets defaults to false.
+
+    const SimulationConnector::Result result = SimulationConnector::discover(options);
+
+    EXPECT_EQ(result.connection.role, SimulationConnector::Role::Host);
+    EXPECT_EQ(result.connection.simulator, std::filesystem::path(simulator_path));
+    EXPECT_NE(result.connection.arch, tt::ARCH::Invalid);
+    EXPECT_TRUE(result.connection.server_directory.empty());
+    EXPECT_TRUE(result.connection.sockets.empty());
+}
+
+// A client reports the directory it attached to and the simulator the host runs -- the latter comes
+// over the wire, since a client has no local simulator build to read. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, ReportsClientConnection) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+
+    SimulationConnectorOptions host_options;
+    host_options.simulator_directory = simulator_path;
+    host_options.serve_over_sockets = true;
+    host_options.server_directory = server_directory;
+    const SimulationConnector::Result host = SimulationConnector::discover(host_options);
+
+    SimulationConnectorOptions client_options;
+    client_options.simulator_directory = server_directory;
+    const SimulationConnector::Result client = SimulationConnector::discover(client_options);
+
+    EXPECT_EQ(client.connection.role, SimulationConnector::Role::Client);
+    EXPECT_EQ(client.connection.server_directory, server_directory);
+    EXPECT_EQ(client.connection.sockets, host.connection.sockets);
+    // Reported by the host over GET_DEVICE_INFO, and matching what the host itself says it runs.
+    EXPECT_EQ(client.connection.simulator, host.connection.simulator);
+    EXPECT_EQ(client.connection.backend, host.connection.backend);
+    EXPECT_EQ(client.connection.arch, host.connection.arch);
 }

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -33,11 +33,13 @@ TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
     SocDescriptor original(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")), chip_info);
 
-    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSIM);
+    const SimulationServerDeviceInfo info =
+        describe_device(original, SimulationBackendType::TTSIM, "/opt/sim_bh/libttsim.so");
     EXPECT_EQ(info.status, 0);
     EXPECT_EQ(info.backend_type, SimulationBackendType::TTSIM);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.tensix_harvesting_mask, 0x1u);
+    EXPECT_EQ(info.simulator_path, "/opt/sim_bh/libttsim.so");
 
     const SocDescriptor rebuilt = build_soc_descriptor(info);
     EXPECT_EQ(rebuilt.arch, original.arch);

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -107,6 +107,7 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     info.eth_harvesting_mask = 0x120;
     info.l2cpu_harvesting_mask = 0x0;
     info.pcie_harvesting_mask = 0x3;
+    info.simulator_path = "/opt/sim_wh/libttsim.so";
 
     const SimulationServerDeviceInfo decoded = decode_device_info(encode(info));
 
@@ -120,6 +121,22 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     EXPECT_EQ(decoded.eth_harvesting_mask, info.eth_harvesting_mask);
     EXPECT_EQ(decoded.l2cpu_harvesting_mask, info.l2cpu_harvesting_mask);
     EXPECT_EQ(decoded.pcie_harvesting_mask, info.pcie_harvesting_mask);
+    EXPECT_EQ(decoded.simulator_path, info.simulator_path);
+}
+
+// simulator_path was appended to the schema after the first hosts shipped. encode() omits it when
+// empty, so this message is on the wire exactly as an older host's would be -- which is what makes
+// this a backward-compatibility case and not just an empty-string one. Decoding it must yield an
+// empty path rather than dereferencing the absent field.
+TEST(SimulationServerProtocol, DeviceInfoWithAnAbsentSimulatorPathRoundTrip) {
+    SimulationServerDeviceInfo info;
+    info.arch = 2;
+    info.soc_descriptor_yaml = "arch: wormhole_b0\n";  // simulator_path left unset
+
+    const SimulationServerDeviceInfo decoded = decode_device_info(encode(info));
+
+    EXPECT_EQ(decoded.arch, info.arch);
+    EXPECT_TRUE(decoded.simulator_path.empty());
 }
 
 // The GetDeviceInfo command survives a request round-trip.


### PR DESCRIPTION
### Issue
#3316. Replaces #3336, which GitHub auto-closed as merged while the stack was reordered — same commit, now based on `main`, with the Python half moved out to #3333, which stacks on this.

### Description
`SimulationConnector::discover()` returned only the devices, so a caller could not ask what it had opened: whether this process runs the simulation or attached to a host that does, and which simulator sits behind it. `role_for()` answers only the first, only from the path, and only before opening — re-running it afterwards races a host that has since exited. Worse on the host side: with `server_directory` empty the connector allocated one internally and merely logged it, so a caller that did not pre-allocate could never name the directory it was serving in.

`discover()` now returns that connection alongside the devices, and `Cluster` reports the same through `get_simulation_connection()`. A host names the simulator it opened; a client names the directory it attached to plus the simulator the host reports over the wire, which needed a new `simulator_path` field in the device-info message — appended last, so an older host still decodes and the client reads it as empty. Role and backend stay separate fields rather than one enum, since they are orthogonal axes; the internal `PathKind` still conflates them, which is #3081 item 1.

### List of the changes
- `SimulationConnector::Connection` (role, simulator, backend, arch, server directory, sockets) and `discover()` returning it with the devices; call sites updated.
- `Cluster::get_simulation_connection()`, recording the host side including a UMD-allocated server directory.
- `simulator_path` added to `SimulationServerDeviceInfo` and served by the host; `SimulationTTDevice::backend_type()` made public.
- Docs and tests.

### Testing
CI

### API Changes
`discover()` returns `SimulationConnector::Result` instead of the device map. New `Cluster::get_simulation_connection()`. `SimulationTTDevice::backend_type()` is now public. `describe_device()` takes the simulator path.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...pjanevski/simulation-live-classification