### PR TITLE
[Base API] Move the Wormhole firmware boot wait into WormholeDeviceFirmware

### DIFF
--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -261,7 +261,7 @@ inline constexpr uint32_t ARC_CSM_ARC_PCIE_DMA_REQUEST = 0x784D4;
 
 // SCRATCH_REG_EXT: a fixed, host-readable CSM window carved into 32-bit slots that firmware uses to
 // publish locators for the host runtime. Offsets are relative to the ARC CSM base (0x10000000) and are
-// meant to be passed to read_from_arc_csm. Firmware publishes the runtime telemetry buffer address in
+// meant to be passed to the ARC CSM window. Firmware publishes the runtime telemetry buffer address in
 // slot 0 and its size in slot 1. See syseng src/hardware/soc/tb/arc_fw/lib/scratch_reg_ext.h
 // (SCRATCH_REG_EXT_START_ADDR = 0x10075C00).
 inline constexpr uint32_t SCRATCH_REG_EXT_OFFSET = 0x75C00;

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -43,10 +43,6 @@ public:
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
-    void read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
-
-    void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
-
     ChipInfo get_chip_info() override;
 
     std::chrono::milliseconds wait_eth_core_training(

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -4,22 +4,44 @@
 
 #pragma once
 
+#include <chrono>
+
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/utils/error.hpp"
+
 namespace tt::umd {
 
 /**
  * @brief Interface to the device's management firmware.
  *
  * Owns the interaction with the firmware running on the device's management processor: waiting for
- * it to boot, issuing commands, and reading the state it publishes. TTDevice holds one and forwards
- * the firmware-backed parts of its API here; the implementations are built from protocol interfaces
+ * it to boot, issuing commands, and reading the state it publishes. TTDevice forwards the
+ * firmware-backed parts of its API here; the implementations are built from protocol interfaces
  * rather than a TTDevice, so they carry no dependency on the facade.
  *
- * The interface starts empty on purpose. Each capability is added together with the TTDevice code
- * it replaces, so every addition is reviewable as a move.
+ * The interface grows one capability at a time, each added together with the TTDevice code it
+ * replaces, so every addition is reviewable as a move.
  */
 class DeviceFirmware {
 public:
     virtual ~DeviceFirmware() = default;
+
+    /**
+     * @brief Performs the firmware initialization.
+     *
+     * Blocks until the management firmware reports it has booted.
+     *
+     * @param timeout_ms Maximum time to wait for the firmware to become ready.
+     * @param noc_id NOC to route the status reads over.
+     * @throws error::FirmwareStartupError if the firmware does not come up within the timeout.
+     */
+    virtual void init_firmware(
+        std::chrono::milliseconds timeout_ms, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) {
+        // Transitional default while startup moves one backend at a time; for backends that have
+        // not moved, TTDevice::wait_arc_core_start still drives startup and never reaches this.
+        // Becomes pure virtual when the last backend moves.
+        UMD_THROW(error::RuntimeError, "init_firmware is not implemented for this backend yet.");
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_arc_window.hpp
@@ -36,10 +36,11 @@ class RemoteInterface;
  *
  * The interfaces are non-owning and must outlive this object.
  *
- * This lands as a skeleton: construction, validation and the window configurations, with no
- * accesses yet. Each access arrives as a behavior migration - read() with the firmware boot wait,
- * write() with the firmware command path - deleting the WormholeTTDevice copy it replaces in the
- * same diff wherever that copy has no other callers left.
+ * TODO: WormholeTTDevice still holds its own copy of the APB routing, with the original bound
+ * check that validates only the first byte of a transfer, for the callers that have not moved to
+ * DeviceFirmware yet (the ARC messenger and its dependents). It is retired with them -- until then
+ * the two can drift. The CSM copy is already gone: its only caller was the firmware boot wait,
+ * which moved here together with this class.
  */
 class WormholeArcWindow {
 public:
@@ -104,6 +105,19 @@ public:
         JtagInterface* jtag_interface,
         RemoteInterface* remote_interface);
 
+    /**
+     * @brief Reads from the window.
+     * @param mem_ptr Destination buffer.
+     * @param arc_addr_offset Offset into the window. The whole transfer has to fit inside it, so the
+     * largest valid offset is the window size less size.
+     * @param size Bytes to read. The remote path honors any size; the JTAG and BAR paths read one
+     * word and reject anything other than sizeof(uint32_t) rather than silently widening.
+     * @param arc_core NOC coordinate of the ARC core, resolved for noc_id. Used on every route,
+     * including JTAG, which WormholeTTDevice pinned to NOC0 instead.
+     * @param noc_id NOC to route through.
+     */
+    void read(void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id);
+
 private:
     WormholeArcWindow(
         const Config& config,
@@ -111,6 +125,8 @@ private:
         PcieInterface* pcie_interface,
         JtagInterface* jtag_interface,
         RemoteInterface* remote_interface);
+
+    void check_access(uint64_t arc_addr_offset, size_t size) const;
 
     Config config_;
     // All non-owning; they belong to the component that owns this object and must outlive it.

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -4,7 +4,15 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
+#include "umd/device/tt_device/firmware/wormhole_arc_window.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -31,12 +39,50 @@ public:
         RemoteInterface* remote_interface,
         ArchitectureImplementation* architecture_impl);
 
+    void init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id = NocId::DEFAULT_NOC) override;
+
 private:
+    /**
+     * @brief Blocks until the management firmware reports it has booted.
+     *
+     * Kept as its own step because init_firmware() has a second job arriving: building the
+     * components that read what the firmware publishes, which lands next to this call rather than
+     * around it.
+     *
+     * @param timeout_ms How long to wait for the firmware to report ready.
+     * @param noc_id NOC to route the status reads over.
+     * @throws error::FirmwareStartupError if the firmware does not come up within the timeout.
+     */
+    void wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id);
+
+    IODeviceType get_io_device_type() const;
+
+    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
+    // API it replaces moves here.
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
+
+    // Thin wrappers that resolve the ARC core for noc_id and hand the access to arc_apb_/arc_csm_.
+    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    // All non-owning; they belong to the object that owns this one and must outlive it.
     DeviceProtocol* device_protocol_ = nullptr;
     PcieInterface* pcie_interface_ = nullptr;
     JtagInterface* jtag_interface_ = nullptr;
     RemoteInterface* remote_interface_ = nullptr;
     ArchitectureImplementation* architecture_impl_ = nullptr;
+
+    // Identifies this device in error payloads; taken from the protocol so it identifies the
+    // device, not the silicon model. See DeviceProtocol::get_mmio_id().
+    int device_id_ = 0;
+
+    // ARC core coordinate per NOC. Fixed for Wormhole, so resolved once in the constructor.
+    tt_xy_pair arc_core_noc0_;
+    tt_xy_pair arc_core_noc1_;
+
+    WormholeArcWindow arc_apb_;
+    WormholeArcWindow arc_csm_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -59,8 +59,6 @@ public:
 
     void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     uint32_t get_clock() override;
     uint32_t get_min_clock_freq() override;
     bool get_noc_translation_enabled() override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -49,6 +49,7 @@ namespace tt::umd {
 
 class ArcMessenger;
 class ArcTelemetryReader;
+class DeviceFirmware;
 class RemoteCommunication;
 class SimulationSysmemManager;
 class DmaInterface;
@@ -319,40 +320,6 @@ public:
     virtual void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) = 0;
 
     /**
-     * Read function that will send read message to the ARC core CSM.
-     *
-     * @param mem_ptr pointer to memory which will receive the data
-     * @param arc_addr_offset address offset in ARC core CSM
-     * @param size number of bytes
-     *
-     * NOTE: This function will read from CSM. It will use the AXI interface to read the data if the chip is local/PCIe,
-     * while the remote chip will use the NOC interface to read the data. Blackhole has board
-     * configurations where the ARC is not available over AXI, hence in this situations, the NOC
-     * interface will be used even for local chips.
-     *
-     * For additional details on the ARC core architecture and communication mechanisms, please refer to:
-     * https://github.com/tenstorrent/tt-isa-documentation
-     */
-    virtual void read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) = 0;
-
-    /**
-     * Write function that will send write message to the ARC core CSM.
-     *
-     * @param mem_ptr pointer to memory from which the data is sent
-     * @param arc_addr_offset address offset in ARC core CSM
-     * @param size number of bytes
-     *
-     * NOTE: This function will write to CSM. It will use the AXI interface to write the data if the chip is local/PCIe,
-     * while the remote chip will use the NOC interface to write the data. Blackhole has board
-     * configurations where the ARC is not available over AXI, hence in this situations, the NOC
-     * interface will be used even for local chips.
-     *
-     * For additional details on the ARC core architecture and communication mechanisms, please refer to:
-     * https://github.com/tenstorrent/tt-isa-documentation
-     */
-    virtual void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) = 0;
-
-    /**
      * Configures a PCIe Address Translation Unit (iATU) region.
      *
      * Device software expects to be able to access memory that is shared with
@@ -383,6 +350,12 @@ public:
     virtual ChipInfo get_chip_info();
 
     FirmwareBundleVersion get_firmware_version();
+
+    /**
+     * Interface to the device's management firmware. Owned by the model, so never null; created
+     * with the device, initialized by init_tt_device() through DeviceFirmware::init_firmware().
+     */
+    DeviceFirmware *get_device_firmware() const;
 
     /**
      * Waits for ARC core to be fully ready for communication.

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -40,10 +40,6 @@ public:
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
-    void read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
-
-    void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
-
     ChipInfo get_chip_info() override;
 
     std::chrono::milliseconds wait_eth_core_training(

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -284,14 +284,6 @@ void BlackholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_
     bar_write32(registers_.arc_apb_bar0_offset + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
 }
 
-void BlackholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
-    UMD_THROW(error::RuntimeError, "CSM write not supported for Blackhole.");
-}
-
-void BlackholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
-    UMD_THROW(error::RuntimeError, "CSM read not supported for Blackhole.");
-}
-
 std::chrono::milliseconds BlackholeTTDevice::wait_eth_core_training(
     CoreCoord eth_core, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);

--- a/device/tt_device/firmware/wormhole_arc_window.cpp
+++ b/device/tt_device/firmware/wormhole_arc_window.cpp
@@ -15,8 +15,12 @@
 
 namespace tt::umd {
 
-// The constructor enforces that exactly one transport interface is given: which one is present
-// is how the accesses added by later PRs pick their route.
+// How this class picks a route, mirroring WormholeTTDevice::read_from_arc_apb: a non-null
+// RemoteInterface means the device is reached over ethernet through a gateway, a non-null
+// JtagInterface means it is reached over JTAG, and otherwise it is reached over PCIe. Inferring the
+// route from which optional interface is present is sound because a TTDevice is built for exactly
+// one communication protocol. The constructor enforces that exactly one of them is given, so the
+// route the null checks pick always has an interface behind it.
 
 /* static */ WormholeArcWindow WormholeArcWindow::arc_apb(
     DeviceProtocol* device_protocol,
@@ -73,6 +77,54 @@ WormholeArcWindow::WormholeArcWindow(
             "The {} window requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
             "which one is present is how it picks the route for an access.",
             config_.name));
