### PR TITLE
[Base API] Move the Blackhole firmware boot wait into BlackholeDeviceFirmware

### DIFF
--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -4,7 +4,15 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/tt_device/firmware/blackhole_arc_apb.hpp"
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -29,11 +37,52 @@ public:
         JtagInterface* jtag_interface,
         ArchitectureImplementation* architecture_impl);
 
+    void init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id = NocId::DEFAULT_NOC) override;
+
 private:
+    /**
+     * @brief Blocks until the management firmware reports it has booted.
+     *
+     * Kept as its own step because init_firmware() has a second job arriving: building the
+     * components that read what the firmware publishes, which lands next to this call rather than
+     * around it.
+     *
+     * @param timeout_ms How long to wait for the firmware to report ready.
+     * @param noc_id NOC to route the status reads over.
+     * @throws error::FirmwareStartupError if the firmware does not come up within the timeout.
+     */
+    void wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id);
+
+    IODeviceType get_io_device_type() const;
+
+    // Whether NOC address translation is active. Private for now: the constructor needs it to
+    // resolve the ARC coordinates, while TTDevice::get_noc_translation_enabled stays the public
+    // entry until that API moves here. Read over BAR/JTAG, so it does not need the firmware up.
+    bool get_noc_translation_enabled() const;
+
+    // The management firmware core's coordinate, resolved for noc_id. Private until the TTDevice
+    // API it replaces moves here.
+    tt_xy_pair get_firmware_noc_coord(NocId noc_id) const;
+
+    // Thin wrapper that resolves the ARC core for noc_id and hands the access to arc_apb_.
+    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id);
+
+    // All non-owning; they belong to the object that owns this one and must outlive it.
     DeviceProtocol* device_protocol_ = nullptr;
     PcieInterface* pcie_interface_ = nullptr;
     JtagInterface* jtag_interface_ = nullptr;
     ArchitectureImplementation* architecture_impl_ = nullptr;
+
+    // Identifies this device in error payloads; taken from the protocol so it identifies the
+    // device, not the silicon model. See DeviceProtocol::get_mmio_id().
+    int device_id_ = 0;
+
+    // ARC core coordinate per NOC, resolved once in the constructor: it depends only on the NOC
+    // translation state, which is fixed for the device's lifetime.
+    tt_xy_pair arc_core_noc0_;
+    tt_xy_pair arc_core_noc1_;
+
+    BlackholeArcApb arc_apb_;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
@@ -180,37 +181,9 @@ void BlackholeTTDevice::probe_arc() {
 }
 
 void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
