### PR TITLE
Make CI runs cancellable: always() -> !cancelled()

### DIFF
--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -66,7 +66,7 @@ jobs:
   ensure-image:
     name: Ensure Docker image
     needs: gatekeeper
-    if: always()  # Don't skip if gatekeeper is skipped.
+    if: ${{ !cancelled() }}  # Don't skip if gatekeeper is skipped.
     permissions:
       packages: write
     secrets: inherit
@@ -83,7 +83,7 @@ jobs:
   build-exalens-kernels:
     name: Build tt-exalens kernels
     needs: gatekeeper
-    if: always()  # Don't skip if gatekeeper is skipped.
+    if: ${{ !cancelled() }}  # Don't skip if gatekeeper is skipped.
     secrets: inherit
     uses: ./.github/workflows/build-exalens-kernels.yml
 
@@ -101,16 +101,22 @@ jobs:
   # On main we also run only Release to maintain a consistent baseline, but don't want to spend resources
   # on extensive testing at this point.
   #
-  # Note that each of the following jobs has to have the always(), because default behavior of Github Actions is to
-  # skip all downstream jobs if one job is skipped, so when gatekeeper is skipped it would end up skipping all jobs.
-  # But we do want it to run only if ensure-image succeeded, so we need to add that condition to all downstream jobs.
+  # Each of the following jobs needs a status check function in its if-condition, because the default
+  # behavior of GitHub Actions is to skip all downstream jobs if one job is skipped, so a skipped
+  # gatekeeper would end up skipping all jobs. Any status check function suppresses that implicit
+  # needs-succeeded gate, which is why the explicit ensure-image condition is spelled out as well.
+  #
+  # The function must be !cancelled() and not always(): always() evaluates true even in a run that
+  # has been cancelled, so GitHub keeps starting these jobs (and the hardware matrices underneath
+  # them) after the run is cancelled, making the run effectively uncancellable. !cancelled() keeps
+  # the skip-propagation override but returns false once the run is cancelled.
 
   build-release:
     name: "Build and Test (Release)"
     needs: [ensure-image, build-exalens-kernels]
     # Skipped: (none)
     if: >-
-      always() &&
+      !cancelled() &&
       needs.ensure-image.result == 'success' &&
       (
         github.event_name == 'pull_request' ||
@@ -136,7 +142,7 @@ jobs:
     needs: [ensure-image, build-exalens-kernels]
     # Skipped: pull_request, push
     if: >-
-      always() &&
+      !cancelled() &&
       needs.ensure-image.result == 'success' &&
       (
         github.event_name == 'merge_group' ||
@@ -160,7 +166,7 @@ jobs:
     needs: [ensure-image, build-exalens-kernels]
     # Skipped: pull_request, push
     if: >-
-      always() &&
+      !cancelled() &&
       needs.ensure-image.result == 'success' &&
       (
         github.event_name == 'merge_group' ||
@@ -184,7 +190,7 @@ jobs:
     needs: [ensure-image, build-exalens-kernels]
     # Skipped: pull_request, merge_group, push
     if: >-
-      always() &&
+      !cancelled() &&
       needs.ensure-image.result == 'success' &&
       (
         github.event_name == 'workflow_dispatch' &&
@@ -209,7 +215,7 @@ jobs:
     needs: [ensure-image, build-exalens-kernels]
     # Skipped: pull_request, merge_group, push
     if: >-
-      always() &&
+      !cancelled() &&
       needs.ensure-image.result == 'success' &&
       (
         github.event_name == 'workflow_dispatch' &&
@@ -229,6 +235,11 @@ jobs:
 
   # Single leaf check that can be required in branch rulesets.
   # Treats skipped jobs as passing (expected on pull_request), fails on failure or cancellation.
+  #
+  # This is the one job that keeps always() rather than !cancelled(). A skipped job counts as
+  # passing for branch protection, so under !cancelled() a cancelled run would report this
+  # required check as green. always() makes it run and report the cancellation as a failure, and
+  # being a trivial ubuntu job it does not hold the cancellation up.
   all-builds-passed:
     name: All builds and tests passed
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -358,11 +358,12 @@ jobs:
     secrets: inherit
     # needs build-tests for the UMD wheel, and build-exalens-kernels for ordering (the artifact
     # must be uploaded before the tests download it). When build-exalens-kernels is skipped
-    # (a caller built it once and provided it), always() lets this run anyway; it still requires
-    # build-tests to have succeeded for the wheel.
+    # (a caller built it once and provided it), !cancelled() lets this run anyway; it still
+    # requires build-tests to have succeeded for the wheel. always() would do the same for the
+    # skip, but would also start this matrix inside an already-cancelled run.
     # TSan builds only run the unified tests, so exalens is skipped for them.
     needs: [build-tests, build-exalens-kernels]
-    if: always() && needs.build-tests.result == 'success' && inputs.build-type != 'TSan'
+    if: ${{ !cancelled() && needs.build-tests.result == 'success' && inputs.build-type != 'TSan' }}
     strategy:
       fail-fast: ${{ inputs.triggering-event == 'merge_group' }}
       matrix:
@@ -405,9 +406,14 @@ jobs:
   # up to the sibling top-level builds (Release/ASan/TSan), giving end-to-end fail-fast.
   # One watcher per job by design — a single watcher with multi-job `needs` would wait for
   # every need to settle before evaluating `if: failure()`, defeating the purpose.
+  #
+  # The !cancelled() gate keeps a run cancellation (manual, or by one of these watchers) from
+  # spawning the remaining watchers to re-cancel a run that is already going away. 'cancelled'
+  # stays in the watched result list so a job killed by its own timeout-minutes, which leaves
+  # the run itself alive, still trips fail-fast.
   fail-fast-build-tests:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.build-tests.result)
     needs: [build-tests]
     runs-on: ubuntu-latest
@@ -418,7 +424,7 @@ jobs:
 
   fail-fast-test-all:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.test-all.result)
     needs: [test-all]
     runs-on: ubuntu-latest
@@ -429,7 +435,7 @@ jobs:
 
   fail-fast-ttsim:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.run-ttsim-tests.result)
     needs: [run-ttsim-tests]
     runs-on: ubuntu-latest
@@ -440,7 +446,7 @@ jobs:
 
   fail-fast-tooling:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.run-tooling-tests.result)
     needs: [run-tooling-tests]
     runs-on: ubuntu-latest
@@ -451,7 +457,7 @@ jobs:
 
   fail-fast-exalens:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.run-exalens-tests.result)
     needs: [run-exalens-tests]
     runs-on: ubuntu-latest
