### PR TITLE
[Base API] Move TTDevice creation into a factory

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -97,6 +97,7 @@ target_sources(
         cluster_descriptor.cpp
         tt_device/blackhole_tt_device.cpp
         tt_device/tt_device.cpp
+        tt_device/tt_device_factory.cpp
         tt_device/tt_device_error.cpp
         tt_device/wormhole_tt_device.cpp
         tt_device/hang_detection/hang_detector.cpp
@@ -240,6 +241,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/core_coordinates.hpp
                 api/umd/device/tt_device/blackhole_tt_device.hpp
                 api/umd/device/tt_device/tt_device.hpp
+                api/umd/device/tt_device/tt_device_factory.hpp
                 api/umd/device/tt_device/tt_device_error.hpp
                 api/umd/device/tt_device/wormhole_tt_device.hpp
                 api/umd/device/tt_device/simulation_tt_device.hpp

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -37,7 +37,7 @@ public:
     static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
 #ifdef TT_UMD_BUILD_SIMULATION
     // Simulation-only factory for a simulated remote chip (no ARC to probe), matching
-    // TTDevice::create_simulation_remote. Compiled in only for simulation builds so the simulation-specific
+    // create_simulation_remote_tt_device. Compiled in only for simulation builds so the simulation-specific
     // construction path is not exposed in silicon builds.
     static std::unique_ptr<RemoteChip> create_for_simulation(
         std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info);

--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -91,7 +91,7 @@ struct TopologyDiscoveryOptions {
 
     /**
      * @brief If true, TTDevice instances created during discovery will use the safe API
-     * (forwarded as the use_safe_api argument to TTDevice::create).
+     * (forwarded as the use_safe_api argument to create_tt_device).
      * Defaults to false.
      */
     bool use_safe_api = false;

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -37,22 +37,15 @@ public:
 
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) override;
 
-protected:
     explicit BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
+protected:
     virtual bool is_arc_available_over_axi();
 
-    // Number of retrain attempts is chosen based on syseng team testing.
 private:
     const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::BLACKHOLE);
 
     int get_pcie_x_coordinate();
