### PR TITLE
Simulation: override the register accessors on SimulationTTDevice

### DIFF
--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -57,6 +57,15 @@ public:
     void write_to_device(
         const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
 
+    // A simulation backend has no separate ordered-register transport: every access reaches the
+    // simulator through the same entry points, clocked synchronously from the calling thread under
+    // device_lock, so ordering is already guaranteed. Delegate to the bulk path -- the base
+    // implementations would route through DeviceProtocol, which a simulation model does not provide.
+    void read_from_device_reg(
+        void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
+    void write_to_device_reg(
+        const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
+
     void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     uint32_t get_clock() override;

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -160,6 +160,15 @@ void SimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_
     }
 }
 
+void SimulationTTDevice::read_from_device_reg(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
+    read_from_device(mem_ptr, core, addr, size, noc_id);
+}
+
+void SimulationTTDevice::write_to_device_reg(
+    const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
+    write_to_device(mem_ptr, core, addr, size, noc_id);
+}
+
 void SimulationTTDevice::host_write(CoreCoord core, uint64_t addr, const void* mem_ptr, size_t size) {
     if (is_device_closed()) {
         return;

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -762,6 +762,30 @@ TEST_F(TestDeviceIOFixture, WriteDataReadReg) {
     }
 }
 
+// The register accessors on the TTDevice itself, rather than through Cluster. The two are not the
+// same path: a Chip may answer register access without ever entering TTDevice's register accessors
+// (SimulationChip delegates them to the bulk path a layer above), so only a direct call exercises
+// the TTDevice-level implementation -- the shared one on silicon, the simulation override on a
+// simulation backend.
+TEST_F(TestDeviceIOFixture, TTDeviceRegReadWrite) {
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+
+    TTDevice* tt_device = cluster->get_tt_device(0);
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
+
+    constexpr uint32_t written_value = 0xABCD1234;
+    tt_device->write_to_device_reg(&written_value, tensix_core, SAFE_IO_L1_ADDRESS, sizeof(written_value));
+
+    uint32_t reg_readback = 0;
+    tt_device->read_from_device_reg(&reg_readback, tensix_core, SAFE_IO_L1_ADDRESS, sizeof(reg_readback));
+    EXPECT_EQ(written_value, reg_readback);
+
+    // The bulk path must observe the same memory, whether or not it is the same transport.
+    uint32_t bulk_readback = 0;
+    tt_device->read_from_device(&bulk_readback, tensix_core, SAFE_IO_L1_ADDRESS, sizeof(bulk_readback));
+    EXPECT_EQ(written_value, bulk_readback);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CoreTypes,
     TestDeviceIOFixture,


### PR DESCRIPTION
### Issue

#3353

### Description

`SimulationTTDevice` overrides the bulk device accessors but not the register ones, so `read_from_device_reg`/`write_to_device_reg` fall through to `TTDevice`, which routes them at `DeviceProtocol`. `TTDevice::get_device_protocol()` returns the model's pointer without a null check and a simulation model provides no protocol, so the base implementations dereference null. Nothing in the library reaches that path today — `SimulationChip` answers register access a layer above — so this is behaviour-neutral on its own; it unblocks #3353 Phase 2, where a simulation device runs the shared `TTDevice` implementations instead of overriding around them.

A simulation backend has no separate ordered-register transport: every access reaches the simulator through the same entry points, clocked synchronously from the calling thread under `device_lock`. The override therefore delegates to the bulk path, matching what `SimulationChip` already does.

### List of the changes

- `SimulationTTDevice`: override `read_from_device_reg`/`write_to_device_reg`, delegating to the bulk accessors
- Add `TestDeviceIOFixture.TTDeviceRegReadWrite`, covering the accessors at the `TTDevice` level — the existing `RegReadWrite` goes through `Cluster`, which stops at `SimulationChip`

### Testing

CI

### API Changes

None.