+}
+
+void WormholeArcWindow::check_access(uint64_t arc_addr_offset, size_t size) const {
+    UMD_ASSERT(size != 0, error::RuntimeError, fmt::format("Zero-length {} access.", config_.name));
+
+    // The JTAG and BAR routes move exactly one word whatever size the caller asked for, so anything
+    // else is a caller error: a smaller size overruns mem_ptr, a larger one leaves it short. Both
+    // were silent in WormholeTTDevice, where the accessors were private and every caller passed a
+    // word.
+    UMD_ASSERT(
+        remote_interface_ != nullptr || size == sizeof(uint32_t),
+        error::RuntimeError,
+        fmt::format(
+            "{} access over JTAG or the PCIe BAR must be {} bytes, got {}.", config_.name, sizeof(uint32_t), size));
+
+    // size_bytes is the size of the window, not its last valid offset, so the whole transfer has to
+    // fit: the last access that fits starts size bytes before the end. Checking only the first byte,
+    // as WormholeTTDevice did, let a word access at the very end run past the window. The bound is a
+    // subtraction rather than an addition so it cannot wrap.
+    UMD_ASSERT(
+        size <= config_.size_bytes && arc_addr_offset <= config_.size_bytes - size,
+        error::RuntimeError,
+        fmt::format(
+            "{} access of {} bytes at offset {:#x} does not fit in the {:#x} byte window.",
+            config_.name,
+            size,
+            arc_addr_offset,
+            config_.size_bytes));
+}
+
+void WormholeArcWindow::read(void* mem_ptr, uint64_t arc_addr_offset, size_t size, tt_xy_pair arc_core, NocId noc_id) {
+    check_access(arc_addr_offset, size);
+
+    const uint64_t noc_address = config_.noc_base_address + arc_addr_offset;
+    if (remote_interface_ != nullptr) {
+        if (config_.content == Content::MEMORY) {
+            device_protocol_->read_data(mem_ptr, arc_core, noc_address, size, noc_id);
+        } else {
+            device_protocol_->read_ctrl(mem_ptr, arc_core, noc_address, size, noc_id);
+        }
+        return;
+    }
+    if (jtag_interface_ != nullptr) {
+        device_protocol_->read_ctrl(mem_ptr, arc_core, noc_address, sizeof(uint32_t), noc_id);
+        return;
+    }
+    auto result = pcie_interface_->bar_read32(config_.bar0_offset_start + arc_addr_offset);
+    *(reinterpret_cast<uint32_t*>(mem_ptr)) = result;
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -4,13 +4,22 @@
 
 #include "umd/device/tt_device/firmware/wormhole_device_firmware.hpp"
 
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils.hpp"
 
 namespace tt::umd {
+
+// How this class picks a route for ARC accesses: a non-null RemoteInterface means the device is
+// reached over ethernet through a gateway, a non-null JtagInterface means it is reached over JTAG,
+// and otherwise it is reached over PCIe. Inferring the route from which optional interface is
+// present is sound because a TTDevice is built for exactly one communication protocol. The routing
+// itself lives in WormholeArcWindow.
 
 WormholeDeviceFirmware::WormholeDeviceFirmware(
     DeviceProtocol* device_protocol,
@@ -22,7 +31,9 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     pcie_interface_(pcie_interface),
     jtag_interface_(jtag_interface),
     remote_interface_(remote_interface),
-    architecture_impl_(architecture_impl) {
+    architecture_impl_(architecture_impl),
+    arc_apb_(WormholeArcWindow::arc_apb(device_protocol, pcie_interface, jtag_interface, remote_interface)),
+    arc_csm_(WormholeArcWindow::arc_csm(device_protocol, pcie_interface, jtag_interface, remote_interface)) {
     UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "WormholeDeviceFirmware requires a DeviceProtocol.");
     UMD_ASSERT(
         architecture_impl_ != nullptr,
@@ -34,6 +45,165 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
         error::RuntimeError,
         "WormholeDeviceFirmware requires exactly one of a PcieInterface, a JtagInterface or a RemoteInterface, since "
         "which one is present is how it picks the route for an access.");
+
+    // Read after the checks above, not in the member initialiser list: that runs first, so a null
+    // protocol faulted there before the assert could report it.
+    device_id_ = device_protocol_->get_mmio_id();
+
+    // The ARC core is at a fixed NOC0 coordinate on Wormhole, so both coordinates are known without
+    // reading anything from the device.
+    arc_core_noc0_ = wormhole::ARC_CORES_NOC0[0];
+    arc_core_noc1_ = tt_xy_pair(
+        wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+        wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
+}
+
+IODeviceType WormholeDeviceFirmware::get_io_device_type() const {
+    return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
+}
+
+void WormholeDeviceFirmware::init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    wait_firmware_ready(timeout_ms, noc_id);
+}
+
+void WormholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // Deliberate difference from the deleted TTDevice wait: its JTAG reads were pinned to the NOC0
+    // ARC coordinate over the default NOC whatever NOC the caller asked for. Every read here uses
+    // noc_id consistently, coordinate and routing both; with the default NOC0 the two are
+    // bit-identical on every transport.
+    // One throwaway read before the poll, so a dead ARC APB path faults on an access that is
+    // clearly a probe rather than partway into the boot-status loop. This was
+    // TTDevice::probe_arc(), moved here with its only caller.
+    uint32_t dummy;
+    read_from_arc_apb(&dummy, wormhole::ARC_RESET_SCRATCH_OFFSET, sizeof(dummy), noc_id);
+
+    // Status codes.
+    constexpr uint32_t STATUS_NO_ACCESS = 0xFFFFFFFF;
+    constexpr uint32_t STATUS_WATCHDOG_TRIGGERED = 0xDEADC0DE;
+    constexpr uint32_t STATUS_BOOT_INCOMPLETE_1 = 0x00000060;
+    constexpr uint32_t STATUS_BOOT_INCOMPLETE_2 = 0x11110000;
+    constexpr uint32_t STATUS_ASLEEP_1 = 0x0000AA00;
+    constexpr uint32_t STATUS_ASLEEP_2 = 0x55;
+    constexpr uint32_t STATUS_INIT_DONE_1 = 0x00000001;
+    constexpr uint32_t STATUS_INIT_DONE_2 = 0xFFFFDEAD;
+    constexpr uint32_t STATUS_OLD_POST_CODE = 0;
+    constexpr uint32_t STATUS_MESSAGE_QUEUED_MASK = 0xFFFFFF00;
+    constexpr uint32_t STATUS_MESSAGE_QUEUED_VAL = 0x0000AA00;
+    constexpr uint32_t STATUS_HANDLING_MESSAGE_MASK = 0xFF00FFFF;
+    constexpr uint32_t STATUS_HANDLING_MESSAGE_VAL = 0xAA000000;
+    constexpr uint32_t STATUS_MESSAGE_COMPLETE_MASK = 0x0000FFFF;
+    constexpr uint32_t STATUS_MESSAGE_COMPLETE_MIN = 0x00000001;
+
+    // Post codes.
+    constexpr uint32_t POST_CODE_INIT_DONE = 0xC0DE0001;
+    constexpr uint32_t POST_CODE_ARC_MSG_HANDLE_DONE = 0xC0DE003F;
+    constexpr uint32_t POST_CODE_ARC_TIME_LAST = 0xC0DE007F;
+
+    uint32_t arc_reset_scratch_status = 0;
+    uint32_t arc_post_code = 0;
+    uint32_t message_id = 0;
+
+    constexpr auto busy_poll_window = std::chrono::microseconds(1000);
+    constexpr auto poll_interval = std::chrono::microseconds(10);
+
+    const bool arc_core_started = utils::poll_until(
+        [this, &arc_reset_scratch_status, &arc_post_code, &message_id, &noc_id]() {
+            read_from_arc_apb(
+                &arc_reset_scratch_status,
+                wormhole::ARC_RESET_SCRATCH_STATUS_OFFSET,
+                sizeof(arc_reset_scratch_status),
+                noc_id);
+
+            read_from_arc_apb(&arc_post_code, wormhole::ARC_RESET_SCRATCH_OFFSET, sizeof(arc_post_code), noc_id);
+
+            uint32_t arc_csm_pcie_dma_request = 0;
+            read_from_arc_csm(
+                &arc_csm_pcie_dma_request,
+                wormhole::ARC_CSM_ARC_PCIE_DMA_REQUEST,
+                sizeof(arc_csm_pcie_dma_request),
+                noc_id);
+
+            switch (arc_reset_scratch_status) {
+                case STATUS_NO_ACCESS:
+                case STATUS_WATCHDOG_TRIGGERED:
+                    UMD_THROW(
+                        error::FirmwareStartupError,
+                        get_io_device_type(),
+                        device_id_,
+                        tt::ARCH::WORMHOLE_B0,
+                        noc_id,
+                        get_firmware_noc_coord(noc_id),
+                        arc_reset_scratch_status,
+                        arc_post_code);
+
+                case STATUS_INIT_DONE_1:
+                case STATUS_INIT_DONE_2:
+                    return true;
+
+                case STATUS_OLD_POST_CODE: {
+                    const bool pc_idle =
+                        (arc_post_code == POST_CODE_INIT_DONE) ||
+                        (arc_post_code >= POST_CODE_ARC_MSG_HANDLE_DONE && arc_post_code <= POST_CODE_ARC_TIME_LAST);
+                    if (pc_idle) {
+                        return true;
+                    }
+                    break;
+                }
+                case STATUS_BOOT_INCOMPLETE_1:
+                case STATUS_BOOT_INCOMPLETE_2:
+                case STATUS_ASLEEP_1:
+                case STATUS_ASLEEP_2:
+                default:
+                    break;
+            }
+
+            const bool is_queued =
+                ((arc_reset_scratch_status & STATUS_MESSAGE_QUEUED_MASK) == STATUS_MESSAGE_QUEUED_VAL);
+            const bool is_handling =
+                ((arc_reset_scratch_status & STATUS_HANDLING_MESSAGE_MASK) == STATUS_HANDLING_MESSAGE_VAL);
+            const bool is_complete =
+                ((arc_reset_scratch_status & STATUS_MESSAGE_COMPLETE_MASK) > STATUS_MESSAGE_COMPLETE_MIN);
+            const bool dma_request = (arc_csm_pcie_dma_request != 0);
+
+            if (is_queued) {
+                message_id = arc_reset_scratch_status & 0xFF;
+            } else if (is_handling) {
+                message_id = (arc_reset_scratch_status >> 16) & 0xFF;
+            } else if (is_complete && !dma_request) {
+                // We only return if the message says complete and DMA is idle.
+                return true;
+            }
+            return false;
+        },
+        timeout_ms,
+        busy_poll_window,
+        poll_interval);
+
+    if (!arc_core_started) {
+        UMD_THROW(
+            error::FirmwareStartupError,
+            get_io_device_type(),
+            device_id_,
+            tt::ARCH::WORMHOLE_B0,
+            noc_id,
+            get_firmware_noc_coord(noc_id),
+            arc_reset_scratch_status,
+            arc_post_code,
+            timeout_ms,
+            message_id);
+    }
+}
+
+tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
+}
+
+void WormholeDeviceFirmware::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_apb_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
+}
+
+void WormholeDeviceFirmware::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_csm_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -330,14 +330,6 @@ void SimulationTTDevice::write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr
     UMD_THROW(error::RuntimeError, "ARC APB access is not supported for simulation devices.");
 }
 
