### PR TITLE
[Base API] Add the WormholeArcWindow skeleton

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -104,6 +104,7 @@ target_sources(
         tt_device/hang_detection/blackhole_hang_detector.cpp
         tt_device/firmware/blackhole_arc_apb.cpp
         tt_device/firmware/blackhole_device_firmware.cpp
+        tt_device/firmware/wormhole_arc_window.cpp
         tt_device/firmware/wormhole_device_firmware.cpp
         tt_device/protocol/pcie_protocol.cpp
         tt_device/protocol/jtag_protocol.cpp
@@ -267,6 +268,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/firmware/blackhole_arc_apb.hpp
                 api/umd/device/tt_device/firmware/device_firmware.hpp
                 api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+                api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
                 api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
                 api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
                 api/umd/device/tt_device/remote_communication.hpp

--- a/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+class DeviceProtocol;
+class JtagInterface;
+class PcieInterface;
+class RemoteInterface;
+
+/**
+ * @brief Access to one of the Wormhole ARC address windows.
+ *
+ * The ARC tile exposes several windows that differ only in where they sit and whether they hold
+ * registers or memory; how an access reaches them is the same for all of them. This holds that
+ * common routing and takes the differences as a Config, so a window is added by naming its
+ * constants rather than by copying the class.
+ *
+ * A single access is routed one of three ways, in order: over the NOC when the device is reached
+ * remotely, over JTAG when it is reached that way, and otherwise through the PCIe BAR. Callers pass
+ * the ARC core coordinate and the NOC to route over, so this holds no NOC state of its own.
+ *
+ * Taking both per call is a deliberate difference from WormholeTTDevice::read_from_arc_apb, which
+ * pinned its JTAG branch to wormhole::ARC_CORES_NOC0[0] and NocId::DEFAULT_NOC whatever NOC the
+ * thread had selected, and only used a NOC-dependent core on the remote branch. Every route here
+ * uses what the caller passed, so a caller that wants the old JTAG behaviour has to pass the NOC0
+ * coordinate itself. Routing is otherwise unchanged.
+ *
+ * The interfaces are non-owning and must outlive this object.
+ *
+ * This lands as a skeleton: construction, validation and the window configurations, with no
+ * accesses yet. Each access arrives as a behavior migration - read() with the firmware boot wait,
+ * write() with the firmware command path - deleting the WormholeTTDevice copy it replaces in the
+ * same diff wherever that copy has no other callers left.
+ */
+class WormholeArcWindow {
+public:
+    /**
+     * @brief What a window holds, which is what the remote route has to match.
+     *
+     * This only selects the remote route's access kind. The JTAG route issues a register access for
+     * every window, memory ones included, which is what WormholeTTDevice::read_from_arc_csm did: it
+     * is reading a single word out of the ARC's address space over a debug transport, where the
+     * register path is the one that is wired up, so the distinction does not arise.
+     */
+    enum class Content : uint8_t {
+        /** Registers, reached over the protocol's register path. */
+        REGISTERS,
+        /** Memory, reached over the protocol's data path when remote. */
+        MEMORY,
+    };
+
+    /**
+     * @brief Where one window sits and what it holds.
+     */
+    struct Config {
+        const char* name;
+        uint64_t noc_base_address;
+        uint32_t bar0_offset_start;
+        uint32_t size_bytes;
+        Content content;
+    };
+
+    /**
+     * @brief Builds access to the ARC APB register window over one communication protocol.
+     * @param device_protocol Protocol to issue NOC accesses through. Required.
+     * @param pcie_interface BAR access, when the device is reached over PCIe.
+     * @param jtag_interface JTAG access, when the device is reached over JTAG.
+     * @param remote_interface Ethernet access, when the device is reached through a gateway.
+     *
+     * Exactly one of the three transport interfaces must be given: which one is present is how the
+     * route is picked, and a TTDevice is built for exactly one communication protocol.
+     */
+    static WormholeArcWindow arc_apb(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+    /**
+     * @brief Builds access to the ARC CSM memory window over one communication protocol.
+     * @param device_protocol Protocol to issue NOC accesses through. Required.
+     * @param pcie_interface BAR access, when the device is reached over PCIe.
+     * @param jtag_interface JTAG access, when the device is reached over JTAG.
+     * @param remote_interface Ethernet access, when the device is reached through a gateway.
+     *
+     * Same transport rule as arc_apb(). CSM holds memory rather than registers, so a remote access
+     * takes the data path; see Content for why JTAG does not.
+     *
+     * Blackhole has no counterpart: BlackholeTTDevice's CSM accessors only ever threw, so there
+     * was nothing to extract there.
+     */
+    static WormholeArcWindow arc_csm(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+private:
+    WormholeArcWindow(
+        const Config& config,
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+    Config config_;
+    // All non-owning; they belong to the component that owns this object and must outlive it.
+    DeviceProtocol* device_protocol_ = nullptr;
+    PcieInterface* pcie_interface_ = nullptr;
+    JtagInterface* jtag_interface_ = nullptr;
+    RemoteInterface* remote_interface_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_arc_window.cpp
+++ b/device/tt_device/firmware/wormhole_arc_window.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+
+#include <fmt/format.h>
+
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
+#include "umd/device/tt_device/protocol/jtag_interface.hpp"
+#include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// The constructor enforces that exactly one transport interface is given: which one is present
+// is how the accesses added by later PRs pick their route.
+
+/* static */ WormholeArcWindow WormholeArcWindow::arc_apb(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) {
+    static constexpr Config config{
+        .name = "ARC APB",
+        .noc_base_address = wormhole::ARC_APB_NOC_BASE_ADDRESS,
+        .bar0_offset_start = wormhole::ARC_APB_BAR0_XBAR_OFFSET_START,
+        // ARC_APB_ADDRESS_RANGE is END - START with an inclusive END, so it is the last valid
+        // offset rather than the window size. The bound below is a size, hence the + 1.
+        .size_bytes = wormhole::ARC_APB_ADDRESS_RANGE + 1,
+        .content = Content::REGISTERS,
+    };
+    return WormholeArcWindow(config, device_protocol, pcie_interface, jtag_interface, remote_interface);
+}
+
+/* static */ WormholeArcWindow WormholeArcWindow::arc_csm(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) {
+    static constexpr Config config{
+        .name = "ARC CSM",
+        .noc_base_address = wormhole::ARC_CSM_NOC_BASE_ADDRESS,
+        .bar0_offset_start = wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START,
+        .size_bytes = wormhole::ARC_CSM_ADDRESS_RANGE + 1,
+        .content = Content::MEMORY,
+    };
+    return WormholeArcWindow(config, device_protocol, pcie_interface, jtag_interface, remote_interface);
+}
+
+WormholeArcWindow::WormholeArcWindow(
+    const Config& config,
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) :
+    config_(config),
+    device_protocol_(device_protocol),
+    pcie_interface_(pcie_interface),
+    jtag_interface_(jtag_interface),
+    remote_interface_(remote_interface) {
+    UMD_ASSERT(
+        device_protocol_ != nullptr,
+        error::RuntimeError,
+        fmt::format("The {} window requires a DeviceProtocol.", config_.name));
+    const int transports = (pcie_interface_ != nullptr) + (jtag_interface_ != nullptr) + (remote_interface_ != nullptr);
+    UMD_ASSERT(
+        transports == 1,
+        error::RuntimeError,
+        fmt::format(
+            "The {} window requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
+            "which one is present is how it picks the route for an access.",
+            config_.name));
+}
+
+}  // namespace tt::umd

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(BAREMETAL_TESTS_SRCS
     test_notification_mechanism.cpp
     test_cluster.cpp
     test_blackhole_arc_apb.cpp
+    test_wormhole_arc_window.cpp
     test_blackhole_arc_message_queue.cpp
     # SimulationServerSocket and SimulationClient have no simulation deps (always compiled), so
     # their tests need no card and no simulation build -- they run in the no-card baremetal CI lane.

--- a/tests/baremetal/test_wormhole_arc_window.cpp
+++ b/tests/baremetal/test_wormhole_arc_window.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+#include "tests/test_utils/protocol_mocks.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+#include "umd/device/utils/error.hpp"
+
+using namespace tt::umd;
+using namespace tt::umd::test_utils;
+using ::testing::NiceMock;
+
+namespace {
+
+class WormholeArcApbWindowTest : public ::testing::Test {
+protected:
+    WormholeArcWindow over_pcie() { return WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, nullptr); }
+
+    WormholeArcWindow over_jtag() { return WormholeArcWindow::arc_apb(&protocol_, nullptr, &jtag_, nullptr); }
+
+    WormholeArcWindow over_remote() { return WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, &remote_); }
+
+    NiceMock<MockDeviceProtocol> protocol_;
+    NiceMock<MockPcieInterface> pcie_;
+    NiceMock<MockJtagInterface> jtag_;
+    NiceMock<MockRemoteInterface> remote_;
+};
+
+// Which interface is present is how the window picks its route, so it cannot be built with an
+// ambiguous set. Giving none leaves no route at all; giving two makes the null checks meaningless.
+TEST_F(WormholeArcApbWindowTest, RequiresExactlyOneTransport) {
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, nullptr), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, &jtag_, nullptr), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, &remote_), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(nullptr, &pcie_, nullptr, nullptr), std::exception);
+}
+
+}  // namespace


### PR DESCRIPTION
## Issue

#2872

## Description
The `WormholeArcWindow` **skeleton**: construction, dependency validation, and the two window configurations (APB, CSM) — no accesses yet. Tested against exactly this surface (the exactly-one-transport and non-null-protocol rules).

Each access arrives later as a behavior migration, together with the deletion of the `TTDevice` copy it replaces and its tests: `read()` with the firmware boot wait (#3346), `write()` with the firmware command path (#3322).

## Testing
`baremetal_tests` 239/239 (the new interface test included), sim on/off.

## API Changes
None (internal component).

Stacked on #3343.

