### PR TITLE
Add optional cluster_id to the cluster descriptor

### DIFF
--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -84,6 +84,27 @@ public:
     static std::unique_ptr<ClusterDescriptor> create_constrained_cluster_descriptor(
         const ClusterDescriptor *full_cluster_desc, const std::unordered_set<ChipId> &target_chip_ids = {});
 
+    /* Cluster id of the accelerator group this descriptor describes. */
+
+    /**
+     * Returns the cluster id: a unique string identifying the group of Tenstorrent accelerators
+     * connected to a common host / controller / root complex. One cluster descriptor describes one
+     * such group.
+     *
+     * The value is currently that group's bare metal hostname, because that is what the factory
+     * system descriptor and the fabric topology solver join on. Semantically this identifies the
+     * accelerator group and not a machine, so the value scheme can change without the field
+     * changing meaning.
+     *
+     * Set when parsing a YAML that carries the key, and by discovery from
+     * TopologyDiscoveryOptions::cluster_id or the OS hostname. It does not change over a
+     * descriptor's lifetime, so there is no setter.
+     *
+     * Empty when the YAML omitted the key and discovery did not stamp one. That is the case for
+     * every descriptor written before this field existed, and is not an error.
+     */
+    const std::optional<std::string> &get_cluster_id() const;
+
     /* Getters for various chip related information. */
 
     /**
@@ -337,6 +358,10 @@ private:
 
     std::vector<ChipId> unhealthy_devices;
     std::map<ChipId, std::vector<DeviceHealthError>> health_errors;
+
+    // Unset on descriptors written before this field existed, and on mock descriptors that were
+    // never given one. Consumers fall back to whatever they used before in that case.
+    std::optional<std::string> cluster_id;
 
     IODeviceType io_device_type = IODeviceType::PCIe;
 

--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
 namespace tt::umd {
 /**
  * @brief Configuration options for controlling the behavior of the topology discovery process.
@@ -95,5 +98,17 @@ struct TopologyDiscoveryOptions {
      * Defaults to false.
      */
     bool use_safe_api = false;
+
+    /**
+     * @brief Cluster id to stamp on the discovered cluster descriptor: a unique string identifying
+     * the group of Tenstorrent accelerators attached to a common host / controller / root complex.
+     * Defaults to the OS hostname, which is the right answer on bare metal. Callers running in a
+     * container or a VM, where gethostname() names the container or the guest rather than the
+     * accelerator group, have to supply one.
+     *
+     * Discovery throws when the supplied id is empty, longer than 128 characters, or contains
+     * anything outside [A-Za-z0-9._-].
+     */
+    std::optional<std::string> cluster_id;
 };
 }  // namespace tt::umd

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -135,6 +135,14 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_from_yaml_content(
     std::unique_ptr<ClusterDescriptor> desc = std::make_unique<ClusterDescriptor>();
 
     YAML::Node yaml = YAML::Load(cluster_descriptor_file_content);
+
+    // Optional, and absent from every descriptor written before the field existed.
+    if (yaml["cluster_id"].IsDefined()) {
+        std::string cluster_id = yaml["cluster_id"].as<std::string>();
+        utils::validate_cluster_id(cluster_id, "the cluster descriptor YAML");
+        desc->cluster_id = std::move(cluster_id);
+    }
+
     desc->load_chips_from_connectivity_descriptor(yaml);
     desc->load_harvesting_information(yaml);
     desc->load_ethernet_connections_from_connectivity_descriptor(yaml);
@@ -412,6 +420,8 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_constrained_cluster
     desc->harvesting_masks_map = filter_chip_collection(full_cluster_desc->harvesting_masks_map, visible_chips);
 
     desc->asic_locations = filter_chip_collection(full_cluster_desc->asic_locations, visible_chips);
+    // Fewer chips, same accelerator group.
+    desc->cluster_id = full_cluster_desc->cluster_id;
     desc->io_device_type = full_cluster_desc->io_device_type;
     desc->eth_fw_version = full_cluster_desc->eth_fw_version;
     desc->fw_bundle_version = full_cluster_desc->fw_bundle_version;
@@ -498,6 +508,7 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_constrained_cluster
         }
 
         auto remapped = std::make_unique<ClusterDescriptor>();