-void SimulationTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
-}
-
-void SimulationTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
-}
-
 uint32_t SimulationTTDevice::get_clock() {
     UMD_THROW(error::RuntimeError, "Getting clock is not supported for simulation devices.");
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -32,6 +32,7 @@
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
 #include "umd/device/tt_device/protocol/dma_interface.hpp"
@@ -76,6 +77,8 @@ TTDevice::TTDevice(std::unique_ptr<TTDeviceModel> model) : model_(std::move(mode
     }
     wire_hang_detector();
 }
+
+DeviceFirmware *TTDevice::get_device_firmware() const { return model_->get_device_firmware(); }
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
@@ -191,48 +192,6 @@ void WormholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_o
     bar_write32(registers_.arc_apb_bar0_offset + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
 }
 
-void WormholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
-    if (arc_addr_offset > wormhole::ARC_CSM_ADDRESS_RANGE) {
-        UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
-    }
-    if (is_remote()) {
-        read_from_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
-        return;
-    }
-    if (get_communication_device_type() == IODeviceType::JTAG) {
-        get_device_protocol()->read_ctrl(
-            mem_ptr,
-            wormhole::ARC_CORES_NOC0[0],
-            wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset,
-            sizeof(uint32_t),
-            NocId::DEFAULT_NOC);
-        return;
-    }
-    auto result = bar_read32(wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + arc_addr_offset);
-    *(reinterpret_cast<uint32_t *>(mem_ptr)) = result;
-}
-
-void WormholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
-    if (arc_addr_offset > wormhole::ARC_CSM_ADDRESS_RANGE) {
-        UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
-    }
-    if (is_remote()) {
-        write_to_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
-        return;
-    }
-    if (get_communication_device_type() == IODeviceType::JTAG) {
-        get_device_protocol()->write_ctrl(
-            mem_ptr,
-            wormhole::ARC_CORES_NOC0[0],
-            wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset,
-            sizeof(uint32_t),
-            NocId::DEFAULT_NOC);
-        return;
-    }
-    bar_write32(
-        wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
-}
-
 std::chrono::milliseconds WormholeTTDevice::wait_eth_core_training(
     CoreCoord eth_core, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
@@ -299,120 +258,9 @@ void WormholeTTDevice::probe_arc() {
 }
 
 void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
-    // Status codes.
-    constexpr uint32_t STATUS_NO_ACCESS = 0xFFFFFFFF;
-    constexpr uint32_t STATUS_WATCHDOG_TRIGGERED = 0xDEADC0DE;
-    constexpr uint32_t STATUS_BOOT_INCOMPLETE_1 = 0x00000060;
-    constexpr uint32_t STATUS_BOOT_INCOMPLETE_2 = 0x11110000;
-    constexpr uint32_t STATUS_ASLEEP_1 = 0x0000AA00;
-    constexpr uint32_t STATUS_ASLEEP_2 = 0x55;
-    constexpr uint32_t STATUS_INIT_DONE_1 = 0x00000001;
-    constexpr uint32_t STATUS_INIT_DONE_2 = 0xFFFFDEAD;
-    constexpr uint32_t STATUS_OLD_POST_CODE = 0;
-    constexpr uint32_t STATUS_MESSAGE_QUEUED_MASK = 0xFFFFFF00;
-    constexpr uint32_t STATUS_MESSAGE_QUEUED_VAL = 0x0000AA00;
-    constexpr uint32_t STATUS_HANDLING_MESSAGE_MASK = 0xFF00FFFF;
-    constexpr uint32_t STATUS_HANDLING_MESSAGE_VAL = 0xAA000000;
-    constexpr uint32_t STATUS_MESSAGE_COMPLETE_MASK = 0x0000FFFF;
-    constexpr uint32_t STATUS_MESSAGE_COMPLETE_MIN = 0x00000001;
-
-    // Post codes.
-    constexpr uint32_t POST_CODE_INIT_DONE = 0xC0DE0001;
-    constexpr uint32_t POST_CODE_ARC_MSG_HANDLE_DONE = 0xC0DE003F;
-    constexpr uint32_t POST_CODE_ARC_TIME_LAST = 0xC0DE007F;
-
-    uint32_t bar_read_arc_reset_scratch_status = 0;
-    uint32_t bar_read_arc_post_code = 0;
-    uint32_t message_id = 0;
-
-    constexpr auto busy_poll_window = std::chrono::microseconds(1000);
-    constexpr auto poll_interval = std::chrono::microseconds(10);
-
-    const bool arc_core_started = utils::poll_until(
-        [this, &bar_read_arc_reset_scratch_status, &bar_read_arc_post_code, &message_id]() {
-            read_from_arc_apb(
-                &bar_read_arc_reset_scratch_status,
-                wormhole::ARC_RESET_SCRATCH_STATUS_OFFSET,
-                sizeof(bar_read_arc_reset_scratch_status));
-
-            read_from_arc_apb(
-                &bar_read_arc_post_code, registers_.arc_reset_scratch_offset, sizeof(bar_read_arc_post_code));
-
-            uint32_t bar_read_arc_csm_pcie_dma_request = 0;
-            read_from_arc_csm(
-                &bar_read_arc_csm_pcie_dma_request,
-                wormhole::ARC_CSM_ARC_PCIE_DMA_REQUEST,
-                sizeof(bar_read_arc_csm_pcie_dma_request));
-
-            switch (bar_read_arc_reset_scratch_status) {
-                case STATUS_NO_ACCESS:
-                case STATUS_WATCHDOG_TRIGGERED:
-                    UMD_THROW(
-                        error::FirmwareStartupError,
-                        get_communication_device_type(),
-                        get_communication_device_id(),
-                        get_arch(),
-                        get_selected_noc_id(),
-                        get_arc_core(),
-                        bar_read_arc_reset_scratch_status,
-                        bar_read_arc_post_code);
-
-                case STATUS_INIT_DONE_1:
-                case STATUS_INIT_DONE_2:
-                    return true;
-
-                case STATUS_OLD_POST_CODE: {
-                    const bool pc_idle = (bar_read_arc_post_code == POST_CODE_INIT_DONE) ||
-                                         (bar_read_arc_post_code >= POST_CODE_ARC_MSG_HANDLE_DONE &&
-                                          bar_read_arc_post_code <= POST_CODE_ARC_TIME_LAST);
-                    if (pc_idle) {
-                        return true;
-                    }
-                    break;
-                }
-                case STATUS_BOOT_INCOMPLETE_1:
-                case STATUS_BOOT_INCOMPLETE_2:
-                case STATUS_ASLEEP_1:
-                case STATUS_ASLEEP_2:
-                default:
-                    break;
-            }
-
-            const bool is_queued =
-                ((bar_read_arc_reset_scratch_status & STATUS_MESSAGE_QUEUED_MASK) == STATUS_MESSAGE_QUEUED_VAL);
-            const bool is_handling =
-                ((bar_read_arc_reset_scratch_status & STATUS_HANDLING_MESSAGE_MASK) == STATUS_HANDLING_MESSAGE_VAL);
-            const bool is_complete =
-                ((bar_read_arc_reset_scratch_status & STATUS_MESSAGE_COMPLETE_MASK) > STATUS_MESSAGE_COMPLETE_MIN);
-            const bool dma_request = (bar_read_arc_csm_pcie_dma_request != 0);
-
-            if (is_queued) {
-                message_id = bar_read_arc_reset_scratch_status & 0xFF;
-            } else if (is_handling) {
-                message_id = (bar_read_arc_reset_scratch_status >> 16) & 0xFF;
-            } else if (is_complete && !dma_request) {
-                // We only return if the message says complete and DMA is idle.
-                return true;
-            }
-            return false;
-        },
-        timeout_ms,
-        busy_poll_window,
-        poll_interval);
-
-    if (!arc_core_started) {
-        UMD_THROW(
-            error::FirmwareStartupError,
-            get_communication_device_type(),
-            get_communication_device_id(),
-            get_arch(),
-            get_selected_noc_id(),
-            get_arc_core(),
-            bar_read_arc_reset_scratch_status,
-            bar_read_arc_post_code,
-            timeout_ms,
-            message_id);
-    }
+    // Transitional shim: the wait moved into WormholeDeviceFirmware; this override goes away with
+    // the API once every backend has moved.
+    get_device_firmware()->init_firmware(timeout_ms, get_selected_noc_id());
 }
 
 void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {

--- a/tests/baremetal/test_wormhole_arc_window.cpp
+++ b/tests/baremetal/test_wormhole_arc_window.cpp
@@ -15,12 +15,23 @@
 
 using namespace tt::umd;
 using namespace tt::umd::test_utils;
+using ::testing::_;
 using ::testing::NiceMock;
+using ::testing::Return;
 
 namespace {
 
+// Arbitrary offset inside the window, not a hardware-defined location: the tests only check that
+// an access at it is routed and bounded correctly.
+constexpr uint64_t APB_OFFSET = 0x100;
+const tt_xy_pair ARC_CORE = {0, 10};
+
 class WormholeArcApbWindowTest : public ::testing::Test {
 protected:
+    uint64_t noc_address() const { return wormhole::ARC_APB_NOC_BASE_ADDRESS + APB_OFFSET; }
+
+    uint32_t bar_address() const { return wormhole::ARC_APB_BAR0_XBAR_OFFSET_START + APB_OFFSET; }
+
     WormholeArcWindow over_pcie() { return WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, nullptr); }
 
     WormholeArcWindow over_jtag() { return WormholeArcWindow::arc_apb(&protocol_, nullptr, &jtag_, nullptr); }
@@ -40,6 +51,152 @@ TEST_F(WormholeArcApbWindowTest, RequiresExactlyOneTransport) {
     EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, &jtag_, nullptr), std::exception);
     EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, &remote_), std::exception);
     EXPECT_THROW(WormholeArcWindow::arc_apb(nullptr, &pcie_, nullptr, nullptr), std::exception);
