### PR TITLE
[Base API] Delete configure_iatu_region: dead since KMD took over iATU programming

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <set>
 
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -24,10 +23,6 @@ enum class IODeviceType;
 
 class BlackholeTTDevice : public TTDevice {
 public:
-    ~BlackholeTTDevice() override;
-
-    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
-
     uint32_t get_clock() override;
 
     uint32_t get_min_clock_freq() override;
@@ -41,9 +36,6 @@ private:
         IODeviceType device_type,
         bool use_safe_api,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-
-    static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1000;
-    std::set<size_t> iatu_regions_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -284,34 +284,6 @@ public:
      */
     virtual void noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
 
-    /**
-     * Configures a PCIe Address Translation Unit (iATU) region.
-     *
-     * Device software expects to be able to access memory that is shared with
-     * the host using the following NOC addresses at the PCIe core:
-     * - GS: 0x0
-     * - WH: 0x8_0000_0000
-     * - BH: 0x1000_0000_0000_0000
-     * Without iATU configuration, these map to host PA 0x0.
-     *
-     * While modern hardware supports IOMMU with flexible IOVA mapping, we must
-     * maintain the iATU configuration to satisfy software that has hard-coded
-     * the above NOC addresses rather than using driver-provided IOVAs.
-     *
-     * This interface is only intended to be used for configuring sysmem with
-     * either 1GB hugepages or a compatible scheme.
-     *
-     * @param region iATU region index (0-15)
-     * @param target DMA address (PA or IOVA) to map to
-     * @param region_size size of the mapping window; must be (1 << 30)
-     *
-     * NOTE: Programming the iATU from userspace is architecturally incorrect:
-     * - iATU should be managed by KMD to ensure proper cleanup on process exit
-     * - Multiple processes can corrupt each other's iATU configurations
-     * We should fix this!
-     */
-    virtual void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
-
     ChipInfo get_chip_info();
 
     FirmwareBundleVersion get_firmware_version();

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -68,7 +68,10 @@ public:
     // Configure this chip's outbound iATU (NOC->host) the silicon way: iATU register writes via BAR2.
     // The simulator decodes these into its iATU model and honors them at DMA egress, so the chip's DMA
     // resolves to this chip's distinct host base (configured as the region target) purely by address.
-    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
+    // TTSim's simulated-iATU programming, used by its own sysmem setup. No longer a TTDevice
+    // override: the facade dropped configure_iatu_region (nothing external calls it), so this is
+    // now a detail of this backend.
+    void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
 
     void close_device();
     void start_device();

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <mutex>
 
-#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -24,8 +23,6 @@ enum class IODeviceType;
 
 class WormholeTTDevice : public TTDevice {
 public:
-    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
-
     uint32_t get_clock() override;
 
     uint32_t get_min_clock_freq() override;
@@ -36,10 +33,6 @@ protected:
     explicit WormholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
 private:
-    const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::WORMHOLE_B0);
-
-    // Builds the ARC message (with the common prefix) that requests the given clock state.
-
     friend std::unique_ptr<TTDevice> TTDevice::create(
         int device_number,
         IODeviceType device_type,

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -5,7 +5,6 @@
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
 
 #include <fmt/format.h>
-#include <sys/mman.h>  // for MAP_FAILED
 
 #include <chrono>
 #include <memory>
@@ -42,78 +41,6 @@
 namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) : TTDevice(std::move(model)) {}
-
-BlackholeTTDevice::~BlackholeTTDevice() {
-    // Turn off iATU for the regions we programmed.  This won't happen if the
-    // application crashes -- this is a good example of why userspace should not
-    // be touching this hardware resource directly -- but it's a good idea to
-    // clean up after ourselves.
-    if (get_communication_device_type() != IODeviceType::PCIe) {
-        return;
-    }
-    if (get_pci_device()->bar2_uc != nullptr && get_pci_device()->bar2_uc != MAP_FAILED) {
-        auto *bar2 = static_cast<volatile uint8_t *>(get_pci_device()->bar2_uc);
-
-        for (size_t region : iatu_regions_) {
-            uint64_t iatu_base = ATU_OFFSET_IN_BH_BAR2 + (region * 0x200);
-            uint64_t region_ctrl_2 = 0;
-            *reinterpret_cast<volatile uint32_t *>(bar2 + iatu_base + 0x04) = region_ctrl_2;
-        }
-    }
-}
-
-void BlackholeTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
-    uint64_t base = region * region_size;
-    uint64_t iatu_base = ATU_OFFSET_IN_BH_BAR2 + (region * 0x200);
-    auto *bar2 = static_cast<volatile uint8_t *>(get_pci_device()->bar2_uc);
-
-    if (region_size % (1ULL << 30) != 0 || region_size > (1ULL << 32)) {
-        // If you hit this, the suggestion is to not use iATU: map your buffer
-        // with the driver, and use the IOVA it provides in your device code.
-        UMD_THROW(
-            error::RuntimeError, "Failed constraint: region_size % (1ULL << 30) == 0; region_size <= (1ULL <<32).");
-    }
-
-    if (bar2 == nullptr || bar2 == MAP_FAILED) {
-        UMD_THROW(error::RuntimeError, "BAR2 not mapped.");
-    }
-
-    auto write_iatu_reg = [bar2](uint64_t offset, uint32_t value) {
-        *reinterpret_cast<volatile uint32_t *>(bar2 + offset) = value;
-    };
-
-    uint64_t limit = (base + (region_size - 1)) & 0xffff'ffff;
-    uint32_t base_lo = (base >> 0x00) & 0xffff'ffff;
-    uint32_t base_hi = (base >> 0x20) & 0xffff'ffff;
-    uint32_t target_lo = (target >> 0x00) & 0xffff'ffff;
-    uint32_t target_hi = (target >> 0x20) & 0xffff'ffff;
-
-    uint32_t region_ctrl_1 = 0;
-    uint32_t region_ctrl_2 = 1 << 31;  // REGION_EN
-    uint32_t region_ctrl_3 = 0;
-    uint32_t limit_hi = 0;
-
-    write_iatu_reg(iatu_base + 0x00, region_ctrl_1);
-    write_iatu_reg(iatu_base + 0x04, region_ctrl_2);
-    write_iatu_reg(iatu_base + 0x08, base_lo);
-    write_iatu_reg(iatu_base + 0x0c, base_hi);
-    write_iatu_reg(iatu_base + 0x10, limit);
-    write_iatu_reg(iatu_base + 0x14, target_lo);
-    write_iatu_reg(iatu_base + 0x18, target_hi);
-    write_iatu_reg(iatu_base + 0x1c, limit_hi);
-    write_iatu_reg(iatu_base + 0x20, region_ctrl_3);
-
-    iatu_regions_.insert(region);
-
-    log_debug(
-        LogUMD,
-        "Device: {} Mapped iATU region {} from 0x{:x} to 0x{:x} to 0x{:x}",
-        this->get_pci_device()->get_device_num(),
-        region,
-        base,
-        limit,
-        target);
-}
 
 uint32_t BlackholeTTDevice::get_clock() {
     if (get_firmware_telemetry_reader()->is_entry_available(TelemetryTag::AICLK)) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -441,10 +441,6 @@ void TTDevice::write_to_device_reg(const void *mem_ptr, CoreCoord core, uint64_t
     get_device_protocol()->write_ctrl(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
 }
 
-void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
-    UMD_THROW(error::RuntimeError, "configure_iatu_region is not implemented for this device.");
-}
-
 void TTDevice::wait_dram_channel_training(const uint32_t dram_channel, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     get_device_firmware()->wait_dram_channel_training(dram_channel, timeout_ms, get_selected_noc_id());

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -370,7 +370,8 @@ void TTSimTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t
     wr(0x10, uint32_t(limit));         // limit (low 32b; upper bits share base hi)
     wr(0x14, uint32_t(target));        // target lo
     wr(0x18, uint32_t(target >> 32));  // target hi
-    // Note: unlike BlackholeTTDevice::configure_iatu_region we do NOT write limit_hi (0x1c) or
+    // Note: unlike the silicon Blackhole iATU programming this models (retired unused; see git
+    // history), we do NOT write limit_hi (0x1c) or
     // region_ctrl_3 (0x20): the deployed ttsim iATU model does not implement those register offsets
     // (a write throws UnimplementedFunctionality). It's safe to omit them here -- the region top is
     // asserted to stay within 4 GiB (limit_hi is always 0) and regions are programmed once at init, not

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -57,42 +57,4 @@ uint32_t WormholeTTDevice::get_clock() {
 
 uint32_t WormholeTTDevice::get_min_clock_freq() { return get_architecture_implementation()->get_min_clock_freq(); }
 
-void WormholeTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
-    uint32_t dest_bar_lo = target & 0xffffffff;
-    uint32_t dest_bar_hi = (target >> 32) & 0xffffffff;
-    std::uint32_t region_id_to_use = region;
-
-    // TODO: stop doing this.  It's related to HUGEPAGE_CHANNEL_3_SIZE_LIMIT.
-    if (region == 3) {
-        region_id_to_use = 4;  // Hack use region 4 for channel 3..this ensures that we have a smaller chan 3 address
-                               // space with the correct start offset
-    }
-
-    if (get_communication_device_type() == IODeviceType::JTAG) {
-        UMD_THROW(error::RuntimeError, "configure_iatu_region is redundant for JTAG communication type.");
-    }
-
-    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 0 * 4, region_id_to_use);
-    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 1 * 4, dest_bar_lo);
-    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 2 * 4, dest_bar_hi);
-    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 3 * 4, region_size);
-    get_device_firmware()->send_device_command(
-        wormhole::ARC_MSG_COMMON_PREFIX |
-            static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER),
-        {0, 0},
-        timeout::ARC_MESSAGE_TIMEOUT,
-        get_selected_noc_id());
-
-    // Print what just happened.
-    uint32_t peer_region_start = region_id_to_use * region_size;
-    uint32_t peer_region_end = (region_id_to_use + 1) * region_size - 1;
-    log_debug(
-        LogUMD,
-        "    [region id {}] NOC to PCI address range 0x{:x}-0x{:x} mapped to addr 0x{:x}",
-        region,
-        peer_region_start,
-        peer_region_end,
-        target);
-}
-
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
#2872

