### PR TITLE
Add UBB_BLACKHOLE_BIN6 board type for Bin6 Galaxy DRAM harvesting

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.hpp
+++ b/device/api/umd/device/types/cluster_descriptor_types.hpp
@@ -36,6 +36,8 @@ enum BoardType : uint32_t {
     UBB_BLACKHOLE,
     QUASAR_BOARD,
     UNKNOWN,
+    // Appended after UNKNOWN so the values above keep their numbering/ABI.
+    UBB_BLACKHOLE_BIN6,
 };
 
 static_assert(N150 == 3, "N150 must be 3");
@@ -49,6 +51,7 @@ static_assert(UBB_WORMHOLE == 9, "WH_UBB must equal UBB");
 static_assert(UBB_BLACKHOLE == 10, "BH_UBB must be 10");
 static_assert(QUASAR_BOARD == 11, "QUASAR must be 11");
 static_assert(UNKNOWN == 12, "UNKNOWN must be 12");
+static_assert(UBB_BLACKHOLE_BIN6 == 13, "BH_UBB_BIN6 must be 13");
 
 // Small performant hash combiner taken from boost library.
 // Not using boost::hash_combine due to dependency complications.
@@ -101,6 +104,7 @@ inline const std::unordered_map<std::string_view, BoardType> board_type_name_map
     {"p300", BoardType::P300},
     {"ubb", BoardType::UBB},
     {"ubb_blackhole", BoardType::UBB_BLACKHOLE},
+    {"ubb_blackhole_bin6", BoardType::UBB_BLACKHOLE_BIN6},
     {"ubb_wormhole", BoardType::UBB_WORMHOLE},
     {"quasar", BoardType::QUASAR_BOARD},
     {"unknown", BoardType::UNKNOWN},
@@ -120,6 +124,7 @@ inline const std::unordered_map<BoardType, std::string_view> board_type_canonica
     {BoardType::P300, "p300"},
     {BoardType::UBB, "ubb"},
     {BoardType::UBB_BLACKHOLE, "ubb_blackhole"},
+    {BoardType::UBB_BLACKHOLE_BIN6, "ubb_blackhole_bin6"},
     {BoardType::UBB_WORMHOLE, "ubb_wormhole"},
     {BoardType::QUASAR_BOARD, "quasar"},
     {BoardType::UNKNOWN, "unknown"},
@@ -190,6 +195,7 @@ inline uint32_t get_number_of_chips_from_board_type(const BoardType board_type) 
         // TODO: switch usage of UBB to UBB_WORMHOLE.
         case BoardType::UBB:
         case BoardType::UBB_BLACKHOLE:
+        case BoardType::UBB_BLACKHOLE_BIN6:
             return 32;
         case BoardType::QUASAR_BOARD:  // Mock device only
             return 1;
@@ -212,6 +218,7 @@ inline const std::unordered_map<uint64_t, BoardType> board_upi_map = {
     // TODO: move 0x35 constant to be equal to UBB_WORMHOLE once we delete UBB.
     {0x35, BoardType::UBB},
     {0x47, BoardType::UBB_BLACKHOLE},
+    {0x202, BoardType::UBB_BLACKHOLE_BIN6},
     {0x50, BoardType::QUASAR_BOARD}};  // Fictional board UPI for Quasar mock device
 
 inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
@@ -233,6 +240,7 @@ static const std::unordered_map<BoardType, uint32_t> expected_tensix_harvested_u
     {BoardType::P300, 2},
     {BoardType::UBB, 0},
     {BoardType::UBB_BLACKHOLE, 1},
