### PR TITLE
[Base API] Give the firmware implementations their private plumbing

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -103,6 +103,7 @@ target_sources(
         tt_device/hang_detection/blackhole_hang_detector.cpp
         tt_device/firmware/blackhole_arc_apb.cpp
         tt_device/firmware/blackhole_device_firmware.cpp
+        tt_device/firmware/wormhole_arc_window.cpp
         tt_device/firmware/wormhole_device_firmware.cpp
         tt_device/protocol/pcie_protocol.cpp
         tt_device/protocol/jtag_protocol.cpp
@@ -266,6 +267,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/firmware/blackhole_arc_apb.hpp
                 api/umd/device/tt_device/firmware/device_firmware.hpp
                 api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+                api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
                 api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
                 api/umd/device/tt_device/firmware/simulation_device_firmware.hpp
                 api/umd/device/tt_device/remote_communication.hpp

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -4,7 +4,15 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/tt_device/firmware/blackhole_arc_apb.hpp"
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -30,10 +38,36 @@ public:
         ArchitectureImplementation* architecture_impl);
 
 private:
+    IODeviceType get_io_device_type() const;
+
+    // Whether NOC address translation is active. Private for now: the constructor needs it to
+    // resolve the ARC coordinates, while TTDevice::get_noc_translation_enabled stays the public
+    // entry until that API moves here. Read over BAR/JTAG, so it does not need the firmware up.
+    bool get_noc_translation_enabled() const;
+
+    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
+    // API it replaces moves here.
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
+
+    // Thin wrapper that resolves the ARC core for noc_id and hands the access to arc_apb_.
+    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    // All non-owning; they belong to the object that owns this one and must outlive it.
     DeviceProtocol* device_protocol_ = nullptr;
     PcieInterface* pcie_interface_ = nullptr;
     JtagInterface* jtag_interface_ = nullptr;
     ArchitectureImplementation* architecture_impl_ = nullptr;