+        remapped->cluster_id = desc->cluster_id;
         remapped->io_device_type = desc->io_device_type;
         remapped->eth_fw_version = desc->eth_fw_version;
         remapped->fw_bundle_version = desc->fw_bundle_version;
@@ -1013,6 +1024,12 @@ std::string ClusterDescriptor::serialize() const {
 
     out << YAML::BeginMap;
 
+    // First in the map because it names the whole descriptor. Omitted when unset, so descriptors
+    // that never had a cluster id serialize byte-identically to before.
+    if (cluster_id.has_value()) {
+        out << YAML::Key << "cluster_id" << YAML::Value << cluster_id.value();
+    }
+
     out << YAML::Key << "arch" << YAML::Value << YAML::BeginMap;
     std::map<ChipId, tt::ARCH> chip_arch_map = std::map<ChipId, tt::ARCH>(chip_arch.begin(), chip_arch.end());
     for (const auto &[chip_id, arch] : chip_arch_map) {
@@ -1371,6 +1388,8 @@ uint8_t ClusterDescriptor::get_asic_location(ChipId chip_id) const {
 const std::unordered_map<ChipId, std::string> &ClusterDescriptor::get_chip_pci_bdfs() const { return chip_pci_bdfs; }
 
 IODeviceType ClusterDescriptor::get_io_device_type() const { return io_device_type; }
+
+const std::optional<std::string> &ClusterDescriptor::get_cluster_id() const { return cluster_id; }
 
 uint16_t ClusterDescriptor::get_bus_id(ChipId chip_id) const {
     auto it = chip_to_bus_id.find(chip_id);

--- a/device/common/utils.hpp
+++ b/device/common/utils.hpp
@@ -7,6 +7,7 @@
 #include <fmt/ranges.h>
 #include <unistd.h>
 
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -15,6 +16,7 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <type_traits>
@@ -134,6 +136,79 @@ inline std::unordered_set<int> get_visible_devices(const std::unordered_set<int>
     return target_devices.empty() && env_var_value.has_value()
                ? get_unordered_set_from_string(env_var_value.value()).value_or(std::unordered_set<int>{})
                : target_devices;
+}
+
+// A cluster id has to fit in the fixed 128-byte buffer that tt-metal packs it into, which is not
+// NUL-terminated -- hence 128 and not 127.
+inline constexpr size_t CLUSTER_ID_MAX_LENGTH = 128;
+
+// Returns why cluster_id is not a legal cluster id, or nullopt when it is legal. Legal ids are 1 to
+// CLUSTER_ID_MAX_LENGTH characters from [A-Za-z0-9._-]. That charset is deliberately
+// hostname-shaped: cluster ids are currently hostname-valued and have to join against hostnames in
+// the factory system descriptor.
+inline std::optional<std::string> get_cluster_id_error(const std::string& cluster_id) {
+    if (cluster_id.empty()) {
+        return "it is empty";
+    }
+    if (cluster_id.size() > CLUSTER_ID_MAX_LENGTH) {
+        return fmt::format("it is {} characters long, the limit is {}", cluster_id.size(), CLUSTER_ID_MAX_LENGTH);
+    }
+    for (const char character : cluster_id) {
+        const unsigned char c = static_cast<unsigned char>(character);
+        const bool is_alphanumeric = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+        if (!is_alphanumeric && character != '.' && character != '-' && character != '_') {
+            return fmt::format("it contains '{}', and only alphanumerics, '.', '-' and '_' are allowed", character);
+        }
+    }
+    return std::nullopt;
+}
+
+inline void validate_cluster_id(const std::string& cluster_id, const std::string_view source) {
+    const std::optional<std::string> cluster_id_error = get_cluster_id_error(cluster_id);
+    if (cluster_id_error.has_value()) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Invalid cluster id \"{}\" from {}: {}.", cluster_id, source, cluster_id_error.value()));
+    }
+}
+
+// Cluster id to stamp on a cluster descriptor built by discovery: the caller-supplied one when there
+// is one, otherwise the OS hostname. Returns nullopt when there is no supplied id and the hostname
+// cannot be used as one, which leaves the field unset and lets consumers fall back to what they did
+// before.
+//
+// A supplied id that is not legal throws: the caller passed it on purpose, and quietly substituting
+// the hostname would produce a wrong-but-plausible topology, which is what supplying an id is meant
+// to prevent. An unusable hostname only warns, because that is not something the caller asked for.
+inline std::optional<std::string> resolve_cluster_id(const std::optional<std::string>& supplied_cluster_id) {
+    static constexpr std::string_view SOURCE = "TopologyDiscoveryOptions::cluster_id";
+
+    if (supplied_cluster_id.has_value()) {
+        validate_cluster_id(supplied_cluster_id.value(), SOURCE);
+        log_debug(LogUMD, "Using cluster id \"{}\" from {}.", supplied_cluster_id.value(), SOURCE);
+        return supplied_cluster_id;
+    }
+
+    std::array<char, 256> hostname = {};
+    if (gethostname(hostname.data(), hostname.size() - 1) != 0) {
+        log_warning(LogUMD, "gethostname() failed, leaving the cluster id unset. Pass one in {}.", SOURCE);
+        return std::nullopt;
+    }
+
+    // Stored raw, with no FQDN stripping -- consumers canonicalize.
+    std::string cluster_id(hostname.data());
+    const std::optional<std::string> cluster_id_error = get_cluster_id_error(cluster_id);
+    if (cluster_id_error.has_value()) {
+        log_warning(
+            LogUMD,
+            "Leaving the cluster id unset because the OS hostname \"{}\" cannot be used as one: {}. Pass one in {}.",
+            cluster_id,
+            cluster_id_error.value(),
+            SOURCE);
+        return std::nullopt;
+    }
+    log_debug(LogUMD, "Using cluster id \"{}\" from the OS hostname.", cluster_id);
+    return cluster_id;
 }
 
 template <typename... Args>

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -22,6 +22,7 @@
 
 #include "api/umd/device/topology/topology_discovery_blackhole.hpp"
 #include "api/umd/device/topology/topology_discovery_wormhole.hpp"
+#include "common/utils.hpp"
 #include "tracy.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
@@ -127,7 +128,11 @@ std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<T
     std::unique_ptr<TopologyDiscovery> td =
         TopologyDiscovery::create_topology_discovery(options, io_device_type, soc_descriptor_path);
     if (td == nullptr) {
-        return std::make_pair(std::make_unique<ClusterDescriptor>(), std::move(devices));
+        // No PCI/JTAG devices: still stamp cluster_id (and throw on an illegal supplied id).
+        // Callers and the Python bindings go through discover() even on an empty machine.
+        auto cluster_desc = std::make_unique<ClusterDescriptor>();
+        cluster_desc->cluster_id = utils::resolve_cluster_id(options.cluster_id);
+        return std::make_pair(std::move(cluster_desc), std::move(devices));
     }
     std::unique_ptr<ClusterDescriptor> cluster_desc = td->create_ethernet_map();
     // Resort devices by ChipID instead of internal unique identifiers.
@@ -514,6 +519,8 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
             cluster_desc->idle_eth_channels[current_chip_id].erase(active_channel);
         }
     }