+}
+
+// A remote device is reached over the NOC, and the APB window holds registers, so the access has to
+// go through the protocol's register path and keep the caller's size.
+TEST_F(WormholeArcApbWindowTest, RemoteReadIsARegisterAccessKeepingSize) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), 16, NocId::NOC0));
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.read(values.data(), APB_OFFSET, sizeof(values), ARC_CORE, NocId::NOC0);
+}
+
+// A device opened over JTAG has no PcieInterface, so the access goes over the NOC, one word at a
+// time. WormholeTTDevice pinned this branch to NOC0; the window uses what the caller passed.
+TEST_F(WormholeArcApbWindowTest, JtagReadUsesTheCallersCoreAndNoc) {
+    auto window = over_jtag();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), sizeof(uint32_t), NocId::NOC1));
+
+    uint32_t value = 0;
+    window.read(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC1);
+}
+
+// A local PCIe device goes through the BAR, which never touches the NOC.
+TEST_F(WormholeArcApbWindowTest, PcieReadGoesThroughTheBar) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_read32(bar_address())).WillOnce(Return(0xDEADBEEF));
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _)).Times(0);
+
+    uint32_t value = 0;
+    window.read(&value, APB_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+    EXPECT_EQ(value, 0xDEADBEEF);
+}
+
+// The JTAG and BAR routes always move one word, so a size they cannot honor is rejected instead of
+// overrunning or short-changing the caller's buffer.
+TEST_F(WormholeArcApbWindowTest, NonWordSizeIsRejectedOnTheWordSizedRoutes) {
+    uint32_t value = 0;
+
+    auto pcie_window = over_pcie();
+    EXPECT_THROW(pcie_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
+
+    auto jtag_window = over_jtag();
+    EXPECT_THROW(jtag_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
+}
+
+// The window bound covers the whole transfer, not just its first byte: a word access starting at
+// the window size, or four bytes before its end plus one, runs past the end.
+TEST_F(WormholeArcApbWindowTest, AccessMustFitEntirelyInsideTheWindow) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    // ARC_APB_ADDRESS_RANGE is END - START with an inclusive END, so the window is one byte larger
+    // than it.
+    constexpr uint64_t WINDOW_SIZE = static_cast<uint64_t>(wormhole::ARC_APB_ADDRESS_RANGE) + 1;
+
+    // Starts inside the window but runs past its end.
+    EXPECT_THROW(
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    // Starts at the first byte past the window.
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    // Starts at zero but is larger than the whole window.
+    EXPECT_THROW(window.read(&value, 0, WINDOW_SIZE + 1, ARC_CORE, NocId::NOC0), std::exception);
+
+    // The last word that fits ends exactly on the window's last byte.
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _));
+    window.read(&value, WINDOW_SIZE - sizeof(value), sizeof(value), ARC_CORE, NocId::NOC0);
+}
+
+TEST_F(WormholeArcApbWindowTest, ZeroLengthAccessIsRejected) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    EXPECT_THROW(window.read(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), std::exception);
+}
+
+// Arbitrary offset inside the window, not a hardware-defined location.
+constexpr uint64_t CSM_OFFSET = 0x200;
+
+class WormholeArcCsmWindowTest : public ::testing::Test {
+protected:
+    uint64_t noc_address() const { return wormhole::ARC_CSM_NOC_BASE_ADDRESS + CSM_OFFSET; }
+
+    uint32_t bar_address() const { return wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + CSM_OFFSET; }
+
+    WormholeArcWindow over_pcie() { return WormholeArcWindow::arc_csm(&protocol_, &pcie_, nullptr, nullptr); }
+
+    WormholeArcWindow over_jtag() { return WormholeArcWindow::arc_csm(&protocol_, nullptr, &jtag_, nullptr); }
+
+    WormholeArcWindow over_remote() { return WormholeArcWindow::arc_csm(&protocol_, nullptr, nullptr, &remote_); }
+
+    NiceMock<MockDeviceProtocol> protocol_;
+    NiceMock<MockPcieInterface> pcie_;
+    NiceMock<MockJtagInterface> jtag_;
+    NiceMock<MockRemoteInterface> remote_;
+};
+
+// CSM holds memory rather than registers, so a remote access takes the data path where the APB
+// window takes the register one. This is the only routing difference between the two.
+TEST_F(WormholeArcCsmWindowTest, RemoteReadIsADataAccess) {
+    auto window = over_remote();
+
+    EXPECT_CALL(protocol_, read_data(_, ARC_CORE, noc_address(), 16, NocId::NOC0));
+    EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _)).Times(0);
+
+    std::array<uint32_t, 4> values{};
+    window.read(values.data(), CSM_OFFSET, sizeof(values), ARC_CORE, NocId::NOC0);
+}
+
+// The memory-vs-registers distinction is a remote-route one only: JTAG reaches every window over
+// the register path, as the TTDevice-era CSM accessor this replaced did.
+TEST_F(WormholeArcCsmWindowTest, JtagReadStaysOnTheRegisterPath) {
+    auto window = over_jtag();
+
+    EXPECT_CALL(protocol_, read_ctrl(_, ARC_CORE, noc_address(), sizeof(uint32_t), NocId::NOC1));
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _)).Times(0);
+
+    uint32_t value = 0;
+    window.read(&value, CSM_OFFSET, sizeof(value), ARC_CORE, NocId::NOC1);
+}
+
+TEST_F(WormholeArcCsmWindowTest, PcieReadGoesThroughTheCsmBarOffset) {
+    auto window = over_pcie();
+
+    EXPECT_CALL(pcie_, bar_read32(bar_address())).WillOnce(Return(0x12345678));
+
+    uint32_t value = 0;
+    window.read(&value, CSM_OFFSET, sizeof(value), ARC_CORE, NocId::NOC0);
+    EXPECT_EQ(value, 0x12345678);
+}
+
+// The two windows are separate address ranges, so each is bounded by its own size.
+TEST_F(WormholeArcCsmWindowTest, AccessIsBoundedByTheCsmWindow) {
+    auto window = over_remote();
+    uint32_t value = 0;
+
+    constexpr uint64_t WINDOW_SIZE = static_cast<uint64_t>(wormhole::ARC_CSM_ADDRESS_RANGE) + 1;
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+
+    EXPECT_CALL(protocol_, read_data(_, _, _, _, _));
+    window.read(&value, WINDOW_SIZE - sizeof(value), sizeof(value), ARC_CORE, NocId::NOC0);
 }
 
 }  // namespace


