### PR TITLE
[CI] Fix workflow validation on a direct dispatch of build-and-run-all-tests

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -97,6 +97,17 @@ on:
         type: string
         default: ""
 
+# Must be declared here, and not left to the default token, because a workflow this one calls only
+# receives the permissions its caller declares explicitly. Without this block, run-ttsim-tests.yml
+# is handed no `actions` scope, and its nested regression-check job - which needs `actions: read` for
+# the download-artifact API - fails workflow validation on a direct dispatch of this workflow.
+# `actions: write` is what the merge-queue fail-fast watchers below need for the cancel-workflow API;
+# `contents: read` and `packages: read` cover checkout and ghcr.io image pulls in the called workflows.
+permissions:
+  contents: read
+  actions: write
+  packages: read
+
 jobs:
   # Define all available cards which will be used for testing.
   cards:


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/actions/runs/33679863075

### Description
A manual dispatch of `build-and-run-all-tests.yml` has been failing at startup:

```
The nested job 'regression-check' is requesting 'actions: read', but is only allowed 'actions: none'.
```

A workflow passes down only the permissions its caller declares explicitly, not the ambient default
token. With no top-level `permissions:` here, `run-ttsim-tests.yml` got no `actions` scope and its
nested `regression-check` job failed validation. This only shows up on a direct dispatch, since in
CI the permissions come from the multiple-builds caller.

### List of the changes
- Added a top-level `permissions:` block (`contents: read`, `actions: write`, `packages: read`) to
  `build-and-run-all-tests.yml`, matching the one in the multiple-builds caller.

### Testing
Manual dispatch of the workflow to confirm it starts: https://github.com/tenstorrent/tt-umd/actions/runs/33681725798

### API Changes
This PR has no API changes.