+    // The caller-supplied cluster id, else the OS hostname. Stays unset if neither is usable.
+    cluster_desc->cluster_id = utils::resolve_cluster_id(options.cluster_id);
     cluster_desc->io_device_type = io_device_type;
     cluster_desc->eth_fw_version = expected_eth_fw_version;
     cluster_desc->fw_bundle_version = first_fw_bundle_version;

--- a/docs/CLUSTER_ID.md
+++ b/docs/CLUSTER_ID.md
@@ -1,0 +1,72 @@
+# Cluster id
+
+The **cluster id** is a unique string identifying **a group of Tenstorrent accelerators connected to a common host / controller / root complex**. One cluster descriptor describes exactly one such group, so the id is a descriptor-level field and not a per-chip one:
+
+```yaml
+cluster_id: bh-glx-110-c01u02
+arch:
+  0: blackhole
+  ...
+```
+
+It is available as `ClusterDescriptor::get_cluster_id()` (`Optional[str]` from Python), and is empty on any descriptor that predates the field or was never given one.
+
+The value is currently that group's **bare metal hostname**, because the factory system descriptor (FSD) and the fabric topology solver join on hostnames. But the field identifies the accelerator group, not a machine — it is named `cluster_id` rather than `hostname` so the value scheme can change later without the field changing meaning.
+
+Note that this is unrelated to `EthCoord::cluster_id`, which is a per-chip integer grouping ethernet-connected chips within one descriptor.
+
+## Where the value comes from
+
+| Descriptor | Cluster id |
+|---|---|
+| Parsed from YAML | the `cluster_id` key, or empty when the key is absent |
+| Built by topology discovery | `TopologyDiscoveryOptions::cluster_id` when the caller supplied one, otherwise the OS hostname |
+| `create_mock_cluster` | empty |
+
+Discovery is the only place that calls `gethostname()`, and it never does so for a descriptor loaded from YAML: that descriptor may describe a different machine, and substituting the local hostname would relabel it.
+
+## Supplying a cluster id
+
+`gethostname()` is only the right answer when the process runs on bare metal:
+
+| Where the process runs | `gethostname()` returns | Usable as a cluster id? |
+|---|---|---|
+| Bare metal | the machine's hostname, e.g. `bh-glx-110-c01u02` | yes |
+| Container | the container id, e.g. `7f3a91c2b4de` | **no** — changes every run, unrelated to the hardware |
+| VM | whatever the guest was named, e.g. `pod-fabric-worker-3` | **no** — names the guest, not the accelerator group |
+
+In the last two cases the hostname is stable enough to look convincing while pointing at nothing physical, which is worse than having no value at all: fabric would build a topology keyed on it and silently disagree with the FSD. Callers that run there know where the value has to come from — a scheduler, an orchestrator label, an environment variable of their own — so they pass it in:
+
+```cpp
+TopologyDiscoveryOptions options;
+options.cluster_id = "bh-glx-110-c01u02";
+auto cluster_desc = TopologyDiscovery::discover(options).first;
+```
+
+```python
+options = tt_umd.TopologyDiscoveryOptions()
+options.cluster_id = "bh-glx-110-c01u02"
+cluster_desc = tt_umd.TopologyDiscovery.create_cluster_descriptor(options)
+```
+
+UMD deliberately does not read an environment variable for this. Container and VM plumbing belongs to whoever launches the process, and one string on the options struct is enough for them to pass it down.
+
+## Legal values
+
+1 to 128 characters from `[A-Za-z0-9._-]`. The charset is deliberately hostname-shaped while cluster ids are hostname-valued, and the length limit is the fixed 128-byte buffer that consumers pack the id into (no NUL terminator, hence 128 and not 127).
+
+| Situation | Behavior |
+|---|---|
+| No cluster id supplied to discovery | OS hostname is used, raw, with no FQDN stripping — consumers canonicalize |
+| A legal cluster id supplied to discovery | that value is used |
+| An illegal cluster id supplied to discovery | **throws.** The caller passed it on purpose; silently falling back to a container hostname would produce a wrong-but-plausible topology, which is the failure that supplying an id is meant to prevent |
+| OS hostname unusable as a cluster id (over 128 characters, exotic characters), or `gethostname()` fails | warning logged, cluster id left unset — discovery still succeeds and consumers fall back to what they did before |
+| An illegal `cluster_id` in a YAML being parsed | throws |
+
+A cluster id never changes over a descriptor's lifetime, so there is no setter. Both entry points validate, which means every cluster id on a descriptor is a legal one.
+
+## Serialization
+
+`serialize()` writes `cluster_id` first in the map, and omits the key entirely when the id is unset, so descriptors that never had one serialize byte-identically to before. A descriptor recaptured on hardware (`serialize_to_file`) carries the live cluster id for free.
+
+Old UMD reading a YAML that has `cluster_id` ignores the unknown key, and new UMD reading a YAML without it leaves the field empty. Neither is an error, and the key is not in the schema's `required` list.