### PR DESCRIPTION
## Issue

#2872

## Description
The Wormhole startup migration, one diff with three parts of the same move:

- **`WormholeArcWindow::read()` is implemented here** by migrating the routing out of `WormholeTTDevice`'s accessors, and the read-route and whole-transfer-bound **tests arrive with it**.
- The **boot wait moves verbatim** into `WormholeDeviceFirmware::init_firmware()` on top of it, together with the private plumbing it consumes (device identity, fixed ARC coordinates, the window members and thin accessors). `DeviceFirmware` gains `init_firmware()` with a transitional throwing default until every backend moves, and `WormholeTTDevice::wait_arc_core_start` becomes a one-line shim.
- The **TTDevice CSM accessor family dies** — the moved wait was its last caller (interface virtuals, Wormhole implementations, Blackhole throw-stubs, simulation overrides; no users in tt-metal/tt-exalens). The APB copy survives with its remaining callers and retires as they move.

Deliberate difference, spelled out in the wait: JTAG reads follow the caller's `noc_id` (coordinate and routing) instead of being pinned to NOC0. Bit-identical under the default NOC0.

## Testing
`baremetal_tests` 249/249 (read-path window tests included), sim on/off.

## API Changes
Removed: `TTDevice::read_from_arc_csm`/`write_to_arc_csm`. Added: `DeviceFirmware::init_firmware`, `TTDevice::get_device_firmware()`.

Stacked on #3344.