-
-    friend std::unique_ptr<TTDevice> TTDevice::create(
-        int device_number,
-        IODeviceType device_type,
-        bool use_safe_api,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1000;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -66,41 +66,14 @@ struct CoreCoord;
 class TTDevice {
 public:
     /**
-     * @brief Factory method to create a TTDevice instance.
+     * @brief Builds a device around its model.
      *
-     * Creates and returns a unique pointer to a TTDevice object configured with the
-     * specified parameters. This is the primary way to instantiate TTDevice objects.
-     *
-     * @param device_number The device identifier/index to connect to, specific to the I/O device interface.
-     * @param device_type The type of I/O device interface to use. (default: PCIe)
-     * @param use_safe_api Flag to enable safe I/O API that can recover from SIGBUS errors.
-     *                     Available only for PCIe I/O device type. (default: false)
-     * @param soc_arch_descriptor Shared pointer to the SoC architecture descriptor.
-     *                            If nullptr, a default descriptor will be used. (default: nullptr)
-     *
-     * @return std::unique_ptr<TTDevice> A unique pointer to the created TTDevice instance.
-     *
-     * @throws May throw exceptions if device creation fails or device_number is invalid.
+     * Every TTDevice is built around a model, which supplies its identity and the components it
+     * runs on: the protocol it talks to hardware over, its architecture implementation and its SoC
+     * architecture descriptor. Assembly - probing the architecture, picking the transport and the
+     * concrete model - lives in tt_device_factory.hpp, not here.
      */
-    static std::unique_ptr<TTDevice> create(
-        int device_number,
-        IODeviceType device_type = IODeviceType::PCIe,
-        bool use_safe_api = false,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
-
-    static std::unique_ptr<TTDevice> create(
-        std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
-
-#ifdef TT_UMD_BUILD_SIMULATION
-    // A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its SocDescriptor.
-    // Simulated remote chips have no ARC to probe, so the caller supplies the full descriptor directly. This is a
-    // dedicated factory (compiled in only for simulation builds) rather than an overload of the silicon create()
-    // above, so the simulation-only flow stays fully separated from the silicon path.
-    // TODO: temporary - remove once ttsim provides a mocked ARC that can serve the SocDescriptor like silicon does.
-    static std::unique_ptr<TTDevice> create_simulation_remote(
-        std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor);
-#endif  // TT_UMD_BUILD_SIMULATION
+    explicit TTDevice(std::unique_ptr<TTDeviceModel> model);
 
     virtual ~TTDevice() = default;
 
@@ -532,13 +505,12 @@ public:
 
     const SocDescriptor &get_soc_descriptor() const;
 
+    // Assigns the descriptor exactly once; the factory's simulation-remote path supplies it directly
+    // because a simulated remote chip has no ARC for init_tt_device() to construct it from.
+    void set_soc_descriptor(const SocDescriptor &soc_descriptor);
+
 protected:
     LockManager lock_manager;
-
-    // Every TTDevice is built around a model, which supplies its identity and the components it
-    // runs on: the protocol it talks to hardware over, its architecture implementation and its SoC
-    // architecture descriptor.
-    explicit TTDevice(std::unique_ptr<TTDeviceModel> model);
 
     // Emulates a NOC multicast write by issuing a unicast write_to_device to every core in the
     // [core_start, core_end] grid. Simulation backends have no hardware multicast, so they delegate
@@ -552,7 +524,6 @@ protected:
         NocId noc_id = NocId::DEFAULT_NOC);
 
     void construct_soc_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-    void set_soc_descriptor(const SocDescriptor &soc_descriptor);
 
 private:
     // Wires the model's hang detector to this device: routes a timed-out MMIO op to a NOC liveness

--- a/device/api/umd/device/tt_device/tt_device_factory.hpp
+++ b/device/api/umd/device/tt_device/tt_device_factory.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "umd/device/types/communication_protocol.hpp"
+
+namespace tt::umd {
+
+class RemoteCommunication;
+class SocArchDescriptor;
+class SocDescriptor;
+class TTDevice;
+
+/**
+ * Creates a TTDevice for a locally attached device.
+ *
+ * The composition root for a device: probes the architecture over the requested transport, builds
+ * the matching TTDeviceModel with that transport, and injects it into the matching TTDevice.
+ * TTDevice itself carries no knowledge of how it is assembled.
+ *
+ * @param device_number The device identifier/index to connect to, specific to the I/O device interface.
+ * @param device_type The type of I/O device interface to use. (default: PCIe)
+ * @param use_safe_api Flag to enable safe I/O API that can recover from SIGBUS errors.
+ *                     Available only for PCIe I/O device type. (default: false)
+ * @param soc_arch_descriptor Shared pointer to the SoC architecture descriptor.
+ *                            If nullptr, a default descriptor will be used. (default: nullptr)
+ * @return std::unique_ptr<TTDevice> The created device.
+ * @throws May throw exceptions if device creation fails or device_number is invalid.
+ */
+std::unique_ptr<TTDevice> create_tt_device(
+    int device_number,
+    IODeviceType device_type = IODeviceType::PCIe,
+    bool use_safe_api = false,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+
+/**
+ * Creates a TTDevice for a remote device reached over ethernet through a local gateway.
+ */
+std::unique_ptr<TTDevice> create_tt_device(
+    std::unique_ptr<RemoteCommunication> remote_communication,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+
+#ifdef TT_UMD_BUILD_SIMULATION
+/**
+ * Creates a TTDevice for a simulated remote chip.
+ *
+ * A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its
+ * SocDescriptor. Simulated remote chips have no ARC to probe, so the caller supplies the full
+ * descriptor directly. This is a dedicated factory (compiled in only for simulation builds) rather
+ * than an overload of the silicon create_tt_device() above, so the simulation-only flow stays fully
+ * separated from the silicon path.
+ * TODO: temporary - remove once ttsim provides a mocked ARC that can serve the SocDescriptor like
+ * silicon does.
+ */
+std::unique_ptr<TTDevice> create_simulation_remote_tt_device(
+    std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor);
+#endif  // TT_UMD_BUILD_SIMULATION
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -36,25 +36,9 @@ public:
 
     ~WormholeTTDevice() override = default;
 
-protected:
     explicit WormholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
 private:
     const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::WORMHOLE_B0);
-
-    // Builds the ARC message (with the common prefix) that requests the given clock state.
-
-    friend std::unique_ptr<TTDevice> TTDevice::create(
-        int device_number,
-        IODeviceType device_type,
-        bool use_safe_api,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-    friend std::unique_ptr<TTDevice> TTDevice::create(
-        std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-#ifdef TT_UMD_BUILD_SIMULATION
-    friend std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
-        std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor);
-#endif  // TT_UMD_BUILD_SIMULATION
 };
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
         error::RuntimeError,
         "RemoteTTDevice passed to RemoteChip::create_for_simulation must have a RemoteCommunication.");
     // The remote TTDevice for a simulated chip is never run through init_tt_device() (it has no ARC to probe), so
-    // its SocDescriptor is supplied to TTDevice::create() instead. get_soc_descriptor() can then keep delegating
+    // its SocDescriptor is supplied to create_tt_device() instead. get_soc_descriptor() can then keep delegating
     // to the TTDevice like every other chip.
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device), chip_info));
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -33,6 +33,7 @@
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 // Simulation-specific headers -- only needed when TT_UMD_BUILD_SIMULATION is set.
 // The code that uses these types is guarded by #ifdef TT_UMD_BUILD_SIMULATION below.
 #ifdef TT_UMD_BUILD_SIMULATION
@@ -229,7 +230,7 @@ std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
 
     // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
     // instead of letting init_tt_device construct one.
-    auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
+    auto remote_tt_device = create_simulation_remote_tt_device(std::move(remote_communication), soc_desc);
     return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
 }
 #endif  // TT_UMD_BUILD_SIMULATION

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -36,6 +36,7 @@
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/topology/topology_utils.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
@@ -174,7 +175,7 @@ void TopologyDiscovery::get_connected_devices() {
 
     for (auto& device_id : local_device_ids) {
         std::unique_ptr<TTDevice> tt_device =
-            TTDevice::create(device_id, io_device_type, options.use_safe_api, soc_arch_descriptor_);
+            create_tt_device(device_id, io_device_type, options.use_safe_api, soc_arch_descriptor_);
         if (options.low_power) {
             // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
             log_warning(

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -152,7 +153,7 @@ std::unique_ptr<TTDevice> TopologyDiscoveryWormhole::create_remote_device(
     remote_communication->set_remote_transfer_ethernet_cores(
         gateway_device->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             gateway_eth_channels, CoordSystem::TRANSLATED));
-    return TTDevice::create(std::move(remote_communication), soc_arch_descriptor);
+    return create_tt_device(std::move(remote_communication), soc_arch_descriptor);
 }
 
 uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(TTDevice* tt_device, CoreCoord local_eth_core) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -24,12 +24,10 @@
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/driver_atomics.hpp"
-#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
-#include "umd/device/tt_device/blackhole_tt_device.hpp"
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
@@ -42,9 +40,6 @@
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
-#include "umd/device/tt_device/wormhole_tt_device.hpp"
-#include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
-#include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -91,100 +86,6 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     get_device_firmware()->init_firmware(timeout_ms, get_selected_noc_id());
     construct_soc_descriptor(model_->get_shared_soc_arch_descriptor());
 }
-
-/* static */ std::unique_ptr<TTDevice> TTDevice::create(
-    int device_number,
-    IODeviceType device_type,
-    bool use_safe_api,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    ZoneScopedC(tracy::Color::DarkGreen);
-    UMD_ASSERT(
-        (!use_safe_api) || (device_type == IODeviceType::PCIe),
-        error::RuntimeError,
-        "Safe I/O API is not supported for non-PCIe device types.");
-    tt::ARCH arch = tt::ARCH::Invalid;
-    if (device_type == IODeviceType::JTAG) {
-        auto jtag_device = JtagDevice::create();
-        arch = jtag_device->get_jtag_arch(device_number);
-        switch (arch) {
-            case ARCH::WORMHOLE_B0:
-                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
-                    std::move(jtag_device), device_number, soc_arch_descriptor)));
-            case ARCH::BLACKHOLE:
-                return std::unique_ptr<BlackholeTTDevice>(
-                    new BlackholeTTDevice(std::make_unique<BlackholeTTDeviceModel>(
-                        std::move(jtag_device), device_number, soc_arch_descriptor)));
-            default:
-                UMD_THROW(
-                    error::RuntimeError,
-                    fmt::format("Creating TTDevice is not supported for {} architecture.", arch_to_str(arch)));
-        }
-    }
-
-    auto pci_device = std::make_unique<PCIDevice>(device_number);
-    arch = pci_device->get_arch();
-
-    switch (arch) {
-        case ARCH::WORMHOLE_B0:
-            return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
-        case ARCH::BLACKHOLE:
-            return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
-        default:
-            UMD_THROW(
-                error::RuntimeError,
-                fmt::format("Creating TTDevice is not supported for {} architecture.", arch_to_str(arch)));
-    }
-}
-
-std::unique_ptr<TTDevice> TTDevice::create(
-    std::unique_ptr<RemoteCommunication> remote_communication,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    ZoneScopedC(tracy::Color::DarkGreen);
-    UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
-    tt::ARCH arch = remote_communication->get_local_device()->get_arch();
-    switch (arch) {
-        case tt::ARCH::WORMHOLE_B0:
-            return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication), soc_arch_descriptor)));
-        default:
-            UMD_THROW(
-                error::RuntimeError,
-                fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
-    }
-}
-
-#ifdef TT_UMD_BUILD_SIMULATION
-std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
-    std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor) {
-    ZoneScopedC(tracy::Color::DarkGreen);
-    UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
-    tt::ARCH arch = remote_communication->get_local_device()->get_arch();
-    UMD_ASSERT(
-        soc_descriptor.arch == arch,
-        error::RuntimeError,
-        fmt::format(
-            "Supplied SocDescriptor arch ({}) does not match the remote device arch ({}).",
-            arch_to_str(soc_descriptor.arch),
-            arch_to_str(arch)));
-    switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: {
-            auto device =
-                std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
-                    std::move(remote_communication), /*soc_arch_descriptor=*/nullptr)));
-            // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
-            // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
-            device->set_soc_descriptor(soc_descriptor);
-            return device;
-        }
-        default:
-            UMD_THROW(
-                error::RuntimeError,
-                fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
-    }
-}
-#endif  // TT_UMD_BUILD_SIMULATION
 
 ArchitectureImplementation *TTDevice::get_architecture_implementation() { return model_->get_architecture_impl(); }
 