--- a/docs/yaml_schemas/cluster_descriptor.yaml
+++ b/docs/yaml_schemas/cluster_descriptor.yaml
@@ -18,6 +18,19 @@ required:
   - boards
 
 properties:
+  # Identity of the accelerator group this descriptor describes. Optional, and absent from every
+  # descriptor written before the field existed -- do not add it to `required`.
+  cluster_id:
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: >
+      Unique id of the group of Tenstorrent accelerators attached to a common host / controller /
+      root complex. One descriptor is one such group. Currently the bare metal hostname of that
+      machine, which is what the factory system descriptor and the fabric topology solver join on.
+      Not a filename and not a unique chip id.
+    pattern: "^[A-Za-z0-9._-]+$"
+
   # Architecture specification for each chip.
   arch:
     type: object

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -61,6 +61,13 @@ void bind_topology_discovery(nb::module_& m) {
         .def("get_chip_unique_ids", &ClusterDescriptor::get_chip_unique_ids, release_gil())
         .def("get_io_device_type", &ClusterDescriptor::get_io_device_type, release_gil())
         .def(
+            "get_cluster_id",
+            &ClusterDescriptor::get_cluster_id,
+            release_gil(),
+            "Unique id of the group of accelerators attached to a common host / controller / root complex. "
+            "Currently that machine's hostname. "
+            "None when the YAML omitted the key and discovery did not stamp one.")
+        .def(
             "serialize_to_file",
             [](const ClusterDescriptor& self, const std::string& dest_file) -> std::string {
                 std::filesystem::path file_path = self.serialize_to_file(dest_file);
@@ -143,7 +150,13 @@ void bind_topology_discovery(nb::module_& m) {
         .def_rw("perform_6u_eth_retrain", &TopologyDiscoveryOptions::perform_6u_eth_retrain)
         // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
         .def_rw("low_power", &TopologyDiscoveryOptions::low_power)
-        .def_rw("use_safe_api", &TopologyDiscoveryOptions::use_safe_api);
+        .def_rw("use_safe_api", &TopologyDiscoveryOptions::use_safe_api)
+        .def_rw(
+            "cluster_id",
+            &TopologyDiscoveryOptions::cluster_id,
+            "Cluster id to stamp on the discovered cluster descriptor. Defaults to the OS hostname, which is "
+            "only correct on bare metal; supply one when running in a container or a VM. Discovery raises if it "
+            "is empty, longer than 128 characters, or contains anything outside [A-Za-z0-9._-].");
 
     nb::class_<TopologyDiscovery>(m, "TopologyDiscovery")
         .def_static(

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(BAREMETAL_TESTS_SRCS
     test_architecture_tlbs.cpp
     test_cluster_descriptor_offline.cpp
+    test_cluster_descriptor_cluster_id.cpp
     test_core_coord_translation_wh.cpp
     test_core_coord_translation_bh.cpp
     test_core_coord_translation_quasar.cpp

--- a/tests/baremetal/test_cluster_descriptor_cluster_id.cpp
+++ b/tests/baremetal/test_cluster_descriptor_cluster_id.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <array>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+
+#include "common/utils.hpp"
+#include "tests/test_utils/fetch_local_files.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/utils/error.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+namespace {
+
+const std::string cluster_id_example = "bh-glx-110-c01u02";
+
+std::string read_cluster_desc(const std::string& cluster_desc_name) {
+    std::ifstream fdesc(test_utils::GetClusterDescAbsPath(cluster_desc_name));
+    EXPECT_FALSE(fdesc.fail());
+    std::stringstream buffer;
+    buffer << fdesc.rdbuf();
+    return buffer.str();
+}
+
+// cluster_id is a top level key, so prepending it is enough. Single quoted so that values which are
+// not legal cluster ids still reach the parser as strings.
+std::string with_cluster_id(const std::string& cluster_desc_content, const std::string& cluster_id) {
+    return "cluster_id: '" + cluster_id + "'\n" + cluster_desc_content;
+}
+
+// What resolve_cluster_id() is expected to return with no cluster id supplied: this machine's
+// hostname, or nothing when that hostname cannot be expressed as a cluster id (long FQDN, exotic
+// characters).
+std::optional<std::string> local_os_hostname_as_cluster_id() {
+    std::array<char, 256> hostname = {};
+    if (gethostname(hostname.data(), hostname.size() - 1) != 0) {
+        return std::nullopt;
+    }
+    std::string os_hostname(hostname.data());
+    if (utils::get_cluster_id_error(os_hostname).has_value()) {
+        return std::nullopt;
+    }
+    return os_hostname;
+}
+
+}  // namespace
+
+TEST(ClusterDescriptorClusterIdTest, ClusterIdIsLoadedFromYaml) {
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml_content(
+        with_cluster_id(read_cluster_desc("blackhole_P150.yaml"), cluster_id_example));
+
+    ASSERT_TRUE(cluster_desc->get_cluster_id().has_value());
+    EXPECT_EQ(cluster_desc->get_cluster_id().value(), cluster_id_example);
+}
+
+TEST(ClusterDescriptorClusterIdTest, ClusterIdIsUnsetWhenYamlOmitsIt) {
+    std::unique_ptr<ClusterDescriptor> cluster_desc =
+        ClusterDescriptor::create_from_yaml_content(read_cluster_desc("blackhole_P150.yaml"));
+
+    EXPECT_FALSE(cluster_desc->get_cluster_id().has_value());
+}
+
+// Back-compat: no descriptor may be rejected because it predates this field. Deliberately does not
+// assert the id is unset, so filling cluster_id into an example later is not a test failure.
+TEST(ClusterDescriptorClusterIdTest, AllOfflineDescriptorsStillParse) {
+    for (const std::string& cluster_desc_yaml : test_utils::GetAllClusterDescs()) {
+        std::ifstream fdesc(cluster_desc_yaml);
+        ASSERT_FALSE(fdesc.fail()) << cluster_desc_yaml;
+        std::stringstream buffer;
+        buffer << fdesc.rdbuf();
+
+        EXPECT_NO_THROW(ClusterDescriptor::create_from_yaml_content(buffer.str())) << cluster_desc_yaml;
+    }
+}
+
+TEST(ClusterDescriptorClusterIdTest, YamlAcceptsLegalClusterIds) {
+    const std::string cluster_desc_content = read_cluster_desc("blackhole_P150.yaml");
+
+    for (const std::string& cluster_id :
+         {cluster_id_example,
+          std::string("sjc1-tt-qb-01"),
+          std::string("metal-wh-09"),
+          std::string("bh-glx-110-c01u02.tenstorrent.com"),
+          std::string("host_0"),
+          std::string("a"),
+          std::string(utils::CLUSTER_ID_MAX_LENGTH, 'a')}) {
+        std::unique_ptr<ClusterDescriptor> cluster_desc;
+        ASSERT_NO_THROW(
+            cluster_desc =
+                ClusterDescriptor::create_from_yaml_content(with_cluster_id(cluster_desc_content, cluster_id)))
+            << cluster_id;
+        EXPECT_EQ(cluster_desc->get_cluster_id().value(), cluster_id);
+    }
+}
+
+// Parsing validates too, so every cluster id that reaches a descriptor is a legal one.
+TEST(ClusterDescriptorClusterIdTest, YamlRejectsIllegalClusterIds) {
+    const std::string cluster_desc_content = read_cluster_desc("blackhole_P150.yaml");
+
+    // Empty, whitespace, path separators, and one over the limit.
+    for (const std::string& cluster_id :
+         {std::string(""),
+          std::string("   "),
+          std::string("has space"),
+          std::string("foo/bar"),
+          std::string("foo\\bar"),
+          std::string(utils::CLUSTER_ID_MAX_LENGTH + 1, 'a')}) {
+        EXPECT_THROW(
+            ClusterDescriptor::create_from_yaml_content(with_cluster_id(cluster_desc_content, cluster_id)),
+            error::UmdException<error::RuntimeError>)
+            << "\"" << cluster_id << "\"";
+    }
+}
+
+TEST(ClusterDescriptorClusterIdTest, SerializeOmitsClusterIdWhenUnset) {
+    std::unique_ptr<ClusterDescriptor> cluster_desc =
+        ClusterDescriptor::create_from_yaml_content(read_cluster_desc("blackhole_P150.yaml"));
+
+    EXPECT_EQ(cluster_desc->serialize().find("cluster_id"), std::string::npos);
+}
+
+TEST(ClusterDescriptorClusterIdTest, SerializeRoundTripsClusterId) {
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml_content(
+        with_cluster_id(read_cluster_desc("blackhole_P150.yaml"), cluster_id_example));
+
+    const std::string serialized = cluster_desc->serialize();
+    EXPECT_NE(serialized.find("cluster_id"), std::string::npos);
+
+    std::unique_ptr<ClusterDescriptor> reparsed = ClusterDescriptor::create_from_yaml_content(serialized);
+    ASSERT_TRUE(reparsed->get_cluster_id().has_value());
+    EXPECT_EQ(reparsed->get_cluster_id().value(), cluster_id_example);
+}
+
+TEST(ClusterDescriptorClusterIdTest, ConstrainedDescriptorKeepsClusterId) {
+    // Galaxy has many chips on one board, so constraining to a subset is not expanded back to the
+    // full board and takes the chip id remapping path.
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml_content(
+        with_cluster_id(read_cluster_desc("blackhole_galaxy.yaml"), cluster_id_example));
+    ASSERT_GT(cluster_desc->get_number_of_chips(), 2);
+
+    std::unique_ptr<ClusterDescriptor> constrained =
+        ClusterDescriptor::create_constrained_cluster_descriptor(cluster_desc.get(), {0, 1});
+
+    ASSERT_LT(constrained->get_number_of_chips(), cluster_desc->get_number_of_chips());
+    ASSERT_TRUE(constrained->get_cluster_id().has_value());
+    EXPECT_EQ(constrained->get_cluster_id().value(), cluster_id_example);
+}
+
+TEST(ClusterDescriptorClusterIdTest, ConstrainedDescriptorKeepsClusterIdUnsetWhenSourceHasNone) {
+    std::unique_ptr<ClusterDescriptor> cluster_desc =
+        ClusterDescriptor::create_from_yaml_content(read_cluster_desc("blackhole_galaxy.yaml"));
+
+    std::unique_ptr<ClusterDescriptor> constrained =
+        ClusterDescriptor::create_constrained_cluster_descriptor(cluster_desc.get(), {0, 1});
+
+    EXPECT_FALSE(constrained->get_cluster_id().has_value());
+}
+
+TEST(ClusterDescriptorClusterIdTest, MockClusterHasNoClusterId) {
+    std::unique_ptr<ClusterDescriptor> mock_cluster =
+        ClusterDescriptor::create_mock_cluster({0}, tt::ARCH::BLACKHOLE, true);
+
+    EXPECT_FALSE(mock_cluster->get_cluster_id().has_value());
+}
+
+// What discovery stamps on the descriptor. Exercised through the helper rather than through
+// TopologyDiscovery so that it runs without a card.
+TEST(ResolveClusterIdTest, SuppliedClusterIdWins) {
+    EXPECT_EQ(utils::resolve_cluster_id("tt-vm-host-7"), "tt-vm-host-7");
+}
+
+// Not a silent fallback to the OS hostname: that would produce a wrong-but-plausible topology,
+// which is what supplying a cluster id exists to prevent.
+TEST(ResolveClusterIdTest, IllegalSuppliedClusterIdThrows) {
+    for (const std::string& cluster_id :
+         {std::string(""),
+          std::string("   "),
+          std::string("has space"),
+          std::string("has\ttab"),
+          std::string("foo/bar"),
+          std::string(utils::CLUSTER_ID_MAX_LENGTH + 1, 'a')}) {
+        EXPECT_THROW(utils::resolve_cluster_id(cluster_id), error::UmdException<error::RuntimeError>)
+            << "\"" << cluster_id << "\"";
+    }
+}
+
+// With nothing supplied the OS hostname is used, and a hostname that cannot be expressed as a
+// cluster id only warns and leaves the field unset -- it never throws, so discovery keeps working.
+TEST(ResolveClusterIdTest, DefaultsToHostname) {
+    EXPECT_EQ(utils::resolve_cluster_id(std::nullopt), local_os_hostname_as_cluster_id());
+}


### PR DESCRIPTION
Fabric needs one string that identifies the group of accelerators a
descriptor describes, so that FSD-built and live/mock topologies key their
chips the same way. A cluster descriptor had no such field, so tt-metal fell
back to the mock YAML's filename, which is not a hostname.

Adds an optional top-level `cluster_id` to the cluster descriptor: a unique
string identifying the group of Tenstorrent accelerators connected to a
common host / controller / root complex. Its value is currently that group's
bare metal hostname, because that is what the factory system descriptor and
the fabric topology solver join on, but the field identifies the accelerator
group rather than a machine -- hence `cluster_id` and not `hostname`, so the
value scheme can change later without another schema migration.

Discovery stamps it from `TopologyDiscoveryOptions::cluster_id` when the caller
supplies one, else from gethostname(). The option is what makes the field
usable in containers and VMs, where gethostname() returns the container id or
guest name -- stable enough to look convincing while pointing at nothing
physical. UMD deliberately does not read an environment variable for this:
container and VM plumbing belongs to whoever launches the process, and one
field on the options struct is enough for them to pass the value down.
`ClusterOptions` already embeds `TopologyDiscoveryOptions`, so Cluster callers
get it too.

A supplied id that is not legal throws rather than falling back to
gethostname(): the caller passed it on purpose, and quietly substituting a
container hostname would produce a wrong-but-plausible topology, which is the
failure the option exists to prevent. An OS hostname that cannot be used as a
cluster id (over 128 characters, exotic characters) only warns and leaves the
field unset, since that is not something the caller asked for and throwing
there would break discovery on hosts that work today.

Legal ids are 1 to 128 characters from [A-Za-z0-9._-]: a hostname-shaped
charset while cluster ids are hostname-valued, and a length limit that is the
fixed 128-byte buffer consumers pack the id into. Both paths that can set the
field -- YAML parsing and discovery -- validate, so every cluster id on a
descriptor is a legal one. The value is not expected to change over a
descriptor's lifetime, so there is no setter.

Note that `cluster_id` here is unrelated to the existing `EthCoord::cluster_id`,
which is a per-chip integer that groups ethernet-connected chips within one
descriptor.

The field is optional forever: old YAMLs load with it empty, old UMD ignores
the key, serialize() omits it when unset so existing descriptors serialize
unchanged, and it is not in the schema's `required` list. It is copied by
create_constrained_cluster_descriptor and apply_chip_id_remapping (fewer
chips, same accelerator group) and left unset by create_mock_cluster.

Documented in docs/CLUSTER_ID.md.

Offline gtests in tests/baremetal/test_cluster_descriptor_cluster_id.cpp:
parse with and without the key, every existing offline descriptor still
parses, legal and illegal values through YAML, serialize omit/round-trip,
constrained-descriptor copy, a supplied id winning over the hostname, an
illegal supplied id throwing, the hostname default, and a mock cluster having
no cluster id.

Built with the default preset (clang-20, clang-tidy on, -Werror). All 13
gtests pass, and the rest of baremetal_tests is unaffected.

Adds `ClusterDescriptor::get_cluster_id()` and
`TopologyDiscoveryOptions::cluster_id` (both bound in nanobind), and an
optional `cluster_id` key in the cluster descriptor YAML schema.