@@ -462,7 +468,7 @@ jobs:
 
   fail-fast-tracy:
     if: |
-      always() && inputs.triggering-event == 'merge_group' &&
+      !cancelled() && inputs.triggering-event == 'merge_group' &&
       contains(fromJSON('["failure", "cancelled"]'), needs.run-tracy.result)
     needs: [run-tracy]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Issue
Part of https://github.com/tenstorrent/tt-umd/issues/3355

### Description
Cancelling a run of the test workflow did not actually stop it. Jobs are gated on
always() so that a skipped gatekeeper does not skip everything downstream, but
always() also evaluates true in a cancelled run, so GitHub kept starting the
pending build/test jobs (and the hardware matrices under them) after the
cancellation. !cancelled() suppresses the implicit needs-succeeded gate the same
way, so the skip-propagation behavior is unchanged, but returns false once the run
is cancelled.

This is a prerequisite for adding cancel-in-progress concurrency groups to the PR
gate - with always() in place, auto-cancellation would spawn phantom hardware jobs
on every push to a PR instead of only on a manual cancel.

### List of the changes
- build-and-run-all-tests-multiple-builds.yml: ensure-image, build-exalens-kernels
  and the five build-* jobs switch to !cancelled(). all-builds-passed deliberately
  keeps always(): a skipped job counts as passing for branch protection, so under
  !cancelled() a cancelled run would report the required check green.
- build-and-run-all-tests.yml: run-exalens-tests switches to !cancelled(); the six
  fail-fast-* merge-queue watchers get a !cancelled() gate so a cancellation stops
  spawning the remaining watchers to re-cancel a run that is already going away.
  They keep 'cancelled' in the watched result list, so a job killed by its own
  timeout-minutes still trips fail-fast.
- Comments updated to record why the distinction matters.

Note that bare `if: !cancelled()` is a YAML parse error (`!` is a tag indicator),
hence the `${{ }}` wrapping on the single-line conditions.

### Testing
Cancelled run on this PR: https://github.com/tenstorrent/tt-umd/actions/runs/33645651153/job/100302993793
After that I retried it, so second attempt should pass regularly

### API Changes
This PR has no API changes.


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/ci-concurrency-groups
