### PR TITLE
Portability cleanups: temp-dir helper, path conversions, env shims for tests

### DIFF
--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -7,6 +7,13 @@
 #include <optional>
 #include <string>
 
+// <windows.h> (winbase.h) defines IGNORE as an object-like macro, which would mangle the
+// Action::IGNORE enumerator below in any TU that included it first. The macro is a Win16-era
+// relic with no modern users; drop it.
+#ifdef IGNORE
+#undef IGNORE
+#endif
+
 namespace tt::umd {
 /**
  * @brief Configuration options for controlling the behavior of the topology discovery process.

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1180,12 +1180,7 @@ std::filesystem::path ClusterDescriptor::serialize_to_file(const std::filesystem
 }
 
 std::filesystem::path ClusterDescriptor::get_default_cluster_descriptor_file_path() const {
-    std::filesystem::path temp_path = std::filesystem::temp_directory_path();
-    std::string cluster_path_dir_template = temp_path / "umd_XXXXXX";
-    std::filesystem::path cluster_path_dir = mkdtemp(cluster_path_dir_template.data());
-    std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
-
-    return cluster_path;
+    return utils::create_unique_temp_dir() / "cluster_descriptor.yaml";
 }
 
 std::set<uint32_t> ClusterDescriptor::get_active_eth_channels(ChipId chip_id) {

--- a/device/common/utils.hpp
+++ b/device/common/utils.hpp
@@ -5,18 +5,23 @@
 #pragma once
 
 #include <fmt/ranges.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <random>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <type_traits>
@@ -26,6 +31,29 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd::utils {
+
+// Creates and returns a fresh, uniquely named directory under the system temp directory.
+inline std::filesystem::path create_unique_temp_dir() {
+    std::filesystem::path temp_path = std::filesystem::temp_directory_path();
+#ifdef _WIN32
+    // mkdtemp() does not exist on Windows; generate a random directory name and create it instead,
+    // retrying on the unlikely collision. create_directory returning true means we made it, so the
+    // name was unique.
+    std::random_device rd;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        const uint64_t nonce = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+        std::filesystem::path unique_dir = temp_path / fmt::format("umd_{:016x}", nonce);
+        std::error_code ec;
+        if (std::filesystem::create_directory(unique_dir, ec)) {
+            return unique_dir;
+        }
+    }
+    UMD_THROW(error::RuntimeError, "Failed to create a unique temp directory.");
+#else
+    std::string dir_template = temp_path / "umd_XXXXXX";
+    return std::filesystem::path(mkdtemp(dir_template.data()));
+#endif
+}
 
 inline std::optional<std::string> get_env_var_value(const char* env_var_name) {
     const char* env_var = std::getenv(env_var_name);

--- a/device/jtag/jtag_device.cpp
+++ b/device/jtag/jtag_device.cpp
@@ -83,7 +83,7 @@ JtagDevice::JtagDevice(std::unique_ptr<Jtag> jtag_device, const std::unordered_s
         }
     }
 
-    std::unique_ptr<Jtag> jtag = std::make_unique<Jtag>(actual_path.c_str());
+    std::unique_ptr<Jtag> jtag = std::make_unique<Jtag>(actual_path.string().c_str());
     std::unique_ptr<JtagDevice> jtag_device = std::make_unique<JtagDevice>(std::move(jtag), jtag_target_devices);
 
     // Check that all chips are of the same type.

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/utils.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -422,12 +423,7 @@ std::filesystem::path SocDescriptor::serialize_to_file(const std::filesystem::pa
 }
 
 std::filesystem::path SocDescriptor::get_default_soc_descriptor_file_path() {
-    std::filesystem::path temp_path = std::filesystem::temp_directory_path();
-    std::string soc_path_dir_template = temp_path / "umd_XXXXXX";
-    std::filesystem::path soc_path_dir = mkdtemp(soc_path_dir_template.data());
-    std::filesystem::path soc_path = soc_path_dir / "soc_descriptor.yaml";
-
-    return soc_path;
+    return utils::create_unique_temp_dir() / "soc_descriptor.yaml";
 }
 
 std::vector<CoreCoord> SocDescriptor::translate_coordinates(

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -32,6 +32,16 @@ namespace tt {
 enum class ARCH;
 }  // namespace tt
 
+#ifdef _WIN32
+// MSVC's CRT has no setenv/unsetenv; map them onto _putenv_s, which the getenv the code under test
+// uses does observe. _putenv_s with an empty value removes the variable.
+namespace {
+int setenv(const char* name, const char* value, int /*overwrite*/) { return _putenv_s(name, value); }
+
+int unsetenv(const char* name) { return _putenv_s(name, ""); }
+}  // namespace
+#endif
+
 using namespace tt::umd;
 
 class TestTTVisibleDevices : public ::testing::Test {
@@ -110,7 +120,15 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDF) {
 
     int total_combinations = 1 << pci_bdf_addresses.size();
 
-    for (uint32_t combination = 0; combination < total_combinations; combination++) {
+#ifdef _WIN32
+    // Windows cannot hold an environment variable with an empty value: both _putenv_s and
+    // SetEnvironmentVariable delete the variable instead. The empty combination therefore reads as
+    // "TT_VISIBLE_DEVICES unset" (all chips visible) rather than "no chips visible", so skip it.
+    const uint32_t first_combination = 1;
+#else
+    const uint32_t first_combination = 0;
+#endif
+    for (uint32_t combination = first_combination; combination < total_combinations; combination++) {
         std::vector<std::string> target_bdf_addresses;
         target_bdf_addresses.reserve(pci_bdf_addresses.size());
         for (int i = 0; i < pci_bdf_addresses.size(); i++) {

--- a/tests/baremetal/test_cluster_descriptor_offline.cpp
+++ b/tests/baremetal/test_cluster_descriptor_offline.cpp
@@ -33,6 +33,16 @@
 using namespace tt;
 using namespace tt::umd;
 
+#ifdef _WIN32
+// MSVC's CRT has no setenv/unsetenv; map them onto _putenv_s, which the getenv the code under test
+// uses does observe. _putenv_s with an empty value removes the variable.
+namespace {
+int setenv(const char* name, const char* value, int /*overwrite*/) { return _putenv_s(name, value); }
+
+int unsetenv(const char* name) { return _putenv_s(name, ""); }
+}  // namespace
+#endif
+
 int count_connections(
     const std::unordered_map<ChipId, std::unordered_map<EthernetChannel, std::tuple<ChipId, EthernetChannel>>>&
         connections) {


### PR DESCRIPTION
### Issue
#3351 (PR 1 of the series proposed there)

### Description
Small cleanups that the Windows host build needs, but that stand on their own. No behaviour change on Linux; the POSIX path still uses `mkdtemp`. Nothing here enables Windows by itself (no CMake changes, no new platform files); those come in later PRs once the shape is agreed.

### List of the changes
- Fold the duplicated `mkdtemp` temp-directory code in `cluster_descriptor.cpp` and `soc_descriptor.cpp` into one helper, `utils::create_unique_temp_dir()`. The helper carries a `_WIN32` branch (random name + `create_directory` retry) since `mkdtemp` does not exist there.
- `jtag_device.cpp`: `path.c_str()` → `path.string().c_str()` where a `const char*` is required (`path::c_str()` is `wchar_t*` on Windows).
- `topology_discovery_options.hpp`: `#undef IGNORE` guard, because `<windows.h>` defines `IGNORE` as a macro and would mangle the `Action::IGNORE` enumerator.
- `setenv`/`unsetenv` shims for MSVC in `test_tt_visible_devices.cpp` and `test_cluster_descriptor_offline.cpp`. In `OpenChipsByBDF`, skip the empty-list combination on Windows: an environment variable with an empty value cannot exist there (`_putenv_s`/`SetEnvironmentVariable` delete it), so "no chips visible" cannot be expressed.

### Testing
- Windows (Blackhole P100A, full port branch containing these hunks): `api_tests` 262 pass / 49 skip, `unified_tests` 10/10, `umd_misc_tests` 16/16, Blackhole `unit_tests` 16/16.
- Linux: not built locally (this is a Windows-only development machine); relying on CI here. The Linux code path is unchanged apart from the two call sites now going through the helper.
- `clang-format` (repo `.clang-format`) applied.

### API Changes
This PR has no API changes.