### PR TITLE
Avoid cross-process non-MMIO locking for isolated simulation

### DIFF
--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -501,7 +501,7 @@ bool TTDevice::is_remote() { return model_->get_remote_interface() != nullptr; }
 // device to be addressed within.
 int TTDevice::get_communication_device_id() const {
     DeviceProtocol *device_protocol = model_->get_device_protocol();
-    return device_protocol != nullptr ? device_protocol->get_mmio_id() : -1;
+    return device_protocol != nullptr ? device_protocol->get_mmio_id() : -getpid();
 }
 
 // Derived from the transport the device actually has, rather than stored: exactly one of these


### PR DESCRIPTION
### Description
`TTDevice::get_communication_device_id()` returns `-1` for a device with no device protocol. That id keys UMD's cross-process locks, so every simulator on a machine named the same shared-memory lock (`TT_UMD_LOCK.NON_MMIO_-1_PCIe`) and serialized its ETH transactions against every other, unrelated run -- two independent ttsim tt-metal tests would block each other for no reason.

Report the PID instead: unique among live processes, stable for the model's lifetime, so each simulator's lock name is private to its own process.

### List of the changes
- `TTDevice::get_communication_device_id()` defaults to `getpid()`.

### Testing
CI. The bug is cross-process so no unit test covers it; verified by auditing the call sites above.

### API Changes
This PR has no API changes.