### PR TITLE
Simulation: report the chip id as the communication device id

### DIFF
--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -17,7 +17,7 @@ namespace tt::umd {
 // actually differ between them.
 class SimulationTTDeviceModel : public TTDeviceModel {
 public:
-    explicit SimulationTTDeviceModel(tt::ARCH arch);
+    SimulationTTDeviceModel(tt::ARCH arch, int communication_device_id);
 
     ~SimulationTTDeviceModel() override;
 
@@ -35,6 +35,7 @@ public:
 
 private:
     tt::ARCH arch_;
+    int communication_device_id_;
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
 };
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -92,7 +92,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     ChipId chip_id,
     int num_host_mem_channels) :
     SimulationTTDevice(
-        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
+        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch, chip_id),
         simulator_directory,
         std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)),
     communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)) {
@@ -107,7 +107,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
 RtlSimulationTTDevice::RtlSimulationTTDevice(
     const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
-    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch), std::move(client)) {
+    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch, chip_id), std::move(client)) {
     set_soc_descriptor(soc_descriptor);
 
     // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -100,7 +100,7 @@ TTSimTTDevice::TTSimTTDevice(
     // Each chip gets a distinct host base derived from chip_id, so its outbound-iATU DMA routes to its
     // own host window by address (see configure_iatu_region / SimulationSysmemManager).
     SimulationTTDevice(
-        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch),
+        std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch, chip_id),
         simulator_directory,
         std::make_unique<SimulationSysmemManager>(
             num_host_mem_channels, soc_descriptor.arch, static_cast<uint32_t>(chip_id))),
@@ -183,7 +183,7 @@ void TTSimTTDevice::initialize_backend() {
 
 TTSimTTDevice::TTSimTTDevice(
     const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
-    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch), std::move(client)),
+    SimulationTTDevice(std::make_unique<SimulationTTDeviceModel>(soc_descriptor.arch, chip_id), std::move(client)),
     chip_id_(chip_id) {
     set_soc_descriptor(soc_descriptor);
 

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -8,8 +8,10 @@
 
 namespace tt::umd {
 
-SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch) :
-    arch_(arch), architecture_impl_(ArchitectureImplementation::create(arch)) {}
+SimulationTTDeviceModel::SimulationTTDeviceModel(tt::ARCH arch, int communication_device_id) :
+    arch_(arch),
+    communication_device_id_(communication_device_id),
+    architecture_impl_(ArchitectureImplementation::create(arch)) {}
 
 // Out-of-line: the unique_ptr members hold forward-declared types, whose deleters need a
 // complete type where the destructor is instantiated.
@@ -17,9 +19,11 @@ SimulationTTDeviceModel::~SimulationTTDeviceModel() = default;
 
 tt::ARCH SimulationTTDeviceModel::get_arch() const { return arch_; }
 
-// A simulation backend has no host transport to be addressed within, so it reports no communication
-// device at all.
-int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
+// A simulation backend has no host transport to be addressed within, but the id still identifies
+// the device: it keys the per-device mutexes taken on its behalf (the NON_MMIO mutex a
+// RemoteCommunication built over this device initializes and acquires) and names the device in
+// errors raised against it. The simulated chip id serves that role.
+int SimulationTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 // A simulation backend reaches its device directly rather than over a transport protocol; the
 // simulation TTDevice overrides the read/write paths instead of routing them through one.


### PR DESCRIPTION
### Issue

#3353

### Description

`SimulationTTDeviceModel::get_communication_device_id()` returned `-1` for every simulated device. That id is not purely informational: `RemoteCommunication` initializes and acquires its `NON_MMIO` mutex keyed on it, so every simulated gateway in a process shared a single lock name, and `TTDeviceError` names the device by it, so any error raised from a simulation device reported chip `-1`.

Pass the simulated chip id through to the model instead. All four construction sites already have it in scope. This is also a prerequisite for #3353 Phase 5, where topology discovery writes this value into `chips_with_mmio` — a simulated cluster would otherwise map every chip to `-1`.

### List of the changes

- `SimulationTTDeviceModel`: take the communication device id at construction and return it
- `TTSimTTDevice`, `RtlSimulationTTDevice`: pass `chip_id` when building the model, in both the host and client constructors

### Testing

CI

### API Changes

- `SimulationTTDeviceModel`'s constructor now takes the communication device id alongside the arch. Made required rather than defaulted so every construction site has to state it.