+
+    // Identifies this device in error payloads; taken from the protocol so it identifies the
+    // device, not the silicon model. See DeviceProtocol::get_mmio_id().
+    int device_id_ = 0;
+
+    // ARC core coordinate per NOC, resolved once in the constructor: it depends only on the NOC
+    // translation state, which is fixed for the device's lifetime.
+    tt_xy_pair arc_core_noc0_;
+    tt_xy_pair arc_core_noc1_;
+
+    BlackholeArcApb arc_apb_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+class DeviceProtocol;
+class JtagInterface;
+class PcieInterface;
+class RemoteInterface;
+
+/**
+ * @brief Access to one of the Wormhole ARC address windows.
+ *
+ * The ARC tile exposes several windows that differ only in where they sit and whether they hold
+ * registers or memory; how an access reaches them is the same for all of them. This holds that
+ * common routing and takes the differences as a Config, so a window is added by naming its
+ * constants rather than by copying the class.
+ *
+ * A single access is routed one of three ways, in order: over the NOC when the device is reached
+ * remotely, over JTAG when it is reached that way, and otherwise through the PCIe BAR. Callers pass
+ * the ARC core coordinate and the NOC to route over, so this holds no NOC state of its own.
+ *
+ * Taking both per call is a deliberate difference from WormholeTTDevice::read_from_arc_apb, which
+ * pinned its JTAG branch to wormhole::ARC_CORES_NOC0[0] and NocId::DEFAULT_NOC whatever NOC the
+ * thread had selected, and only used a NOC-dependent core on the remote branch. Every route here
+ * uses what the caller passed, so a caller that wants the old JTAG behaviour has to pass the NOC0
+ * coordinate itself. Routing is otherwise unchanged.
+ *
+ * The interfaces are non-owning and must outlive this object.
+ *
+ * TODO: WormholeTTDevice still holds its own copies of this routing (APB and CSM), with the
+ * original bound check that validates only the first byte of a transfer. Those are the copies that
+ * currently run; this class's first production consumer is the firmware boot wait, which moves in
+ * an upcoming PR - until then its consumer is the unit-test suite. The TTDevice copies retire as
+ * their callers move.
+ */
+class WormholeArcWindow {
+public:
+    /**
+     * @brief What a window holds, which is what the remote route has to match.
+     *
+     * This only selects the remote route's access kind. The JTAG route issues a register access for
+     * every window, memory ones included, which is what WormholeTTDevice::read_from_arc_csm did: it
+     * is reading a single word out of the ARC's address space over a debug transport, where the
+     * register path is the one that is wired up, so the distinction does not arise.
+     */
+    enum class Content : uint8_t {
+        /** Registers, reached over the protocol's register path. */
+        REGISTERS,
+        /** Memory, reached over the protocol's data path when remote. */
+        MEMORY,
+    };
+
+    /**
+     * @brief Where one window sits and what it holds.
+     */
+    struct Config {
+        const char* name;
+        uint64_t noc_base_address;
+        uint32_t bar0_offset_start;
+        uint32_t size_bytes;
+        Content content;
+    };
+
+    /**
+     * @brief Builds access to the ARC APB register window over one communication protocol.
+     * @param device_protocol Protocol to issue NOC accesses through. Required.
+     * @param pcie_interface BAR access, when the device is reached over PCIe.
+     * @param jtag_interface JTAG access, when the device is reached over JTAG.
+     * @param remote_interface Ethernet access, when the device is reached through a gateway.
+     *
+     * Exactly one of the three transport interfaces must be given: which one is present is how the
+     * route is picked, and a TTDevice is built for exactly one communication protocol.
+     */
+    static WormholeArcWindow arc_apb(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+    /**
+     * @brief Builds access to the ARC CSM memory window over one communication protocol.
+     * @param device_protocol Protocol to issue NOC accesses through. Required.
+     * @param pcie_interface BAR access, when the device is reached over PCIe.
+     * @param jtag_interface JTAG access, when the device is reached over JTAG.
+     * @param remote_interface Ethernet access, when the device is reached through a gateway.
+     *
+     * Same transport rule as arc_apb(). CSM holds memory rather than registers, so a remote access
+     * takes the data path; see Content for why JTAG does not.
+     *
+     * Blackhole has no counterpart: BlackholeTTDevice's CSM accessors only ever threw, so there
+     * was nothing to extract there.
+     */
+    static WormholeArcWindow arc_csm(
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+    /**
+     * @brief Reads from the window.
+     * @param mem_ptr Destination buffer.
+     * @param arc_addr_offset Offset into the window. The whole transfer has to fit inside it, so the
+     * largest valid offset is the window size less size.
+     * @param size Bytes to read. The remote path honors any size; the JTAG and BAR paths read one
+     * word and reject anything other than sizeof(uint32_t) rather than silently widening.
+     * @param arc_core NOC coordinate of the ARC core, resolved for noc_id. Used on every route,
+     * including JTAG, which WormholeTTDevice pinned to NOC0 instead.
+     * @param noc_id NOC to route through.
+     */
+    void read(void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id);
+
+    /**
+     * @brief Writes to the window.
+     * @param mem_ptr Source buffer.
+     * @param arc_addr_offset Offset into the window. The whole transfer has to fit inside it, so the
+     * largest valid offset is the window size less size.
+     * @param size Bytes to write. The remote path honors any size; the JTAG and BAR paths write one
+     * word and reject anything other than sizeof(uint32_t) rather than silently widening.
+     * @param arc_core NOC coordinate of the ARC core, resolved for noc_id. Used on every route,
+     * including JTAG, which WormholeTTDevice pinned to NOC0 instead.
+     * @param noc_id NOC to route through.
+     */
+    void write(const void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id);
+
+private:
+    WormholeArcWindow(
+        const Config& config,
+        DeviceProtocol* device_protocol,
+        PcieInterface* pcie_interface,
+        JtagInterface* jtag_interface,
+        RemoteInterface* remote_interface);
+
+    void check_access(uint64_t arc_addr_offset, size_t size) const;
+
+    Config config_;
+    // All non-owning; they belong to the component that owns this object and must outlive it.
+    DeviceProtocol* device_protocol_ = nullptr;
+    PcieInterface* pcie_interface_ = nullptr;
+    JtagInterface* jtag_interface_ = nullptr;
+    RemoteInterface* remote_interface_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -4,7 +4,15 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -32,11 +40,34 @@ public:
         ArchitectureImplementation* architecture_impl);
 
 private:
+    IODeviceType get_io_device_type() const;
+
+    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
+    // API it replaces moves here.
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
+
+    // Thin wrappers that resolve the ARC core for noc_id and hand the access to arc_apb_/arc_csm_.
+    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    // All non-owning; they belong to the object that owns this one and must outlive it.
     DeviceProtocol* device_protocol_ = nullptr;
     PcieInterface* pcie_interface_ = nullptr;
     JtagInterface* jtag_interface_ = nullptr;
     RemoteInterface* remote_interface_ = nullptr;
     ArchitectureImplementation* architecture_impl_ = nullptr;
+
+    // Identifies this device in error payloads; taken from the protocol so it identifies the
+    // device, not the silicon model. See DeviceProtocol::get_mmio_id().
+    int device_id_ = 0;
+
+    // ARC core coordinate per NOC. Fixed for Wormhole, so resolved once in the constructor.
+    tt_xy_pair arc_core_noc0_;
+    tt_xy_pair arc_core_noc1_;
+
+    WormholeArcWindow arc_apb_;
+    WormholeArcWindow arc_csm_;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -4,12 +4,20 @@
 
 #include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
 
+#include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+// How this class picks a route: a non-null JtagInterface means the device is reached over JTAG,
+// otherwise it is reached over PCIe. Inferring the route from which optional interface is present
+// is sound because a TTDevice is built for exactly one communication protocol - reaching the same
+// chip over both PCIe and JTAG today requires two TTDevice objects, so the two interfaces are never
+// both handed to the same firmware object. If UMD ever supports using both protocols against a
+// single device, this has to become an explicit protocol selection rather than a null check.
 
 BlackholeDeviceFirmware::BlackholeDeviceFirmware(
     DeviceProtocol* device_protocol,
@@ -19,17 +27,47 @@ BlackholeDeviceFirmware::BlackholeDeviceFirmware(
     device_protocol_(device_protocol),
     pcie_interface_(pcie_interface),
     jtag_interface_(jtag_interface),
-    architecture_impl_(architecture_impl) {
+    architecture_impl_(architecture_impl),
+    arc_apb_(device_protocol, pcie_interface, jtag_interface) {
     UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "BlackholeDeviceFirmware requires a DeviceProtocol.");
     UMD_ASSERT(
         architecture_impl_ != nullptr,
         error::RuntimeError,
         "BlackholeDeviceFirmware requires an ArchitectureImplementation.");
-    UMD_ASSERT(
-        (pcie_interface_ != nullptr) != (jtag_interface_ != nullptr),
-        error::RuntimeError,
-        "BlackholeDeviceFirmware requires exactly one of a PcieInterface or a JtagInterface, since which one is "
-        "present is how it picks the route for an access.");
+    // The exactly-one-transport invariant that get_io_device_type() and the ARC APB routing rely on
+    // is enforced by arc_apb_, which is constructed from the same two interfaces above.
+
+    // Read after the checks above, not in the member initialiser list: that runs first, so a null
+    // protocol faulted there before the assert could report it.
+    device_id_ = device_protocol_->get_mmio_id();
+
+    // Resolve both ARC coordinates once. The NOC translation state they depend on is fixed for the
+    // device's lifetime and is read over BAR/JTAG, so this does not need the firmware to be up.
+    const bool noc_translation_enabled = get_noc_translation_enabled();
+    arc_core_noc0_ = blackhole::get_arc_core(noc_translation_enabled, /*use_noc1=*/false);
+    arc_core_noc1_ = blackhole::get_arc_core(noc_translation_enabled, /*use_noc1=*/true);
+}
+
+IODeviceType BlackholeDeviceFirmware::get_io_device_type() const {
+    return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
+}
+
+bool BlackholeDeviceFirmware::get_noc_translation_enabled() const {
+    uint32_t niu_cfg;
+    if (get_io_device_type() == IODeviceType::JTAG) {
+        niu_cfg = jtag_interface_->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);
+    } else {
+        niu_cfg = pcie_interface_->bar_read32(blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + 0x100);
+    }
+    return ((niu_cfg >> 14) & 0x1) != 0;
+}
+
+tt_xy_pair BlackholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
+}
+
+void BlackholeDeviceFirmware::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_apb_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_arc_window.cpp
+++ b/device/tt_device/firmware/wormhole_arc_window.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+
+#include <fmt/format.h>
+
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
+#include "umd/device/tt_device/protocol/jtag_interface.hpp"
+#include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// How this class picks a route, mirroring WormholeTTDevice::read_from_arc_apb: a non-null
+// RemoteInterface means the device is reached over ethernet through a gateway, a non-null
+// JtagInterface means it is reached over JTAG, and otherwise it is reached over PCIe. Inferring the
+// route from which optional interface is present is sound because a TTDevice is built for exactly
+// one communication protocol. The constructor enforces that exactly one of them is given, so the
+// route the null checks pick always has an interface behind it.
+
+/* static */ WormholeArcWindow WormholeArcWindow::arc_apb(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) {
+    static constexpr Config config{
+        .name = "ARC APB",
+        .noc_base_address = wormhole::ARC_APB_NOC_BASE_ADDRESS,
+        .bar0_offset_start = wormhole::ARC_APB_BAR0_XBAR_OFFSET_START,
+        // ARC_APB_ADDRESS_RANGE is END - START with an inclusive END, so it is the last valid
+        // offset rather than the window size. The bound below is a size, hence the + 1.
+        .size_bytes = wormhole::ARC_APB_ADDRESS_RANGE + 1,
+        .content = Content::REGISTERS,
+    };
+    return WormholeArcWindow(config, device_protocol, pcie_interface, jtag_interface, remote_interface);
+}
+
+/* static */ WormholeArcWindow WormholeArcWindow::arc_csm(
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) {
+    static constexpr Config config{
+        .name = "ARC CSM",
+        .noc_base_address = wormhole::ARC_CSM_NOC_BASE_ADDRESS,
+        .bar0_offset_start = wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START,
+        .size_bytes = wormhole::ARC_CSM_ADDRESS_RANGE + 1,
+        .content = Content::MEMORY,
+    };
+    return WormholeArcWindow(config, device_protocol, pcie_interface, jtag_interface, remote_interface);
+}
+
+WormholeArcWindow::WormholeArcWindow(
+    const Config& config,
+    DeviceProtocol* device_protocol,
+    PcieInterface* pcie_interface,
+    JtagInterface* jtag_interface,
+    RemoteInterface* remote_interface) :
+    config_(config),
+    device_protocol_(device_protocol),
+    pcie_interface_(pcie_interface),
+    jtag_interface_(jtag_interface),
+    remote_interface_(remote_interface) {
+    UMD_ASSERT(
+        device_protocol_ != nullptr,
+        error::RuntimeError,
+        fmt::format("The {} window requires a DeviceProtocol.", config_.name));
+    const int transports = (pcie_interface_ != nullptr) + (jtag_interface_ != nullptr) + (remote_interface_ != nullptr);
+    UMD_ASSERT(
+        transports == 1,
+        error::RuntimeError,
+        fmt::format(
+            "The {} window requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
+            "which one is present is how it picks the route for an access.",
+            config_.name));
+}
+
+void WormholeArcWindow::check_access(uint64_t arc_addr_offset, size_t size) const {
+    UMD_ASSERT(size != 0, error::RuntimeError, fmt::format("Zero-length {} access.", config_.name));
+
+    // The JTAG and BAR routes move exactly one word whatever size the caller asked for, so anything
+    // else is a caller error: a smaller size overruns mem_ptr, a larger one leaves it short. Both
+    // were silent in WormholeTTDevice, where the accessors were private and every caller passed a
+    // word.
+    UMD_ASSERT(
+        remote_interface_ != nullptr || size == sizeof(uint32_t),
+        error::RuntimeError,
+        fmt::format(
+            "{} access over JTAG or the PCIe BAR must be {} bytes, got {}.", config_.name, sizeof(uint32_t), size));
+
+    // size_bytes is the size of the window, not its last valid offset, so the whole transfer has to
+    // fit: the last access that fits starts size bytes before the end. Checking only the first byte,
+    // as WormholeTTDevice did, let a word access at the very end run past the window. The bound is a
+    // subtraction rather than an addition so it cannot wrap.
+    UMD_ASSERT(
+        size <= config_.size_bytes && arc_addr_offset <= config_.size_bytes - size,
+        error::RuntimeError,
+        fmt::format(
+            "{} access of {} bytes at offset {:#x} does not fit in the {:#x} byte window.",
+            config_.name,
+            size,
+            arc_addr_offset,
+            config_.size_bytes));
+}
+
+void WormholeArcWindow::read(void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id) {
+    check_access(arc_addr_offset, size);
+
+    const uint64_t noc_address = config_.noc_base_address + arc_addr_offset;
+    if (remote_interface_ != nullptr) {
+        if (config_.content == Content::MEMORY) {
+            device_protocol_->read_data(mem_ptr, arc_core, noc_address, size, noc_id);
+        } else {
+            device_protocol_->read_ctrl(mem_ptr, arc_core, noc_address, size, noc_id);
+        }
+        return;
+    }
+    if (jtag_interface_ != nullptr) {
+        device_protocol_->read_ctrl(mem_ptr, arc_core, noc_address, sizeof(uint32_t), noc_id);
+        return;
+    }
+    auto result = pcie_interface_->bar_read32(config_.bar0_offset_start + arc_addr_offset);
+    *(reinterpret_cast<uint32_t*>(mem_ptr)) = result;
+}
+
+void WormholeArcWindow::write(
+    const void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id) {
+    check_access(arc_addr_offset, size);
+
+    const uint64_t noc_address = config_.noc_base_address + arc_addr_offset;
+    if (remote_interface_ != nullptr) {
+        if (config_.content == Content::MEMORY) {
+            device_protocol_->write_data(mem_ptr, arc_core, noc_address, size, noc_id);
+        } else {
+            device_protocol_->write_ctrl(mem_ptr, arc_core, noc_address, size, noc_id);
+        }
+        return;
+    }
+    if (jtag_interface_ != nullptr) {
+        device_protocol_->write_ctrl(mem_ptr, arc_core, noc_address, sizeof(uint32_t), noc_id);
+        return;
+    }
+    pcie_interface_->bar_write32(
+        config_.bar0_offset_start + arc_addr_offset, *(reinterpret_cast<const uint32_t*>(mem_ptr)));
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -4,6 +4,7 @@
 
 #include "umd/device/tt_device/firmware/wormhole_device_firmware.hpp"
 
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
@@ -11,6 +12,12 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+// How this class picks a route for ARC accesses: a non-null RemoteInterface means the device is
+// reached over ethernet through a gateway, a non-null JtagInterface means it is reached over JTAG,
+// and otherwise it is reached over PCIe. Inferring the route from which optional interface is
+// present is sound because a TTDevice is built for exactly one communication protocol. The routing
+// itself lives in WormholeArcWindow.
 
 WormholeDeviceFirmware::WormholeDeviceFirmware(
     DeviceProtocol* device_protocol,
@@ -22,7 +29,9 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     pcie_interface_(pcie_interface),
     jtag_interface_(jtag_interface),
     remote_interface_(remote_interface),
-    architecture_impl_(architecture_impl) {
+    architecture_impl_(architecture_impl),
+    arc_apb_(WormholeArcWindow::arc_apb(device_protocol, pcie_interface, jtag_interface, remote_interface)),
+    arc_csm_(WormholeArcWindow::arc_csm(device_protocol, pcie_interface, jtag_interface, remote_interface)) {
     UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "WormholeDeviceFirmware requires a DeviceProtocol.");
     UMD_ASSERT(
         architecture_impl_ != nullptr,
@@ -34,6 +43,33 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
         error::RuntimeError,
         "WormholeDeviceFirmware requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
         "which one is present is how it picks the route for an access.");
+
+    // Read after the checks above, not in the member initialiser list: that runs first, so a null
+    // protocol faulted there before the assert could report it.
+    device_id_ = device_protocol_->get_mmio_id();
+
+    // The ARC core is at a fixed NOC0 coordinate on Wormhole, so both coordinates are known without
+    // reading anything from the device.
+    arc_core_noc0_ = wormhole::ARC_CORES_NOC0[0];
+    arc_core_noc1_ = tt_xy_pair(
+        wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+        wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
+}
+
+IODeviceType WormholeDeviceFirmware::get_io_device_type() const {
+    return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
+}
+
+tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
+}
+
+void WormholeDeviceFirmware::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_apb_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
+}
+
+void WormholeDeviceFirmware::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_csm_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
 }
 
 }  // namespace tt::umd

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(BAREMETAL_TESTS_SRCS
     test_notification_mechanism.cpp
     test_cluster.cpp
     test_blackhole_arc_apb.cpp
+    test_wormhole_arc_window.cpp
     test_blackhole_arc_message_queue.cpp
     # SimulationServerSocket and SimulationClient have no simulation deps (always compiled), so
     # their tests need no card and no simulation build -- they run in the no-card baremetal CI lane.

--- a/tests/baremetal/test_wormhole_arc_window.cpp
+++ b/tests/baremetal/test_wormhole_arc_window.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+#include "tests/test_utils/protocol_mocks.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+#include "umd/device/utils/error.hpp"
+
+using namespace tt::umd;
+using namespace tt::umd::test_utils;
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+constexpr uint64_t APB_OFFSET = 0x100;
+const tt_xy_pair ARC_CORE = {0, 10};
+
+class WormholeArcApbWindowTest : public ::testing::Test {
+protected:
+    uint64_t noc_address() const { return wormhole::ARC_APB_NOC_BASE_ADDRESS + APB_OFFSET; }
+
+    uint32_t bar_address() const { return wormhole::ARC_APB_BAR0_XBAR_OFFSET_START + APB_OFFSET; }
+
+    WormholeArcWindow over_pcie() { return WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, nullptr); }
+
+    WormholeArcWindow over_jtag() { return WormholeArcWindow::arc_apb(&protocol_, nullptr, &jtag_, nullptr); }
+
+    WormholeArcWindow over_remote() { return WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, &remote_); }
+
+    NiceMock<MockDeviceProtocol> protocol_;
+    NiceMock<MockPcieInterface> pcie_;
+    NiceMock<MockJtagInterface> jtag_;
+    NiceMock<MockRemoteInterface> remote_;
+};
+
+// Which interface is present is how the window picks its route, so it cannot be built with an
+// ambiguous set. Giving none leaves no route at all; giving two makes the null checks meaningless.
+TEST_F(WormholeArcApbWindowTest, RequiresExactlyOneTransport) {
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, nullptr), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, &jtag_, nullptr), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, &remote_), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(nullptr, &pcie_, nullptr, nullptr), std::exception);
+}
+
+// A remote device is reached over the NOC, and the APB window holds registers, so the access has to
+// go through the protocol's register path and keep the caller's size.
+TEST_F(WormholeArcApbWindowTest, RemoteReadIsARegisterAccessKeepingSize) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), 16, NocId::NOC0));
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.read(values.data(), APB_OFFSET, sizeof(values), ARC_CORE, NocId::NOC0);
+}
+
+TEST_F(WormholeArcApbWindowTest, RemoteWriteIsARegisterAccessKeepingSize) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, write_ctrl(_, ARC_CORE, noc_address(), 16, NocId::NOC1));
+    EXPECT_CALL(protocol_, write_data(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.write(values.data(), APB_OFFSET, sizeof(values), ARC_CORE, NocId::NOC1);
+}
+
+// A device opened over JTAG has no PcieInterface, so the access goes over the NOC, one word at a
+// time. WormholeTTDevice pinned this branch to NOC0; the window uses what the caller passed.
+TEST_F(WormholeArcApbWindowTest, JtagReadUsesTheCallersCoreAndNoc) {
+    auto window = over_jtag();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), sizeof(uint32_t), NocId::NOC1));
+
+    uint32_t value = 0;
+    window.read(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC1);
+}
+
+TEST_F(WormholeArcApbWindowTest, JtagWriteUsesTheCallersCoreAndNoc) {
+    auto window = over_jtag();
+
+    EXPECT_CALL(protocol_, write_ctrl(_, ARC_CORE, noc_address(), sizeof(uint32_t), NocId::NOC1));
+
+    uint32_t value = 0xABCD;
+    window.write(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC1);
+}
+
+// A local PCIe device goes through the BAR, which never touches the NOC.
+TEST_F(WormholeArcApbWindowTest, PcieReadGoesThroughTheBar) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_read32(bar_address())).WillOnce(Return(0xDEADBEEF));
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _)).Times(0);
+
+    uint32_t value = 0;
+    window.read(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+    EXPECT_EQ(value, 0xDEADBEEF);
+}
+
+TEST_F(WormholeArcApbWindowTest, PcieWriteGoesThroughTheBar) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_write32(bar_address(), 0xABCD1234));
+    EXPECT_CALL(protocol_, write_ctrl(_, _, _, _, _)).Times(0);
+
+    uint32_t value = 0xABCD1234;
+    window.write(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+}
+
+// The JTAG and BAR routes always move one word, so a size they cannot honor is rejected instead of
+// overrunning or short-changing the caller's buffer.
+TEST_F(WormholeArcApbWindowTest, NonWordSizeIsRejectedOnTheWordSizedRoutes) {
+    uint32_t value = 0;
+
+    auto pcie_window = over_pcie();
+    EXPECT_THROW(pcie_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(pcie_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), std::exception);
+
+    auto jtag_window = over_jtag();
+    EXPECT_THROW(jtag_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(jtag_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), std::exception);
+}
+
+// The window bound covers the whole transfer, not just its first byte: a word access starting at
+// the window size, or four bytes before its end plus one, runs past the end.
+TEST_F(WormholeArcApbWindowTest, AccessMustFitEntirelyInsideTheWindow) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    // ARC_APB_ADDRESS_RANGE is END - START with an inclusive END, so the window is one byte larger
+    // than it.
+    constexpr uint64_t WINDOW_SIZE = static_cast<uint64_t>(wormhole::ARC_APB_ADDRESS_RANGE) + 1;
+
+    // Starts inside the window but runs past its end.
+    EXPECT_THROW(
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    // Starts at the first byte past the window.
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    // Starts at zero but is larger than the whole window.
+    EXPECT_THROW(window.read(&value, 0, WINDOW_SIZE + 1, ARC_CORE, NocId::NOC0), std::exception);
+
+    // The last word that fits ends exactly on the window's last byte.
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _));
+    window.read(&value, WINDOW_SIZE - sizeof(value), sizeof(value), ARC_CORE, NocId::NOC0);
+}
+
+TEST_F(WormholeArcApbWindowTest, ZeroLengthAccessIsRejected) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    EXPECT_THROW(window.read(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(window.write(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), std::exception);
+}
+
+constexpr uint64_t CSM_OFFSET = 0x200;
+
+class WormholeArcCsmWindowTest : public ::testing::Test {
+protected:
+    uint64_t noc_address() const { return wormhole::ARC_CSM_NOC_BASE_ADDRESS + CSM_OFFSET; }
+
+    uint32_t bar_address() const { return wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + CSM_OFFSET; }
+
+    WormholeArcWindow over_pcie() { return WormholeArcWindow::arc_csm(&protocol_, &pcie_, nullptr, nullptr); }
+
+    WormholeArcWindow over_jtag() { return WormholeArcWindow::arc_csm(&protocol_, nullptr, &jtag_, nullptr); }
+
+    WormholeArcWindow over_remote() { return WormholeArcWindow::arc_csm(&protocol_, nullptr, nullptr, &remote_); }
+
+    NiceMock<MockDeviceProtocol> protocol_;
+    NiceMock<MockPcieInterface> pcie_;
+    NiceMock<MockJtagInterface> jtag_;
+    NiceMock<MockRemoteInterface> remote_;
+};
+
+// CSM holds memory rather than registers, so a remote access takes the data path where the APB
+// window takes the register one. This is the only routing difference between the two.
+TEST_F(WormholeArcCsmWindowTest, RemoteReadIsADataAccess) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, read_data(_, ARC_CORE, noc_address(), 16, NocId::NOC0));
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.read(values.data(), CSM_OFFSET, sizeof(values), ARC_CORE, NocId::NOC0);
+}
+
+TEST_F(WormholeArcCsmWindowTest, RemoteWriteIsADataAccess) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, write_data(_, ARC_CORE, noc_address(), 16, NocId::NOC0));
+    EXPECT_CALL(protocol_, write_ctrl(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.write(values.data(), CSM_OFFSET, sizeof(values), ARC_CORE, NocId::NOC0);
+}
+
+// The memory-vs-registers distinction is a remote-route one only: JTAG reaches every window over
+// the register path, as the TTDevice-era CSM accessor this replaced did.
+TEST_F(WormholeArcCsmWindowTest, JtagReadStaysOnTheRegisterPath) {
+    auto window = over_jtag();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), sizeof(uint32_t), NocId::NOC1));
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _)).Times(0);
+
+    uint32_t value = 0;
+    window.read(&value, CSM_OFFSET, sizeof(value), ARC_CORE, NocId::NOC1);
+}
+
+TEST_F(WormholeArcCsmWindowTest, PcieReadGoesThroughTheCsmBarOffset) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_read32(bar_address())).WillOnce(Return(0x12345678));
+
+    uint32_t value = 0;
+    window.read(&value, CSM_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+    EXPECT_EQ(value, 0x12345678);
+}
+
+TEST_F(WormholeArcCsmWindowTest, PcieWriteGoesThroughTheCsmBarOffset) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_write32(bar_address(), 0x87654321));
+
+    uint32_t value = 0x87654321;
+    window.write(&value, CSM_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+}
+
+// The two windows are separate address ranges, so each is bounded by its own size.
+TEST_F(WormholeArcCsmWindowTest, AccessIsBoundedByTheCsmWindow) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    constexpr uint64_t WINDOW_SIZE = static_cast<uint64_t>(wormhole::ARC_CSM_ADDRESS_RANGE) + 1;
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _));
+    window.read(&value, WINDOW_SIZE - sizeof(value), sizeof(value), ARC_CORE, NocId::NOC0);
+}
+
+}  // namespace


### PR DESCRIPTION
## Description
Private plumbing the boot waits will consume: device identity for error payloads, the per-NOC ARC coordinates (Blackhole resolves them in the constructor from a private NOC-translation read — the public `TTDevice::get_noc_translation_enabled` survives until its own delegation PR; Wormhole's are fixed constants), the ARC window members, and thin accessors over them (`get_io_device_type`, `get_firmware_noc_coord`, `read_from_arc_apb`, `read_from_arc_csm`). All private; briefly caller-less — the waits that consume them are the next two PRs.

## Testing
`baremetal_tests` 254/254, sim on/off.

## API Changes
None.

Stacked on the window PR.