--- a/device/tt_device/tt_device_factory.cpp
+++ b/device/tt_device/tt_device_factory.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/tt_device_factory.hpp"
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <utility>
+
+#include "tracy.hpp"
+#include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/blackhole_tt_device.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/wormhole_tt_device.hpp"
+#include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
+#include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+std::unique_ptr<TTDevice> create_tt_device(
+    int device_number,
+    IODeviceType device_type,
+    bool use_safe_api,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(
+        (!use_safe_api) || (device_type == IODeviceType::PCIe),
+        error::RuntimeError,
+        "Safe I/O API is not supported for non-PCIe device types.");
+    tt::ARCH arch = tt::ARCH::Invalid;
+    if (device_type == IODeviceType::JTAG) {
+        auto jtag_device = JtagDevice::create();
+        arch = jtag_device->get_jtag_arch(device_number);
+        switch (arch) {
+            case ARCH::WORMHOLE_B0:
+                return std::make_unique<WormholeTTDevice>(std::make_unique<WormholeTTDeviceModel>(
+                    std::move(jtag_device), device_number, soc_arch_descriptor));
+            case ARCH::BLACKHOLE:
+                return std::make_unique<BlackholeTTDevice>(std::make_unique<BlackholeTTDeviceModel>(
+                    std::move(jtag_device), device_number, soc_arch_descriptor));
+            default:
+                UMD_THROW(
+                    error::RuntimeError,
+                    fmt::format("Creating TTDevice is not supported for {} architecture.", arch_to_str(arch)));
+        }
+    }
+
+    auto pci_device = std::make_unique<PCIDevice>(device_number);
+    arch = pci_device->get_arch();
+
+    switch (arch) {
+        case ARCH::WORMHOLE_B0:
+            return std::make_unique<WormholeTTDevice>(
+                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor));
+        case ARCH::BLACKHOLE:
+            return std::make_unique<BlackholeTTDevice>(
+                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor));
+        default:
+            UMD_THROW(
+                error::RuntimeError,
+                fmt::format("Creating TTDevice is not supported for {} architecture.", arch_to_str(arch)));
+    }
+}
+
+std::unique_ptr<TTDevice> create_tt_device(
+    std::unique_ptr<RemoteCommunication> remote_communication,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
+    tt::ARCH arch = remote_communication->get_local_device()->get_arch();
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return std::make_unique<WormholeTTDevice>(
+                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication), soc_arch_descriptor));
+        default:
+            UMD_THROW(
+                error::RuntimeError,
+                fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
+    }
+}
+
+#ifdef TT_UMD_BUILD_SIMULATION
+std::unique_ptr<TTDevice> create_simulation_remote_tt_device(
+    std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
+    tt::ARCH arch = remote_communication->get_local_device()->get_arch();
+    UMD_ASSERT(
+        soc_descriptor.arch == arch,
+        error::RuntimeError,
+        fmt::format(
+            "Supplied SocDescriptor arch ({}) does not match the remote device arch ({}).",
+            arch_to_str(soc_descriptor.arch),
+            arch_to_str(arch)));
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0: {
+            auto device = std::make_unique<WormholeTTDevice>(std::make_unique<WormholeTTDeviceModel>(
+                std::move(remote_communication), /*soc_arch_descriptor=*/nullptr));
+            // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
+            // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
+            device->set_soc_descriptor(soc_descriptor);
+            return device;
+        }
+        default:
+            UMD_THROW(
+                error::RuntimeError,
+                fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
+    }
+}
+#endif  // TT_UMD_BUILD_SIMULATION
+
+}  // namespace tt::umd

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -39,6 +39,7 @@
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -304,7 +305,7 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
     tt_devices.reserve(pci_device_ids.size());
 
     for (auto& i : pci_device_ids) {
-        auto tt_device = TTDevice::create(i);
+        auto tt_device = create_tt_device(i);
         try {
             tt_device->get_device_firmware()->init_firmware(timeout::ARC_LONG_POST_RESET_TIMEOUT);
         } catch (error::UmdBaseException& err) {

--- a/examples/tt_device_example/README.md
+++ b/examples/tt_device_example/README.md
@@ -33,7 +33,7 @@ TTDevice provides two levels of functionality:
 
 ```cpp
 // Create device
-std::unique_ptr<TTDevice> device = TTDevice::create(device_id);
+std::unique_ptr<TTDevice> device = create_tt_device(device_id);
 
 // Basic operations work immediately
 tt::ARCH arch = device->get_arch();

--- a/examples/tt_device_example/tt_device_example.cpp
+++ b/examples/tt_device_example/tt_device_example.cpp
@@ -10,6 +10,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt;
@@ -27,7 +28,7 @@ int main(int argc, char* argv[]) {
     for (int device_id : pci_devices) {
         std::cout << "\n=== Device " << device_id << " (Before Initialization) ===" << std::endl;
 
-        std::unique_ptr<TTDevice> device = TTDevice::create(device_id);
+        std::unique_ptr<TTDevice> device = create_tt_device(device_id);
 
         std::cout << "Architecture: "
                   << (device->get_arch() == tt::ARCH::WORMHOLE_B0 ? "Wormhole B0"

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -27,6 +27,7 @@
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 #include "umd/device/tt_device/simulation_device_factory.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -117,7 +118,7 @@ std::unique_ptr<TTDevice> create_remote_tt_device(
     remote_communication->set_remote_transfer_ethernet_cores(
         local_tt_device->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             cluster_descriptor->get_active_eth_channels(local_chip_id), CoordSystem::TRANSLATED));
-    return TTDevice::create(std::move(remote_communication));
+    return create_tt_device(std::move(remote_communication));
 }
 
 // Create remote TTDevice from explicit EthCoord (rack, shelf, x, y). Does not set
@@ -131,7 +132,7 @@ std::unique_ptr<TTDevice> create_remote_tt_device_from_coord(TTDevice *local_chi
             std::string("Remote communication is not supported for ") + arch_to_str(local_chip->get_arch()) +
                 " architecture.");
     }
-    return TTDevice::create(std::move(remote_communication));
+    return create_tt_device(std::move(remote_communication));
 }
 
 void bind_tt_device(nb::module_ &m) {
@@ -242,7 +243,7 @@ void bind_tt_device(nb::module_ &m) {
         .def_static(
             "create",
             static_cast<std::unique_ptr<TTDevice> (*)(
-                int, IODeviceType, bool, const std::shared_ptr<SocArchDescriptor> &)>(&TTDevice::create),
+                int, IODeviceType, bool, const std::shared_ptr<SocArchDescriptor> &)>(&create_tt_device),
             nb::arg("device_number"),
             nb::arg("device_type") = IODeviceType::PCIe,
             nb::arg("use_safe_api") = true,

--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -18,6 +18,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/utils/semver.hpp"
@@ -29,7 +30,7 @@ TEST(TestTelemetry, BasicTelemetry) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         if (tt_device->get_firmware_version() < FirmwareBundleVersion(18, 4, 0)) {
@@ -57,7 +58,7 @@ TEST(TestTelemetry, TelemetryEntryAvailable) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         FirmwareTelemetryReader* arc_telemetry_reader = tt_device->get_firmware_telemetry_reader();

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/gddr_telemetry.hpp"
@@ -82,7 +83,7 @@ public:
     void SetUp() override {
         std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
         for (int pci_device_id : pci_device_ids) {
-            auto tt_device = TTDevice::create(pci_device_id);
+            auto tt_device = create_tt_device(pci_device_id);
             tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
             ASSERT_NE(tt_device->get_firmware_info_provider(), nullptr);
@@ -840,7 +841,7 @@ TEST_F(TestFirmwareInfoProvider, RuntimeTelemetryBufferAddressAndSize) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -62,7 +63,7 @@ protected:
 
         for (uint32_t jlink_device_id = 0; jlink_device_id < jlink_device_count_; ++jlink_device_id) {
             DeviceData device_data;
-            device_data.tt_device_ = TTDevice::create(jlink_device_id, IODeviceType::JTAG);
+            device_data.tt_device_ = create_tt_device(jlink_device_id, IODeviceType::JTAG);
             device_data.tt_device_->init_tt_device();
             device_data.tensix_core_ = device_data.tt_device_->get_soc_descriptor()
                                            .get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0]
@@ -162,7 +163,7 @@ TEST_F(ApiJtagDeviceTest, JtagTranslatedCoordsTest) {
 
     // Test shouldn't last long since there's a limited number of PCIe devices on the system.
     for (const auto& pci_device_id : pci_device_ids) {
-        auto pci_tt_device = TTDevice::create(pci_device_id, IODeviceType::PCIe);
+        auto pci_tt_device = create_tt_device(pci_device_id, IODeviceType::PCIe);
         if (!pci_tt_device) {
             UMD_THROW(error::RuntimeError, "Failed to create PCI TT device.");
         }

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -31,6 +31,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -45,7 +46,7 @@ TEST(ApiSysmemManager, BasicIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         // Initializes system memory with one channel.

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -18,6 +18,7 @@
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -43,7 +44,7 @@ TEST_F(ApiTLBManager, ManualTLBConfiguration) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         const size_t tlb_tensix_size = tt_device->get_arch() == tt::ARCH::WORMHOLE_B0 ? (1 << 20) : (1 << 21);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -40,7 +41,7 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     std::vector<uint32_t> data_read(data_write.size(), 0);
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -70,7 +71,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegIO) {
     std::vector<uint32_t> data_read(data_write0.size(), 0);
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         uint64_t address = get_architecture_registers(tt_device->get_arch()).riscv_debug_bus_cntl_reg;
@@ -97,7 +98,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegUnalignedThrows) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -119,7 +120,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegUnalignedThrows) {
 TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -144,7 +145,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
     const uint32_t num_loops = 1000;
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -251,7 +252,7 @@ TEST(ApiTTDeviceTest, MulticastIO) {
     std::vector<uint8_t> data_read(data_write.size(), 0);
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -293,7 +294,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
     std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -331,7 +332,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
 TEST(ApiTTDeviceTest, UninitializedError) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         // These methods should work without initialization.
@@ -378,7 +379,7 @@ TEST(ApiTTDeviceTest, UninitializedError) {
 TEST(ApiTTDeviceTest, UninitializedIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -387,7 +388,7 @@ TEST(ApiTTDeviceTest, UninitializedIO) {
             tt_device->get_soc_descriptor().translate_chip_coord_to_translated(tensix_core, get_selected_noc_id());
         tt_device.reset();
 
-        tt_device = TTDevice::create(pci_device_id);
+        tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         using err = error::UmdException<error::UnresolvableCoordinateError>;
 

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -41,6 +41,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
@@ -110,7 +111,7 @@ TEST_P(WarmResetParamTest, DISABLED_SafeApiHandlesReset) {
     CoreCoord tensix_core;
 
     for (int pci_device_id : pci_device_ids) {
-        tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
+        tt_devices[pci_device_id] = create_tt_device(pci_device_id, IODeviceType::PCIe, true);
         tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
         tt_devices[pci_device_id]->init_tt_device();
@@ -184,7 +185,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
     CoreCoord tensix_core;
 
     for (int pci_device_id : pci_device_ids) {
-        tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
+        tt_devices[pci_device_id] = create_tt_device(pci_device_id, IODeviceType::PCIe, true);
         tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
         tt_devices[pci_device_id]->init_tt_device();
@@ -244,7 +245,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
             CoreCoord tensix_core;
 
             for (int pci_device_id : pci_device_ids) {
-                tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
+                tt_devices[pci_device_id] = create_tt_device(pci_device_id, IODeviceType::PCIe, true);
                 tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
                 tt_devices[pci_device_id]->init_tt_device();

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -15,6 +15,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/firmware/device_firmware.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
@@ -29,7 +30,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessagesBasic) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->get_device_firmware()->init_firmware(timeout::ARC_STARTUP_TIMEOUT);
 
@@ -48,7 +49,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageArgPassing) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->get_device_firmware()->init_firmware(timeout::ARC_STARTUP_TIMEOUT);
 
@@ -69,7 +70,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageReturnValues) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->get_device_firmware()->init_firmware(timeout::ARC_STARTUP_TIMEOUT);
 
@@ -90,7 +91,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -125,7 +126,7 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
     const uint32_t num_loops = 1000;
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -11,6 +11,7 @@
 
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
 using namespace tt;
@@ -20,7 +21,7 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 

--- a/tests/hang_detection/test_hang_detection.cpp
+++ b/tests/hang_detection/test_hang_detection.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
@@ -66,7 +67,7 @@ protected:
     }
 
     void init_device(int pci_device_id) {
-        tt_device_ = TTDevice::create(pci_device_id);
+        tt_device_ = create_tt_device(pci_device_id);
         tt_device_->init_tt_device();
         soc_desc_ = std::make_unique<SocDescriptor>(tt_device_->get_soc_descriptor());
     }

--- a/tests/hang_detection/test_warm_reset_after_noc_hang.cpp
+++ b/tests/hang_detection/test_warm_reset_after_noc_hang.cpp
@@ -16,6 +16,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -67,7 +68,7 @@ TEST_F(WarmResetAfterNocHangTest, TTDeviceWarmResetAfterNocHang) {
     std::vector<uint8_t> zero_data(data.size(), 0);
     std::vector<uint8_t> readback_data(data.size(), 0);
 
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
+    std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_ids.at(0));
     tt_device->set_power_state(TTDevice::PowerState::BUSY);
     tt_device->init_tt_device();
 
@@ -99,7 +100,7 @@ TEST_F(WarmResetAfterNocHangTest, TTDeviceWarmResetAfterNocHang) {
 
     tt_device.reset();
 
-    tt_device = TTDevice::create(pci_device_ids.at(0));
+    tt_device = create_tt_device(pci_device_ids.at(0));
     tt_device->set_power_state(TTDevice::PowerState::BUSY);
     tt_device->init_tt_device();
 

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -18,6 +18,7 @@
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -30,7 +31,7 @@ inline bool has_remote_chips() {
     if (pci_device_ids.empty()) {
         return false;
     }
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);
+    std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_ids[0]);
     tt_device->init_tt_device();
 
     auto board_type = tt_device->get_board_type();

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -27,6 +27,7 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -227,7 +228,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
     auto low_level_monitor_thread = std::thread([&] {
         std::cout << "Creating low level monitor cluster" << std::endl;
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_ids.at(0));
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -253,7 +254,7 @@ TEST(Multiprocess, LongLivedMonitor) {
 
     auto low_level_monitor_thread = std::thread([&] {
         std::cout << "Creating low level monitor cluster" << std::endl;
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_ids.at(0));
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -353,7 +354,7 @@ TEST(Multiprocess, DMAWriteReadRaceCondition) {
                       << std::endl;
 
             // Each process creates its own TTDevice object with the same PCIDevice.
-            std::unique_ptr<TTDevice> tt_device = TTDevice::create(test_device_id);
+            std::unique_ptr<TTDevice> tt_device = create_tt_device(test_device_id);
             tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
 
@@ -428,7 +429,7 @@ TEST(Multiprocess, DISABLED_DMAWriteReadRaceConditionProcessIsolation) {
             std::cout << "Process " << process_id << " with pid " << pid << ": Starting DMA operations" << std::endl;
 
             // Each process creates its own TTDevice object with the same PCIDevice.
-            std::unique_ptr<TTDevice> tt_device = TTDevice::create(test_device_id);
+            std::unique_ptr<TTDevice> tt_device = create_tt_device(test_device_id);
             tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
 

--- a/tests/wormhole/test_arc_telemetry_wh.cpp
+++ b/tests/wormhole/test_arc_telemetry_wh.cpp
@@ -6,6 +6,7 @@
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 
 using namespace tt::umd;
@@ -14,7 +15,7 @@ TEST(WormholeTelemetry, BasicWormholeTelemetry) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -40,7 +41,7 @@ TEST(WormholeTelemetry, WormholeTelemetryEntryAvailable) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
@@ -64,7 +65,7 @@ TEST(TestTelemetry, CompareTwoTelemetryValues) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<TTDevice> tt_device = create_tt_device(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         FirmwareTelemetryReader* arc_telemetry_reader = tt_device->get_firmware_telemetry_reader();

--- a/tools/tlb_virus.cpp
+++ b/tools/tlb_virus.cpp
@@ -21,6 +21,7 @@
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
@@ -43,7 +44,7 @@ int main(int argc, char* argv[]) {
         std::map<int, std::map<size_t, std::pair<int, uint32_t>>> tlb_allocation_summary;
 
         for (int pci_device_id : PCIDevice::enumerate_devices()) {
-            auto tt_device = TTDevice::create(pci_device_id);
+            auto tt_device = create_tt_device(pci_device_id);
             std::vector<std::unique_ptr<TlbHandle>> allocated_tlbs;
             tt_device->init_tt_device();
             tt::ARCH arch = tt_device->get_arch();


### PR DESCRIPTION
### Issue
#2872

### Description
The three static `create` functions leave `TTDevice` for a new `tt_device_factory` — the composition root for devices, following the `simulation_device_factory` precedent. The factory probes the architecture over the requested transport, builds the matching concrete `TTDeviceModel`, injects it into `TTDevice`, and returns `std::unique_ptr<TTDevice>`. The facade no longer knows how it is assembled, and every construction-only dependency (`JtagDevice`, `PCIDevice` creation, the concrete models) leaves `tt_device.cpp` with the bodies. Sequencing: this PR lands LAST, on top of the #3394 stack, once tt-metal's three `TTDevice::create` call sites migrate to `create_tt_device()` (the run-ttsim-tests gate builds tt-metal against this PR's UMD).

### List of the changes
- `create_tt_device(...)` (two overloads) and `create_simulation_remote_tt_device(...)` free functions in `umd/device/tt_device/tt_device_factory.{hpp,cpp}`; bodies moved verbatim.
- `TTDevice(std::unique_ptr<TTDeviceModel>)` goes public (so `std::make_unique` works and the `create`-friendships are deleted); `set_soc_descriptor()` goes public with it — the simulation-remote path assigns the caller-supplied descriptor, still guarded by its assign-exactly-once invariant.
- All callers flip to the free functions: warm reset, topology discovery, cluster, 14 test files, the example (and its README), `tools/tlb_virus`, and the Python bindings — where the Python-facing name `TTDevice.create` is kept, now bound to the free function.

### Testing
`baremetal_tests` 254/254, simulation on and off, Python bindings build, no undefined symbols, pre-commit clean against main; CI.

### API Changes
This PR has API changes: `TTDevice::create` (both overloads) and `TTDevice::create_simulation_remote` are removed, replaced by `create_tt_device` / `create_simulation_remote_tt_device` in `umd/device/tt_device/tt_device_factory.hpp`; `TTDevice`'s model constructor and `set_soc_descriptor` are now public; Python `TTDevice.create` unchanged.