+    {BoardType::UBB_BLACKHOLE_BIN6, 1},
 };
 
 static const std::unordered_map<BoardType, uint32_t> expected_dram_harvested_units_map = {
@@ -243,6 +251,9 @@ static const std::unordered_map<BoardType, uint32_t> expected_dram_harvested_uni
     {BoardType::P300, 0},
     {BoardType::UBB, 0},
     {BoardType::UBB_BLACKHOLE, 0},
+    // Bin6 parts ship with one GDDR channel harvested; that is the sole
+    // difference from the chips populating a UBB_BLACKHOLE.
+    {BoardType::UBB_BLACKHOLE_BIN6, 1},
 };
 
 static const std::unordered_map<BoardType, uint32_t> expected_eth_harvested_units_map = {
@@ -253,6 +264,7 @@ static const std::unordered_map<BoardType, uint32_t> expected_eth_harvested_unit
     {BoardType::P300, 2},
     {BoardType::UBB, 0},
     {BoardType::UBB_BLACKHOLE, 2},
+    {BoardType::UBB_BLACKHOLE_BIN6, 2},
 };
 
 struct HarvestingMasks {

--- a/device/api/umd/device/types/cluster_descriptor_types.hpp
+++ b/device/api/umd/device/types/cluster_descriptor_types.hpp
@@ -34,10 +34,9 @@ enum BoardType : uint32_t {
     UBB,
     UBB_WORMHOLE = UBB,
     UBB_BLACKHOLE,
+    UBB_BLACKHOLE_BIN6,
     QUASAR_BOARD,
     UNKNOWN,
-    // Appended after UNKNOWN so the values above keep their numbering/ABI.
-    UBB_BLACKHOLE_BIN6,
 };
 
 static_assert(N150 == 3, "N150 must be 3");
@@ -49,9 +48,9 @@ static_assert(GALAXY == 8, "GALAXY must be 8");
 static_assert(UBB == 9, "UBB must be 9");
 static_assert(UBB_WORMHOLE == 9, "WH_UBB must equal UBB");
 static_assert(UBB_BLACKHOLE == 10, "BH_UBB must be 10");
-static_assert(QUASAR_BOARD == 11, "QUASAR must be 11");
-static_assert(UNKNOWN == 12, "UNKNOWN must be 12");
-static_assert(UBB_BLACKHOLE_BIN6 == 13, "BH_UBB_BIN6 must be 13");
+static_assert(UBB_BLACKHOLE_BIN6 == 11, "BH_UBB_BIN6 must be 11");
+static_assert(QUASAR_BOARD == 12, "QUASAR must be 12");
+static_assert(UNKNOWN == 13, "UNKNOWN must be 13");
 
 // Small performant hash combiner taken from boost library.
 // Not using boost::hash_combine due to dependency complications.

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1399,6 +1399,7 @@ std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
         case BoardType::UBB_WORMHOLE:
             return ubb_tray_id(wormhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
         case BoardType::UBB_BLACKHOLE:
+        case BoardType::UBB_BLACKHOLE_BIN6:
             return ubb_tray_id(blackhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
         default:
             return std::nullopt;

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -178,7 +178,8 @@ void TopologyDiscoveryBlackhole::patch_eth_connections() {
 }
 
 void TopologyDiscoveryBlackhole::init_first_device(TTDevice* tt_device) {
-    is_running_on_6u = tt_device->get_board_type() == BoardType::UBB_BLACKHOLE;
+    const BoardType board_type = tt_device->get_board_type();
+    is_running_on_6u = board_type == BoardType::UBB_BLACKHOLE || board_type == BoardType::UBB_BLACKHOLE_BIN6;
 }
 
 uint64_t TopologyDiscoveryBlackhole::get_unconnected_device_id(TTDevice* tt_device) {

--- a/nanobind/py_api_basic_types.cpp
+++ b/nanobind/py_api_basic_types.cpp
@@ -121,6 +121,7 @@ void bind_basic_types(nb::module_ &m) {
         .value("UBB", tt::BoardType::UBB)
         .value("UBB_WORMHOLE", tt::BoardType::UBB_WORMHOLE)
         .value("UBB_BLACKHOLE", tt::BoardType::UBB_BLACKHOLE)
+        .value("UBB_BLACKHOLE_BIN6", tt::BoardType::UBB_BLACKHOLE_BIN6)
         .value("QUASAR", tt::BoardType::QUASAR_BOARD)
         .value("UNKNOWN", tt::BoardType::UNKNOWN)
         .def("__str__", &tt::board_type_to_string)

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -128,7 +128,7 @@ TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
         EXPECT_TRUE(
             board_type == BoardType::N150 || board_type == BoardType::N300 || board_type == BoardType::P100 ||
             board_type == BoardType::P150 || board_type == BoardType::P300 || board_type == BoardType::UBB ||
-            board_type == BoardType::UBB_BLACKHOLE);
+            board_type == BoardType::UBB_BLACKHOLE || board_type == BoardType::UBB_BLACKHOLE_BIN6);
 
         tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -28,7 +28,8 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
 
         EXPECT_TRUE(
             chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150 ||
-            chip_info.board_type == BoardType::P300 || chip_info.board_type == BoardType::UBB_BLACKHOLE);
+            chip_info.board_type == BoardType::P300 || chip_info.board_type == BoardType::UBB_BLACKHOLE ||
+            chip_info.board_type == BoardType::UBB_BLACKHOLE_BIN6);
 
         switch (chip_info.board_type) {
             case BoardType::P100:
@@ -40,7 +41,8 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
                 EXPECT_TRUE(chip_info.asic_location <= 1);
                 break;
             }
-            case BoardType::UBB_BLACKHOLE: {
+            case BoardType::UBB_BLACKHOLE:
+            case BoardType::UBB_BLACKHOLE_BIN6: {
                 EXPECT_TRUE(chip_info.asic_location <= 8);
                 break;
             }

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -109,7 +109,8 @@ private:
 inline bool is_galaxy_configuration(Cluster* cluster) {
     return !cluster->get_target_device_ids().empty() &&
            (cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_WORMHOLE ||
-            cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_BLACKHOLE);
+            cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_BLACKHOLE ||
+            cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_BLACKHOLE_BIN6);
 }
 
 // Returns the top-left (lowest x, lowest y) and bottom-right (highest x, highest y) TENSIX cores


### PR DESCRIPTION
### Issue
#3178 

### Description
UBB_BLACKHOLE always expects 0 DRAM harvested units, so a Bin6 Galaxy with 1 GDDR channel harvested reports as inconsistent on every chip during ClusterDescriptor construction, even though the configuration is valid. Bin6 is a distinct SKU with its own board ID, so it gets its own BoardType rather than a change to the existing expectation.

### List of the changes
 - Added BoardType::UBB_BLACKHOLE_BIN6
 - Mapped UPI 0x202 to the new board type in board_upi_map
 - Added name map entries, chip count, and expected tensix/dram/eth harvested unit entries for the new board type
 - Updated get_tray_id, is_running_on_6u, and the nanobind BoardType enum to treat UBB_BLACKHOLE_BIN6 like UBB_BLACKHOLE
  - According test updates

### Testing
Ci only, needs to be tested on bin6 glx.

### API Changes
New BoardType enum value
