### PR TITLE
[Base API] Firmware review follow-ups: eager dead-bus detection, pre-init guards, hardening

### DIFF
--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -95,7 +95,8 @@ public:
      * Distinct from set_clock_state(): this manages power domains rather than the clock frequency.
      *
      * @param state The requested power state.
-     * @param noc_id NOC to route through.
+     * @param noc_id Reserved. Power domains are controlled over PCIe only today, so no
+     * implementation routes this over a NOC.
      */
     virtual void set_power_state(PowerState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 

--- a/device/api/umd/device/tt_device/firmware/device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/device_firmware.hpp
@@ -85,7 +85,7 @@ public:
      * the clock to settle near the target before returning.
      *
      * @param state The target clock state.
-     * @param noc_id NOC to route through.
+     * @param noc_id NOC to route through (if the feature is routed through NOC).
      */
     virtual void set_clock_state(ClockState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 
@@ -95,8 +95,7 @@ public:
      * Distinct from set_clock_state(): this manages power domains rather than the clock frequency.
      *
      * @param state The requested power state.
-     * @param noc_id Reserved. Power domains are controlled over PCIe only today, so no
-     * implementation routes this over a NOC.
+     * @param noc_id NOC to route through (if the feature is routed through NOC).
      */
     virtual void set_power_state(PowerState state, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -396,6 +396,8 @@ public:
      * manages hardware power domains.
      *
      * @param state The target clock state (BUSY = max frequency, IDLE = min frequency).
+     * @param noc_id Currently ignored: the call routes on the thread-selected NOC, matching the
+     * per-arch overrides this replaced. Honoring the parameter end-to-end is follow-up work.
      */
     void set_clock_state(ClockState state, NocId noc_id = NocId::DEFAULT_NOC);
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -386,6 +386,7 @@ public:
      * Claims or releases full power domains. No-op for remote devices.
      *
      * @param state The requested power state (BUSY or IDLE).
+     * @param noc_id NOC to route through (if the feature is routed through NOC).
      */
     virtual void set_power_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC);
 
@@ -396,8 +397,7 @@ public:
      * manages hardware power domains.
      *
      * @param state The target clock state (BUSY = max frequency, IDLE = min frequency).
-     * @param noc_id Currently ignored: the call routes on the thread-selected NOC, matching the
-     * per-arch overrides this replaced. Honoring the parameter end-to-end is follow-up work.
+     * @param noc_id NOC to route through (if the feature is routed through NOC).
      */
     void set_clock_state(ClockState state, NocId noc_id = NocId::DEFAULT_NOC);
 

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -144,7 +144,7 @@ DeviceCommandResult BlackholeDeviceFirmware::send_device_command(
     return DeviceCommandResult{exit_code, std::move(return_values)};
 }
 
-void BlackholeDeviceFirmware::set_power_state(PowerState state, NocId noc_id) {
+void BlackholeDeviceFirmware::set_power_state(PowerState state, [[maybe_unused]] NocId noc_id) {
     // Power domains are only controllable over PCIe; JTAG and remote devices have no PcieInterface,
     // which matches what TTDevice::set_power_state did by returning early for them.
     if (pcie_interface_ == nullptr) {
@@ -217,6 +217,12 @@ void BlackholeDeviceFirmware::log_aiclk_timeout_warning(
 
 void BlackholeDeviceFirmware::wait_for_aiclk_value(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms) {
     constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
+
+    // read_entry() throws a bare error on a missing entry; check availability up front and fail
+    // with the message the deleted get_clock() path used.
+    if (!firmware_telemetry_reader_->is_entry_available(TelemetryTag::AICLK)) {
+        UMD_THROW(error::RuntimeError, "AICLK telemetry not available for Blackhole device.");
+    }
 
     uint32_t aiclk = 0;
     const bool settled = utils::poll_until(
@@ -354,6 +360,11 @@ bool BlackholeDeviceFirmware::get_noc_translation_enabled(NocId /*noc_id*/) {
 }
 
 tt_xy_pair BlackholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    // Only the two data NOCs have an ARC coordinate; SYSTEM_NOC routing has no meaning here.
+    UMD_ASSERT(
+        noc_id == NocId::NOC0 || noc_id == NocId::NOC1,
+        error::RuntimeError,
+        "get_firmware_noc_coord expects NOC0 or NOC1.");
     return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
 }
 
@@ -383,6 +394,12 @@ EthTrainingStatus BlackholeDeviceFirmware::get_eth_core_training_status(tt_xy_pa
 
 bool BlackholeDeviceFirmware::wait_dram_channel_training(
     uint32_t dram_channel, std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // The status comes from the info provider, which exists only once init_firmware() has run; the
+    // deleted TTDevice path threw the same error through its facade getter.
+    if (firmware_info_provider_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, get_io_device_type(), device_id_, tt::ARCH::BLACKHOLE);
+    }
+
     const uint32_t dram_banks_number = architecture_impl_->get_dram_banks_number();
     if (dram_channel >= dram_banks_number) {
         UMD_THROW(

--- a/device/tt_device/firmware/wormhole_arc_window.cpp
+++ b/device/tt_device/firmware/wormhole_arc_window.cpp
@@ -6,6 +6,8 @@
 
 #include <fmt/format.h>
 
+#include <cstring>
+
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
@@ -123,8 +125,10 @@ void WormholeArcWindow::read(void* mem_ptr, uint64_t arc_addr_offset, size_t siz
         device_protocol_->read_ctrl(mem_ptr, arc_core, noc_address, sizeof(uint32_t), noc_id);
         return;
     }
-    auto result = pcie_interface_->bar_read32(config_.bar0_offset_start + arc_addr_offset);
-    *(reinterpret_cast<uint32_t*>(mem_ptr)) = result;
+    // memcpy rather than a type-punning cast: the caller's buffer need not be a live uint32_t
+    // object, and the word-size check above already pins the transfer size.
+    const uint32_t result = pcie_interface_->bar_read32(config_.bar0_offset_start + arc_addr_offset);
+    std::memcpy(mem_ptr, &result, sizeof(result));
 }
 
 void WormholeArcWindow::write(
@@ -144,8 +148,9 @@ void WormholeArcWindow::write(
         device_protocol_->write_ctrl(mem_ptr, arc_core, noc_address, sizeof(uint32_t), noc_id);
         return;
     }
-    pcie_interface_->bar_write32(
-        config_.bar0_offset_start + arc_addr_offset, *(reinterpret_cast<const uint32_t*>(mem_ptr)));
+    uint32_t value = 0;
+    std::memcpy(&value, mem_ptr, sizeof(value));
+    pcie_interface_->bar_write32(config_.bar0_offset_start + arc_addr_offset, value);
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -335,6 +335,15 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
             exit_code = (status & 0xffff0000) >> 16;
             break;
         } else if (status == HANG_READ_VALUE) {
+            // 0xFFFFFFFF in the status register is ambiguous: firmware that does not recognize the
+            // message, or a dead bus answering all-ones to every read. Probe the hang-check register
+            // right here to tell them apart, rather than only at the end of the call.
+            if (pcie_interface_ != nullptr &&
+                pcie_interface_->bar_read32(get_architecture_registers(tt::ARCH::WORMHOLE_B0).noc_node_id_bar_offset) ==
+                    HANG_READ_VALUE) {
+                UMD_THROW(
+                    error::PcieHangError, get_io_device_type(), device_id_, tt::ARCH::WORMHOLE_B0, HANG_READ_VALUE);
+            }
             log_warning(LogUMD, "On device {}, message code {:#x} not recognized by FW", device_id_, msg_code);
             exit_code = HANG_READ_VALUE;
             break;
@@ -354,7 +363,7 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
     return DeviceCommandResult{exit_code, std::move(return_values)};
 }
 
-void WormholeDeviceFirmware::set_power_state(PowerState state, NocId noc_id) {
+void WormholeDeviceFirmware::set_power_state(PowerState state, [[maybe_unused]] NocId noc_id) {
     // Power domains are only controllable over PCIe; JTAG and remote devices have no PcieInterface,
     // which matches what TTDevice::set_power_state did by returning early for them.
     if (pcie_interface_ == nullptr) {
@@ -505,6 +514,11 @@ ChipInfo WormholeDeviceFirmware::get_chip_info(NocId noc_id) {
 }
 
 tt_xy_pair WormholeDeviceFirmware::get_firmware_noc_coord(NocId noc_id) const {
+    // Only the two data NOCs have an ARC coordinate; SYSTEM_NOC routing has no meaning here.
+    UMD_ASSERT(
+        noc_id == NocId::NOC0 || noc_id == NocId::NOC1,
+        error::RuntimeError,
+        "get_firmware_noc_coord expects NOC0 or NOC1.");
     return noc_id == NocId::NOC1 ? arc_core_noc1_ : arc_core_noc0_;
 }
 
@@ -568,6 +582,12 @@ EthTrainingStatus WormholeDeviceFirmware::get_eth_core_training_status(tt_xy_pai
 
 bool WormholeDeviceFirmware::wait_dram_channel_training(
     uint32_t dram_channel, std::chrono::milliseconds timeout_ms, NocId noc_id) {
+    // The status comes from the info provider, which exists only once init_firmware() has run; the
+    // deleted TTDevice path threw the same error through its facade getter.
+    if (firmware_info_provider_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, get_io_device_type(), device_id_, tt::ARCH::WORMHOLE_B0);
+    }
+
     const uint32_t dram_banks_number = architecture_impl_->get_dram_banks_number();
     if (dram_channel >= dram_banks_number) {
         UMD_THROW(

--- a/tests/baremetal/test_wormhole_arc_window.cpp
+++ b/tests/baremetal/test_wormhole_arc_window.cpp
@@ -47,10 +47,10 @@ protected:
 // Which interface is present is how the window picks its route, so it cannot be built with an
 // ambiguous set. Giving none leaves no route at all; giving two makes the null checks meaningless.
 TEST_F(WormholeArcApbWindowTest, RequiresExactlyOneTransport) {
-    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, nullptr), std::exception);
-    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, &jtag_, nullptr), std::exception);
-    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, &remote_), std::exception);
-    EXPECT_THROW(WormholeArcWindow::arc_apb(nullptr, &pcie_, nullptr, nullptr), std::exception);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, nullptr, nullptr, nullptr), error::UmdBaseException);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, &jtag_, nullptr), error::UmdBaseException);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(&protocol_, &pcie_, nullptr, &remote_), error::UmdBaseException);
+    EXPECT_THROW(WormholeArcWindow::arc_apb(nullptr, &pcie_, nullptr, nullptr), error::UmdBaseException);
 }
 
 // A remote device is reached over the NOC, and the APB window holds registers, so the access has to
@@ -123,12 +123,12 @@ TEST_F(WormholeArcApbWindowTest, NonWordSizeIsRejectedOnTheWordSizedRoutes) {
     uint32_t value = 0;
 
     auto pcie_window = over_pcie();
-    EXPECT_THROW(pcie_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
-    EXPECT_THROW(pcie_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(pcie_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), error::UmdBaseException);
+    EXPECT_THROW(pcie_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), error::UmdBaseException);
 
     auto jtag_window = over_jtag();
-    EXPECT_THROW(jtag_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), std::exception);
-    EXPECT_THROW(jtag_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(jtag_window.read(&value, APB_OFFSET, 2, ARC_CORE, NocId::NOC0), error::UmdBaseException);
+    EXPECT_THROW(jtag_window.write(&value, APB_OFFSET, 8, ARC_CORE, NocId::NOC0), error::UmdBaseException);
 }
 
 // The window bound covers the whole transfer, not just its first byte: a word access starting at
@@ -143,11 +143,12 @@ TEST_F(WormholeArcApbWindowTest, AccessMustFitEntirelyInsideTheWindow) {
 
     // Starts inside the window but runs past its end.
     EXPECT_THROW(
-        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0),
+        error::UmdBaseException);
     // Starts at the first byte past the window.
-    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), error::UmdBaseException);
     // Starts at zero but is larger than the whole window.
-    EXPECT_THROW(window.read(&value, 0, WINDOW_SIZE + 1, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(window.read(&value, 0, WINDOW_SIZE + 1, ARC_CORE, NocId::NOC0), error::UmdBaseException);
 
     // The last word that fits ends exactly on the window's last byte.
     EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _));
@@ -158,8 +159,8 @@ TEST_F(WormholeArcApbWindowTest, ZeroLengthAccessIsRejected) {
     auto window = over_remote();
     uint32_t value = 0;
 
-    EXPECT_THROW(window.read(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), std::exception);
-    EXPECT_THROW(window.write(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(window.read(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), error::UmdBaseException);
+    EXPECT_THROW(window.write(&value, APB_OFFSET, 0, ARC_CORE, NocId::NOC0), error::UmdBaseException);
 }
 
 // Arbitrary offset inside the window, not a hardware-defined location.
@@ -242,9 +243,10 @@ TEST_F(WormholeArcCsmWindowTest, AccessIsBoundedByTheCsmWindow) {
     uint32_t value = 0;
 
     constexpr uint64_t WINDOW_SIZE = static_cast<uint64_t>(wormhole::ARC_CSM_ADDRESS_RANGE) + 1;
-    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+    EXPECT_THROW(window.read(&value, WINDOW_SIZE, sizeof(value), ARC_CORE, NocId::NOC0), error::UmdBaseException);
     EXPECT_THROW(
-        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0), std::exception);
+        window.read(&value, WINDOW_SIZE - sizeof(value) + 1, sizeof(value), ARC_CORE, NocId::NOC0),
+        error::UmdBaseException);
 
     EXPECT_CALL(protocol_, read_data(_, _, _, _, _));
     window.read(&value, WINDOW_SIZE - sizeof(value), sizeof(value), ARC_CORE, NocId::NOC0);


### PR DESCRIPTION
### Issue
#2872

### Description
The items queued from the review threads of the DeviceFirmware stack (#3322, #3323, #3324, #3325, #3332, #3344, #3346) plus the deferred `HANG_READ_VALUE` comment — collected into one hardening PR now that the stack is on main. No happy-path behavior changes.

### List of the changes
- Eager dead-bus detection (from the #3322 thread): `WormholeDeviceFirmware::send_device_command` probes the hang-check register inside the `HANG_READ_VALUE` branch and throws `PcieHangError` there. Previously a dead bus was first logged as "message code not recognized" and only caught by the post-message tripwire; the tripwire stays, the distinction just happens at detection time.
- Pre-init guards: `wait_dram_channel_training` throws `UninitializedDeviceError` on both architectures instead of dereferencing the null info provider — the deleted `TTDevice` path threw the same error through its facade getter.
- AICLK availability: Blackhole's settle poll checks `is_entry_available(AICLK)` up front and fails with the deleted `get_clock()` message instead of `read_entry`'s bare throw.
- Strict aliasing: `WormholeArcWindow`'s BAR routes use `memcpy` instead of type-punning casts.
- SYSTEM_NOC: `get_firmware_noc_coord` asserts NOC0/NOC1 instead of silently treating anything non-NOC1 as NOC0.
- Docs/annotations: `set_power_state` and `set_clock_state` document `noc_id` as plain API surface — "NOC to route through (if the feature is routed through NOC)"; unused parameters marked `[[maybe_unused]]` at the definitions (where the warning fires); the window tests assert `error::UmdBaseException` rather than any `std::exception`.

### Testing
`baremetal_tests` 254/254 (window suite included), simulation on and off, pre-commit clean against main; CI.

### API Changes
This PR has no API changes.