### Description
`configure_iatu_region` kept per-arch `TTDevice` subclasses alive — but it is dead code, deliberately so: its only caller, `LocalChip::init_pcie_iatus()`, was removed by #3170 (issue #2747, "new KMD supersedes the need to do this in userspace" — KMD programs the mapping at page-pinning time), and `PCIDevice` enforces `KMD_MINIMUM_VERSION = 2.0.0` at construction, so the userspace iATU path is unreachable in every supported configuration. No client uses it (verified across tt-metal, nanobind, tools and tests; tt-metal has only prose comments about iATU address ranges). Pure deletion, no replacement surface; recover from history if userspace ever needs to program the iATU again.

### List of the changes
- `TTDevice::configure_iatu_region` deleted (base body and the Wormhole/Blackhole overrides).
- The Wormhole variant (firmware-assisted via `SETUP_IATU_FOR_PEER_TO_PEER`) and the Blackhole variant (direct DWC iATU registers in BAR2) deleted, together with Blackhole's destructor cleanup and region bookkeeping.
- TTSim's simulated-iATU method stops being an override and becomes a private detail of that backend — it models what the KMD does on silicon and is only called from its own sysmem setup.

Net: −154 lines.

### Testing
Builds with simulation ON and OFF; `baremetal_tests` 254/254; CI.

### API Changes
This PR has API changes: `TTDevice::configure_iatu_region` is removed (dead since #3170, no known users).