-    uint32_t arc_boot_status = 0;
-    uint32_t arc_postcode = 0;
-    uint32_t arc_error_status0 = 0;
-
-    constexpr auto busy_poll_window = std::chrono::microseconds(1000);
-    constexpr auto poll_interval = std::chrono::microseconds(10);
-    const bool arc_core_started = utils::poll_until(
-        [this, &arc_boot_status, &arc_postcode]() {
-            read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof arc_boot_status);
-            read_from_arc_apb(&arc_postcode, registers_.arc_reset_scratch_offset, sizeof arc_postcode);
-            return (arc_boot_status & 0x7) == 0x5;
-        },
-        timeout_ms,
-        busy_poll_window,
-        poll_interval);
-
-    if (!arc_core_started) {
-        read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_4, sizeof arc_error_status0);
-        UMD_THROW(
-            error::FirmwareStartupError,
-            get_communication_device_type(),
-            get_communication_device_id(),
-            get_arch(),
-            get_selected_noc_id(),
-            get_arc_core(),
-            arc_boot_status,
-            arc_postcode,
-            timeout_ms,
-            /*message_id=*/std::nullopt,
-            arc_error_status0);
-    }
+    // Transitional shim: the wait moved into BlackholeDeviceFirmware; this override goes away with
+    // the API once every backend has moved.
+    get_device_firmware()->init_firmware(timeout_ms, get_selected_noc_id());
 }
 
 uint32_t BlackholeTTDevice::get_clock() {

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -4,12 +4,22 @@
 
 #include "umd/device/tt_device/firmware/blackhole_device_firmware.hpp"
 
+#include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils.hpp"
 
 namespace tt::umd {
+
+// How this class picks a route: a non-null JtagInterface means the device is reached over JTAG,
+// otherwise it is reached over PCIe. Inferring the route from which optional interface is present
+// is sound because a TTDevice is built for exactly one communication protocol - reaching the same
+// chip over both PCIe and JTAG today requires two TTDevice objects, so the two interfaces are never
+// both handed to the same firmware object. If UMD ever supports using both protocols against a
+// single device, this has to become an explicit protocol selection rather than a null check.
 
 BlackholeDeviceFirmware::BlackholeDeviceFirmware(
     DeviceProtocol* device_protocol,
@@ -19,17 +29,95 @@ BlackholeDeviceFirmware::BlackholeDeviceFirmware(
     device_protocol_(device_protocol),
     pcie_interface_(pcie_interface),
     jtag_interface_(jtag_interface),
-    architecture_impl_(architecture_impl) {
+    architecture_impl_(architecture_impl),
+    arc_apb_(device_protocol, pcie_interface, jtag_interface) {
     UMD_ASSERT(device_protocol_ != nullptr, error::RuntimeError, "BlackholeDeviceFirmware requires a DeviceProtocol.");
     UMD_ASSERT(
         architecture_impl_ != nullptr,
         error::RuntimeError,
         "BlackholeDeviceFirmware requires an ArchitectureImplementation.");
-    UMD_ASSERT(
-        (pcie_interface_ != nullptr) != (jtag_interface_ != nullptr),
-        error::RuntimeError,
-        "BlackholeDeviceFirmware requires exactly one of a PcieInterface or a JtagInterface, since which one is "
-        "present is how it picks the route for an access.");
+    // The exactly-one-transport invariant that get_io_device_type() and the ARC APB routing rely on
+    // is enforced by arc_apb_, which is constructed from the same two interfaces above.
+
+    // Read after the checks above, not in the member initialiser list: that runs first, so a null
+    // protocol faulted there before the assert could report it.
+    device_id_ = device_protocol_->get_mmio_id();
+
+    // Resolve both ARC coordinates once. The NOC translation state they depend on is fixed for the
+    // device's lifetime and is read over BAR/JTAG, so this does not need the firmware to be up.
+    const bool noc_translation_enabled = get_noc_translation_enabled();
+    arc_core_noc0_ = blackhole::get_arc_core(noc_translation_enabled, /*use_noc1=*/false);
+    arc_core_noc1_ = blackhole::get_arc_core(noc_translation_enabled, /*use_noc1=*/true);
+}
+
+IODeviceType BlackholeDeviceFirmware::get_io_device_type() const {
+    return jtag_interface_ != nullptr ? IODeviceType::JTAG : IODeviceType::PCIe;
+}
+
+void BlackholeDeviceFirmware::init_firmware(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    wait_firmware_ready(timeout_ms, noc_id);
+}
+
+void BlackholeDeviceFirmware::wait_firmware_ready(std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // Deliberate difference from the deleted TTDevice wait: its JTAG reads were pinned to the NOC0
+    // ARC coordinate over the default NOC, and its non-AXI PCIe branch paired the selected NOC's
+    // coordinate with the default NOC's routing. Every read here uses noc_id consistently,
+    // coordinate and routing both; with the default NOC0 the two are bit-identical.
+    // One throwaway read before the poll, so a dead ARC APB path faults on an access that is
+    // clearly a probe rather than partway into the boot-status loop. This was
+    // TTDevice::probe_arc(), moved here with its only caller.
+    uint32_t dummy;
+    read_from_arc_apb(&dummy, blackhole::ARC_RESET_SCRATCH_OFFSET, sizeof(dummy), noc_id);
+
+    uint32_t arc_boot_status = 0;
+    uint32_t arc_postcode = 0;
+    uint32_t arc_error_status0 = 0;
+
+    constexpr auto busy_poll_window = std::chrono::microseconds(1000);
+    constexpr auto poll_interval = std::chrono::microseconds(10);
+    const bool arc_core_started = utils::poll_until(
+        [this, &arc_boot_status, &arc_postcode, &noc_id]() {
+            read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof arc_boot_status, noc_id);
+            read_from_arc_apb(&arc_postcode, blackhole::ARC_RESET_SCRATCH_OFFSET, sizeof arc_postcode, noc_id);
+            return (arc_boot_status & 0x7) == 0x5;
+        },
+        timeout_ms,
+        busy_poll_window,
+        poll_interval);
+
+    if (!arc_core_started) {
+        read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_4, sizeof arc_error_status0, noc_id);
+        UMD_THROW(
+            error::FirmwareStartupError,
+            get_io_device_type(),
+            device_id_,
+            tt::ARCH::BLACKHOLE,
+            noc_id,
+            get_firmware_noc_coord(noc_id),
+            arc_boot_status,
+            arc_postcode,
+            timeout_ms,
+            /*message_id=*/std::nullopt,
+            arc_error_status0);
+    }
+}
+
+bool BlackholeDeviceFirmware::get_noc_translation_enabled() const {
+    uint32_t niu_cfg;
+    if (get_io_device_type() == IODeviceType::JTAG) {
+        niu_cfg = jtag_interface_->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);
+    } else {
+        niu_cfg = pcie_interface_->bar_read32(blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + 0x100);
+    }
+    return ((niu_cfg >> 14) & 0x1) != 0;
+}
+
+tt_xy_pair BlackholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
+}
+
+void BlackholeDeviceFirmware::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size, NocId noc_id) {
+    arc_apb_.read(mem_ptr, arc_addr_offset, size, get_firmware_noc_coord(noc_id), noc_id);
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
## Issue

#2872

## Description
The Blackhole startup migration: the private plumbing (device identity, ARC coordinates from a private NOC-translation read, the `BlackholeArcApb` member and its accessor) arrives **together with its consumer** — the probe read and boot-status poll move verbatim into `BlackholeDeviceFirmware::init_firmware()`, and `BlackholeTTDevice::wait_arc_core_start` becomes a one-line shim.

Deliberate difference, spelled out in the wait: the old non-AXI PCIe branch paired the selected NOC's coordinate with default-NOC routing (a mismatched pair); the moved wait uses the caller's `noc_id` consistently. Bit-identical under the default NOC0.

## Testing
`baremetal_tests` 249/249, sim on/off.

## API Changes
None.

Stacked on #3346.

