### PR TITLE
[Base API] Rename ArcStartupError to FirmwareStartupError, built from identity fields

### DIFF
--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -262,7 +262,7 @@ public:
     IODeviceType get_cluster_io_device_type() const { return io_device_type; }
 
     using DeviceHealthError = std::variant<
-        error::ArcStartupError,
+        error::FirmwareStartupError,
         error::NocHangError,
         error::PcieHangError,
         error::UnsupportedCMFWError,

--- a/device/api/umd/device/topology/topology_utils.hpp
+++ b/device/api/umd/device/topology/topology_utils.hpp
@@ -16,8 +16,8 @@ namespace tt::umd {
 // Converts a device initialization exception into a structured health error, if it is one of the
 // recoverable hardware errors tracked in the cluster descriptor. Returns std::nullopt otherwise.
 inline std::optional<ClusterDescriptor::DeviceHealthError> determine_device_init_error(error::UmdBaseException& err) {
-    if (auto* arc_err = dynamic_cast<error::UmdException<error::ArcStartupError>*>(&err)) {
-        return arc_err->error();
+    if (auto* fw_err = dynamic_cast<error::UmdException<error::FirmwareStartupError>*>(&err)) {
+        return fw_err->error();
     }
     if (auto* noc_err = dynamic_cast<error::UmdException<error::NocHangError>*>(&err)) {
         return noc_err->error();

--- a/device/api/umd/device/tt_device/tt_device_error.hpp
+++ b/device/api/umd/device/tt_device/tt_device_error.hpp
@@ -38,26 +38,32 @@ struct DeviceCoreData : public TTDeviceData {
     NocId noc_id = NocId::DEFAULT_NOC;
 };
 
-struct ArcStartupData : public DeviceCoreData {
+struct FirmwareStartupData : public DeviceCoreData {
     uint32_t scratch_status = 0;
     uint32_t postcode = 0;
     std::optional<uint32_t> message_id = std::nullopt;
     std::optional<uint32_t> smc_init_status = std::nullopt;
 };
 
-struct ArcStartupError : UmdError<ArcStartupData> {
-    ArcStartupError(
-        const TTDevice& tt_device,
+// Thrown by DeviceFirmware, which takes protocol interfaces rather than a TTDevice, so the device
+// identity is passed as the fields a TTDevice would have supplied.
+struct FirmwareStartupError : UmdError<FirmwareStartupData> {
+    FirmwareStartupError(
+        IODeviceType io_device_type,
+        ChipId chip_id,
+        tt::ARCH arch,
         NocId noc_id,
-        xy_pair arc_core,
+        xy_pair fw_core,
         uint32_t scratch_status,
         uint32_t postcode,
         std::optional<uint32_t> message_id = std::nullopt,
         std::optional<uint32_t> smc_init_status = std::nullopt);
-    ArcStartupError(
-        const TTDevice& tt_device,
+    FirmwareStartupError(
+        IODeviceType io_device_type,
+        ChipId chip_id,
+        tt::ARCH arch,
         NocId noc_id,
-        xy_pair arc_core,
+        xy_pair fw_core,
         uint32_t scratch_status,
         uint32_t postcode,
         std::chrono::milliseconds timeout,

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -199,8 +199,10 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
     if (!arc_core_started) {
         read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_4, sizeof arc_error_status0);
         UMD_THROW(
-            error::ArcStartupError,
-            *this,
+            error::FirmwareStartupError,
+            get_communication_device_type(),
+            get_communication_device_id(),
+            get_arch(),
             get_selected_noc_id(),
             get_arc_core(),
             arc_boot_status,

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -38,18 +38,21 @@ PcieHangError::PcieHangError(const TTDevice& tt_device, uint32_t data_read) :
             tt_device.get_communication_device_id()),
         {{tt_device}, data_read}) {}
 
-ArcStartupError::ArcStartupError(
-    const TTDevice& tt_device,
+FirmwareStartupError::FirmwareStartupError(
+    IODeviceType io_device_type,
+    ChipId chip_id,
+    tt::ARCH arch,
     NocId noc_id,
-    xy_pair arc_core,
+    xy_pair fw_core,
     uint32_t scratch_status,
     uint32_t postcode,
     std::optional<uint32_t> message_id,
     std::optional<uint32_t> smc_init_status) :
-    UmdError<ArcStartupData>(
+    UmdError<FirmwareStartupData>(
         fmt::format(
-            "ARC startup error at core {} over {}: scratch_status={:#x}, postcode={:#x}{}{}",
-            arc_core.str(),
+            "Firmware startup error on device {} at core {} over {}: scratch_status={:#x}, postcode={:#x}{}{}",
+            chip_id,
+            fw_core.str(),
             noc_to_str(noc_id),
             scratch_status,
             postcode,
@@ -59,18 +62,25 @@ ArcStartupError::ArcStartupError(
                                               smc_init_status.value(),
                                               blackhole::interpret_smc_init_status(smc_init_status.value()))
                                         : ""),
-        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id, smc_init_status}) {}
+        {{TTDeviceData(io_device_type, chip_id, arch), fw_core, noc_id},
+         scratch_status,
+         postcode,
+         message_id,
+         smc_init_status}) {}
 
-ArcStartupError::ArcStartupError(
-    const TTDevice& tt_device,
+FirmwareStartupError::FirmwareStartupError(
+    IODeviceType io_device_type,
+    ChipId chip_id,
+    tt::ARCH arch,
     NocId noc_id,
-    xy_pair arc_core,
+    xy_pair fw_core,
     uint32_t scratch_status,
     uint32_t postcode,
     std::chrono::milliseconds timeout,
     std::optional<uint32_t> message_id,
     std::optional<uint32_t> smc_init_status) :
-    ArcStartupError(tt_device, noc_id, arc_core, scratch_status, postcode, message_id, smc_init_status) {
+    FirmwareStartupError(
+        io_device_type, chip_id, arch, noc_id, fw_core, scratch_status, postcode, message_id, smc_init_status) {
     message().append(fmt::format(" (Timed out after {} ms)", timeout.count()));
 }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -348,8 +348,10 @@ void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
                 case STATUS_NO_ACCESS:
                 case STATUS_WATCHDOG_TRIGGERED:
                     UMD_THROW(
-                        error::ArcStartupError,
-                        *this,
+                        error::FirmwareStartupError,
+                        get_communication_device_type(),
+                        get_communication_device_id(),
+                        get_arch(),
                         get_selected_noc_id(),
                         get_arc_core(),
                         bar_read_arc_reset_scratch_status,
@@ -400,8 +402,10 @@ void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
 
     if (!arc_core_started) {
         UMD_THROW(
-            error::ArcStartupError,
-            *this,
+            error::FirmwareStartupError,
+            get_communication_device_type(),
+            get_communication_device_id(),
+            get_arch(),
             get_selected_noc_id(),
             get_arc_core(),
             bar_read_arc_reset_scratch_status,

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -307,8 +307,15 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
         auto tt_device = TTDevice::create(i);
         try {
             tt_device->wait_arc_core_start(timeout::ARC_LONG_POST_RESET_TIMEOUT);
-        } catch (error::ArcStartupError& arc_error) {
-            log_warning(LogUMD, arc_error.message());
+        } catch (error::UmdBaseException& err) {
+            // UMD_THROW raises UmdException<E>, which wraps E rather than deriving from it, so a
+            // plain catch (error::FirmwareStartupError&) can never match. The catch this replaces
+            // (error::ArcStartupError&) had the same flaw and silently never fired; this is the
+            // log-and-skip behavior it always intended. See topology_utils.hpp for the same pattern.
+            if (dynamic_cast<error::UmdException<error::FirmwareStartupError>*>(&err) == nullptr) {
+                throw;
+            }
+            log_warning(LogUMD, err.message());
             continue;
         }
         tt_devices.emplace_back(std::move(tt_device));

--- a/nanobind/py_api_error.cpp
+++ b/nanobind/py_api_error.cpp
@@ -69,22 +69,22 @@ void bind_error(nb::module_ &m) {
         .def_rw("core", &DeviceCoreData::core)
         .def_rw("noc_id", &DeviceCoreData::noc_id);
 
-    // ArcStartupData.
-    nb::class_<ArcStartupData, DeviceCoreData>(error_module, "ArcStartupData")
+    // FirmwareStartupData.
+    nb::class_<FirmwareStartupData, DeviceCoreData>(error_module, "FirmwareStartupData")
         .def(nb::init<>(), release_gil())
-        .def_rw("scratch_status", &ArcStartupData::scratch_status)
-        .def_rw("postcode", &ArcStartupData::postcode)
-        .def_rw("message_id", &ArcStartupData::message_id)
-        .def_rw("smc_init_status", &ArcStartupData::smc_init_status);
+        .def_rw("scratch_status", &FirmwareStartupData::scratch_status)
+        .def_rw("postcode", &FirmwareStartupData::postcode)
+        .def_rw("message_id", &FirmwareStartupData::message_id)
+        .def_rw("smc_init_status", &FirmwareStartupData::smc_init_status);
 
-    // ArcStartupError.
-    nb::class_<ArcStartupError>(error_module, "ArcStartupError")
+    // FirmwareStartupError.
+    nb::class_<FirmwareStartupError>(error_module, "FirmwareStartupError")
         .def(
             "message",
-            nb::overload_cast<>(&ArcStartupError::message, nb::const_),
+            nb::overload_cast<>(&FirmwareStartupError::message, nb::const_),
             release_gil(),
             "Get the error message")
-        .def_prop_ro("data", nb::overload_cast<>(&ArcStartupError::data, nb::const_), "Get the error data");
+        .def_prop_ro("data", nb::overload_cast<>(&FirmwareStartupError::data, nb::const_), "Get the error data");
 
     // NocHangData.
     nb::class_<NocHangData, TTDeviceData>(error_module, "NocHangData")


### PR DESCRIPTION
## Issue

#2872

## Description
Isolated rename: `ArcStartupError`/`ArcStartupData` → `FirmwareStartupError`/`FirmwareStartupData`. The startup error is about the management firmware, not the ARC transport (the spec keeps ARC out of the public headers), and the components about to throw it hold protocol interfaces rather than a `TTDevice` — so the constructors take identity fields directly (built on #3310) and the still-alive `TTDevice` waits pass their own identity. The Python binding, `DeviceHealthError` variant and topology error mapping rename in the same diff.

Bonus fix while touching the line: warm reset's catch is rewritten with the `UmdBaseException` + `dynamic_cast` pattern — the plain catch it replaces could never match what `UMD_THROW` throws, so the log-and-skip path had never actually fired.

## Testing
`baremetal_tests` 238/238, sim on/off, Python bindings build.

## API Changes
`error::ArcStartupError`/`ArcStartupData` renamed (C++ and Python); constructors take identity fields instead of `const TTDevice&`.

Stacked on #3318.

