### PR TITLE
Make the tests batching-safe and enable unity builds on the merge queue

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -16,6 +16,13 @@ on:
           Enable sccache compiler caching.
         type: boolean
         default: true
+      enable-unity-build:
+        required: false
+        description: >-
+          Batch sources into unity translation units. Always on in the merge queue; this
+          input only exists so a dispatch can reproduce or measure that configuration.
+        type: boolean
+        default: false
   # Runs on all standard code-review and integration events: PR, merge queue, and post-merge on main.
   pull_request:
   merge_group:
@@ -48,6 +55,12 @@ env:
   CREATE_MAP_BINARIES_DIR: ./device/bin/silicon
   INSTALL_OUTPUT_DIR: ./install
   WHEEL_OUTPUT_DIR: ./build/wheel
+  # Batch sources into unity translation units, for the merge queue only.
+  # Merge-queue runs read the cache off main read-only and get almost nothing from it
+  # (measured: 19m14s of Build All against 19m41s with no cache at all), so they are the
+  # builds worth batching. Pushes to main write the cache and do get value from it, so
+  # they stay per-file, as do the wheel jobs that package what we ship.
+  TT_UMD_UNITY: ${{ (github.event_name == 'merge_group' || inputs.enable-unity-build) && 'ON' || 'OFF' }}
 
 jobs:
   # Skips the heavy sweep on PRs (a build already runs as part of the tests) but
@@ -259,6 +272,7 @@ jobs:
               -DTT_UMD_BUILD_EXAMPLES=OFF \
               -DTT_UMD_ENABLE_CLANG_TIDY=ON \
               -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
+              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
               -DCMAKE_BUILD_TYPE=Release
           else
             cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
@@ -266,6 +280,7 @@ jobs:
               -DTT_UMD_BUILD_PIP=ON \
               -DTT_UMD_ENABLE_CLANG_TIDY=ON \
               -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
+              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
               -DTT_UMD_ENABLE_TRACY=ON
           fi
           cmake --build ${{ env.BUILD_OUTPUT_DIR }}
@@ -378,6 +393,7 @@ jobs:
             -DTT_UMD_BUILD_ALL=ON \
             -DTT_UMD_BUILD_PIP=OFF \
             -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
+            -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
             -DTT_UMD_ENABLE_CLANG_TIDY=ON
           cmake --build ${{ env.BUILD_OUTPUT_DIR }}
           echo "Compile complete."
@@ -450,6 +466,7 @@ jobs:
                 -DTT_UMD_BUILD_PYTHON=ON \
                 -DTT_UMD_BUILD_EXAMPLES=OFF \
                 -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
+                -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
                 -DCMAKE_BUILD_TYPE=Release
               cmake --build ${{ env.BUILD_OUTPUT_DIR }}
               echo "Compile complete."

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -19,8 +19,8 @@ on:
       enable-unity-build:
         required: false
         description: >-
-          Batch sources into unity translation units. Always on in the merge queue; this
-          input only exists so a dispatch can reproduce or measure that configuration.
+          Batch sources into unity translation units. On for every automatic event; this
+          input exists so a dispatch can turn it off and measure against it.
         type: boolean
         default: false
   # Runs on all standard code-review and integration events: PR, merge queue, and post-merge on main.
@@ -55,12 +55,12 @@ env:
   CREATE_MAP_BINARIES_DIR: ./device/bin/silicon
   INSTALL_OUTPUT_DIR: ./install
   WHEEL_OUTPUT_DIR: ./build/wheel
-  # Batch sources into unity translation units, for the merge queue only.
-  # Merge-queue runs read the cache off main read-only and get almost nothing from it
-  # (measured: 19m14s of Build All against 19m41s with no cache at all), so they are the
-  # builds worth batching. Pushes to main write the cache and do get value from it, so
-  # they stay per-file, as do the wheel jobs that package what we ship.
-  TT_UMD_UNITY: ${{ (github.event_name == 'merge_group' || inputs.enable-unity-build) && 'ON' || 'OFF' }}
+  # Batch sources into unity translation units. On for every triggering event, so PRs, the
+  # merge queue and main all compile the same way - a batching-only failure should show up on
+  # the PR that introduced it, not when the merge queue happens to build differently. Same
+  # shape as SCCACHE_GHA_ENABLED below: the `inputs` context only exists for
+  # workflow_dispatch, so a dispatch is the one way to turn this off and A/B it.
+  TT_UMD_UNITY_ENABLED: ${{ github.event_name != 'workflow_dispatch' || inputs.enable-unity-build }}
 
 jobs:
   # Skips the heavy sweep on PRs (a build already runs as part of the tests) but
@@ -272,7 +272,7 @@ jobs:
               -DTT_UMD_BUILD_EXAMPLES=OFF \
               -DTT_UMD_ENABLE_CLANG_TIDY=ON \
               -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
-              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
+              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY_ENABLED == 'true' && 'ON' || 'OFF' }} \
               -DCMAKE_BUILD_TYPE=Release
           else
             cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
@@ -280,7 +280,7 @@ jobs:
               -DTT_UMD_BUILD_PIP=ON \
               -DTT_UMD_ENABLE_CLANG_TIDY=ON \
               -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
-              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
+              -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY_ENABLED == 'true' && 'ON' || 'OFF' }} \
               -DTT_UMD_ENABLE_TRACY=ON
           fi
           cmake --build ${{ env.BUILD_OUTPUT_DIR }}
@@ -393,7 +393,7 @@ jobs:
             -DTT_UMD_BUILD_ALL=ON \
             -DTT_UMD_BUILD_PIP=OFF \
             -DTT_UMD_ENABLE_SCCACHE=${{ env.SCCACHE_GHA_ENABLED == 'true' && 'ON' || 'OFF' }} \
-            -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
+            -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY_ENABLED == 'true' && 'ON' || 'OFF' }} \
             -DTT_UMD_ENABLE_CLANG_TIDY=ON
           cmake --build ${{ env.BUILD_OUTPUT_DIR }}
           echo "Compile complete."
@@ -466,7 +466,7 @@ jobs:
                 -DTT_UMD_BUILD_PYTHON=ON \
                 -DTT_UMD_BUILD_EXAMPLES=OFF \
                 -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
-                -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY }} \
+                -DTT_UMD_ENABLE_UNITY_BUILD=${{ env.TT_UMD_UNITY_ENABLED == 'true' && 'ON' || 'OFF' }} \
                 -DCMAKE_BUILD_TYPE=Release
               cmake --build ${{ env.BUILD_OUTPUT_DIR }}
               echo "Compile complete."

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Build ${{ inputs.build-targets || env.BUILD_TARGETS }}
         run: |
           echo "Compiling the code..."
+          # Unity build on to match build-device: one compilation mode across CI, so a
+          # batching-only failure surfaces here on the PR rather than in the merge queue.
           cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
             -DTT_UMD_BUILD_TESTS=ON \
             -DTT_UMD_BUILD_SIMULATION=OFF \
@@ -169,6 +171,7 @@ jobs:
             -DTT_UMD_ENABLE_TRACY=${{ matrix.use_tracy && 'ON' || 'OFF' }} \
             -DTT_UMD_ENABLE_LOGGING=${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' && 'ON' || 'OFF' }} \
             -DTT_UMD_ENABLE_SCCACHE=${{ inputs.use-sccache && 'ON' || 'OFF' }} \
+            -DTT_UMD_ENABLE_UNITY_BUILD=ON \
             -DCMAKE_BUILD_TYPE=${{ inputs.build-type || 'Release' }}
           cmake --build ${{ env.BUILD_OUTPUT_DIR }} --target ${{ inputs.build-targets || env.BUILD_TARGETS }}
           echo "Compile complete."

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -251,6 +251,8 @@ jobs:
 
       - name: Build UMD api_tests, microbenchmark and sim_server with simulation support
         run: |
+          # Unity build on to match build-device: one compilation mode across CI, so a
+          # batching-only failure surfaces here on the PR rather than in the merge queue.
           cmake -B tt-metal/tt_metal/third_party/umd/build -G Ninja \
             -S tt-metal/tt_metal/third_party/umd \
             -DTT_UMD_BUILD_TESTS=ON \
@@ -260,6 +262,7 @@ jobs:
             -DTT_UMD_BUILD_TOOLS=ON \
             -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
             -DTT_UMD_ENABLE_TRACY=OFF \
+            -DTT_UMD_ENABLE_UNITY_BUILD=ON \
             -DCMAKE_BUILD_TYPE=Release
           # sim_server is the simulation-gated tool; this is the only lane that builds it (build-tests
           # builds the tools with simulation OFF, which excludes it).
@@ -557,6 +560,8 @@ jobs:
 
       - name: Build UMD api_tests with simulation support
         run: |
+          # Unity build on to match build-device: one compilation mode across CI, so a
+          # batching-only failure surfaces here on the PR rather than in the merge queue.
           cmake -B build -G Ninja \
             -S . \
             -DTT_UMD_BUILD_TESTS=ON \
@@ -566,6 +571,7 @@ jobs:
             -DTT_UMD_BUILD_TOOLS=OFF \
             -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
             -DTT_UMD_ENABLE_TRACY=OFF \
+            -DTT_UMD_ENABLE_UNITY_BUILD=ON \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target api_tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,22 @@ endif()
 
 add_subdirectory(third_party)
 
+# Unity builds batch several sources into one translation unit, so the cost of parsing
+# our headers is paid once per batch instead of once per source. Set AFTER third_party
+# so dependencies keep building one source at a time.
+#
+# Opt-in and off by default, so this commit changes nothing on its own. Turning it on also
+# needs the tests to be batching-safe, which is a follow-up; and it changes how the library
+# is compiled (static-initialisation order within a batch, inlining across what used to be
+# separate translation units), which is not something to hand a release build or a
+# developer's incremental loop without asking.
+option(TT_UMD_ENABLE_UNITY_BUILD "Batch UMD sources into unity translation units" OFF)
+set(TT_UMD_UNITY_BUILD_BATCH_SIZE "8" CACHE STRING "Number of sources per unity translation unit")
+if(TT_UMD_ENABLE_UNITY_BUILD)
+    set(CMAKE_UNITY_BUILD ON)
+    set(CMAKE_UNITY_BUILD_BATCH_SIZE "${TT_UMD_UNITY_BUILD_BATCH_SIZE}")
+endif()
+
 # Create a target that aggregates all generated files needed for code analysis.
 # Subdirectories can add dependencies to this target as needed.
 add_custom_target(umd_all_generated_files)
@@ -211,6 +227,8 @@ set(_umd_summary_vars
     TT_UMD_ENABLE_CLANG_TIDY
     TT_UMD_ENABLE_LOGGING
     TT_UMD_ENABLE_TRACY
+    TT_UMD_ENABLE_UNITY_BUILD
+    TT_UMD_UNITY_BUILD_BATCH_SIZE
 )
 message(STATUS "")
 message(STATUS "==================== UMD configuration summary ====================")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,10 @@ add_subdirectory(third_party)
 # separate translation units), which is not something to hand a release build or a
 # developer's incremental loop without asking.
 option(TT_UMD_ENABLE_UNITY_BUILD "Batch UMD sources into unity translation units" OFF)
-set(TT_UMD_UNITY_BUILD_BATCH_SIZE "8" CACHE STRING "Number of sources per unity translation unit")
+# 16 from a sweep of 1..24 at -j4, the parallelism a CI runner actually has. The curve is
+# almost spent by 8 (2.56x of an available 3.01x) and 16 captures 97% of it; 24 buys 3% more
+# while leaving libtt-umd only 5 units, so the tail idles cores on a 4-core runner.
+set(TT_UMD_UNITY_BUILD_BATCH_SIZE "16" CACHE STRING "Number of sources per unity translation unit")
 if(TT_UMD_ENABLE_UNITY_BUILD)
     set(CMAKE_UNITY_BUILD ON)
     set(CMAKE_UNITY_BUILD_BATCH_SIZE "${TT_UMD_UNITY_BUILD_BATCH_SIZE}")

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -29,7 +29,7 @@ using ::testing::InSequence;
 using ::testing::MockFunction;
 using ::testing::Return;
 
-const uint32_t HUGEPAGE_REGION_SIZE = 1ULL << 30;  // 1GB
+const uint32_t SIMULATION_HUGEPAGE_REGION_SIZE = 1ULL << 30;  // 1GB
 
 // ---------------------------------------------------------------------------
 // Non-parametrized tests (WH-only / arch-agnostic)
@@ -41,7 +41,7 @@ TEST(ApiSimulationSysmemManager, BasicIOSingleChannel) {
 
     const HugepageMapping channel_0 = sysmem->get_hugepage_mapping(0);
 
-    EXPECT_EQ(channel_0.mapping_size, HUGEPAGE_REGION_SIZE);
+    EXPECT_EQ(channel_0.mapping_size, SIMULATION_HUGEPAGE_REGION_SIZE);
 
     void* channel_0_mapping = channel_0.mapping;
 
@@ -66,7 +66,7 @@ TEST(ApiSimulationSysmemManager, BasicIOMultiChannel) {
     for (int i = 0; i < 3; i++) {
         const HugepageMapping channel = sysmem->get_hugepage_mapping(i);
 
-        EXPECT_EQ(channel.mapping_size, HUGEPAGE_REGION_SIZE);
+        EXPECT_EQ(channel.mapping_size, SIMULATION_HUGEPAGE_REGION_SIZE);
 
         void* channel_mapping = channel.mapping;
 

--- a/tests/baremetal/test_blackhole_arc_apb.cpp
+++ b/tests/baremetal/test_blackhole_arc_apb.cpp
@@ -26,7 +26,7 @@ namespace {
 constexpr uint32_t PCIE_X_ARC_OVER_AXI = 11;
 constexpr uint32_t PCIE_X_ARC_OVER_NOC = 2;
 
-constexpr uint64_t APB_OFFSET = 0x100;
+constexpr uint64_t BLACKHOLE_APB_OFFSET = 0x100;
 
 // Every routing case is run against both NOCs. BlackholeArcApb does not branch on the NOC today --
 // it forwards whatever it is given -- so this is not covering a branch so much as pinning that
@@ -49,9 +49,9 @@ protected:
             .WillRepeatedly(Return(x));
     }
 
-    uint64_t noc_address() const { return blackhole::ARC_NOC_XBAR_ADDRESS_START + APB_OFFSET; }
+    uint64_t noc_address() const { return blackhole::ARC_NOC_XBAR_ADDRESS_START + BLACKHOLE_APB_OFFSET; }
 
-    uint32_t bar_address() const { return blackhole::ARC_APB_BAR0_XBAR_OFFSET_START + APB_OFFSET; }
+    uint32_t bar_address() const { return blackhole::ARC_APB_BAR0_XBAR_OFFSET_START + BLACKHOLE_APB_OFFSET; }
 
     NiceMock<MockDeviceProtocol> protocol_;
     NiceMock<MockPcieInterface> pcie_;
@@ -72,7 +72,7 @@ TEST_P(BlackholeArcApbTest, ReadOverJtagGoesThroughDeviceProtocol) {
     EXPECT_CALL(protocol_, read_ctrl(_, arc_core(), noc_address(), sizeof(uint32_t), noc()));
 
     uint32_t value = 0;
-    apb.read(&value, APB_OFFSET, sizeof(uint64_t), arc_core(), noc());
+    apb.read(&value, BLACKHOLE_APB_OFFSET, sizeof(uint64_t), arc_core(), noc());
 }
 
 TEST_P(BlackholeArcApbTest, WriteOverJtagGoesThroughDeviceProtocol) {
@@ -81,7 +81,7 @@ TEST_P(BlackholeArcApbTest, WriteOverJtagGoesThroughDeviceProtocol) {
     EXPECT_CALL(protocol_, write_ctrl(_, arc_core(), noc_address(), sizeof(uint32_t), noc()));
 
     uint32_t value = 0xABCD;
-    apb.write(&value, APB_OFFSET, sizeof(uint64_t), arc_core(), noc());
+    apb.write(&value, BLACKHOLE_APB_OFFSET, sizeof(uint64_t), arc_core(), noc());
 }
 
 // Over PCIe with the ARC tile unreachable over AXI, the access goes over the NOC and keeps the
@@ -93,7 +93,7 @@ TEST_P(BlackholeArcApbTest, ReadFallsBackToNocWhenArcNotAvailableOverAxi) {
     EXPECT_CALL(protocol_, read_ctrl(_, arc_core(), noc_address(), sizeof(uint64_t), noc()));
 
     uint64_t value = 0;
-    apb.read(&value, APB_OFFSET, sizeof(value), arc_core(), noc());
+    apb.read(&value, BLACKHOLE_APB_OFFSET, sizeof(value), arc_core(), noc());
 }
 
 TEST_P(BlackholeArcApbTest, WriteFallsBackToNocWhenArcNotAvailableOverAxi) {
@@ -103,7 +103,7 @@ TEST_P(BlackholeArcApbTest, WriteFallsBackToNocWhenArcNotAvailableOverAxi) {
     EXPECT_CALL(protocol_, write_ctrl(_, arc_core(), noc_address(), sizeof(uint64_t), noc()));
 
     uint64_t value = 0x1234;
-    apb.write(&value, APB_OFFSET, sizeof(value), arc_core(), noc());
+    apb.write(&value, BLACKHOLE_APB_OFFSET, sizeof(value), arc_core(), noc());
 }
 
 // Over PCIe with the ARC tile reachable over AXI, the access is a plain BAR access and never
@@ -116,7 +116,7 @@ TEST_P(BlackholeArcApbTest, ReadUsesBarWhenArcAvailableOverAxi) {
     EXPECT_CALL(protocol_, read_ctrl(_, _, _, _, _)).Times(0);
 
     uint32_t value = 0;
-    apb.read(&value, APB_OFFSET, sizeof(value), arc_core(), noc());
+    apb.read(&value, BLACKHOLE_APB_OFFSET, sizeof(value), arc_core(), noc());
     EXPECT_EQ(value, 0xDEADBEEF);
 }
 
@@ -128,7 +128,7 @@ TEST_P(BlackholeArcApbTest, WriteUsesBarWhenArcAvailableOverAxi) {
     EXPECT_CALL(protocol_, write_ctrl(_, _, _, _, _)).Times(0);
 
     uint32_t value = 0xFEEDFACE;
-    apb.write(&value, APB_OFFSET, sizeof(value), arc_core(), noc());
+    apb.write(&value, BLACKHOLE_APB_OFFSET, sizeof(value), arc_core(), noc());
 }
 
 TEST_P(BlackholeArcApbTest, RejectsOffsetOutsideTheXbarRange) {

--- a/tests/baremetal/test_simulation_client.cpp
+++ b/tests/baremetal/test_simulation_client.cpp
@@ -31,8 +31,6 @@ protected:
         std::filesystem::temp_directory_path() / ("tt-umd-sim-client-test-" + std::to_string(::getpid()) + ".sock");
 };
 
-}  // namespace
-
 // attach() connects to a live host's socket; detach() closes and is idempotent.
 TEST_F(SimulationClientTest, AttachesToLiveHostThenDetaches) {
     auto server = SimulationServerSocket::create(path_);  // Binds + listens => a live host at path_.
@@ -114,3 +112,5 @@ TEST_F(SimulationClientTest, TransactThrowsAfterHostGone) {
 
     EXPECT_THROW(client.transact({0x01}), std::exception);
 }
+
+}  // namespace

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -81,8 +81,6 @@ protected:
     std::filesystem::path path_;
 };
 
-}  // namespace
-
 TEST_F(SimulationServerSocketTest, ExposesConnectableSocket) {
     auto server = SimulationServerSocket::create(path_);
 
@@ -346,3 +344,5 @@ TEST(SimulationServerSocket, SocketsInDirectoryEmptyWhenNoneOrNotADir) {
     EXPECT_TRUE(SimulationServerSocket::sockets_in_directory(dir).empty());
     fs::remove_all(dir);
 }
+
+}  // namespace

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -29,7 +29,7 @@
 using namespace tt;
 using namespace tt::umd;
 
-constexpr size_t example_eth_harvesting_mask = (1 << 8) | (1 << 5);
+constexpr size_t example_eth_harvest_mask = (1 << 8) | (1 << 5);
 
 // Test soc descriptor API for Wormhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
@@ -458,18 +458,18 @@ TEST(SocDescriptor, BoardBasedPCIE) {
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
-         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
+         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask, .pcie_harvesting_mask = 0x1},
          .board_type = BoardType::P150}));
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
-         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask},
+         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask},
          .board_type = BoardType::P300,
          .asic_location = 0}));
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
-         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask},
+         .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask},
          .board_type = BoardType::P300,
          .asic_location = 1}));
 
@@ -477,7 +477,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
         SocDescriptor soc_desc(
             std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
-             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
+             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask, .pcie_harvesting_mask = 0x1},
              .board_type = BoardType::P100});
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 11);
@@ -489,7 +489,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
         SocDescriptor soc_desc(
             std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
-             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x2},
+             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask, .pcie_harvesting_mask = 0x2},
              .board_type = BoardType::P150});
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 2);
@@ -501,7 +501,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
         SocDescriptor soc_desc(
             std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
-             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x2},
+             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask, .pcie_harvesting_mask = 0x2},
              .board_type = BoardType::P300,
              .asic_location = 0});
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
@@ -514,7 +514,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
         SocDescriptor soc_desc(
             std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
-             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
+             .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask, .pcie_harvesting_mask = 0x1},
              .board_type = BoardType::P300,
              .asic_location = 1});
         EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
@@ -527,7 +527,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
     EXPECT_EQ(
         SocDescriptor(
             std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
-            {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}})
+            {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}})
             .get_cores(CoreType::PCIE)
             .size(),
         2);
@@ -588,8 +588,7 @@ TEST(SocDescriptor, WormholeNOC1Cores) {
 TEST(SocDescriptor, BlackholeNOC1Cores) {
     // Harvesting mask should harvest first 2 Tensix columns.
     const uint32_t num_harvested_columns = 2;
-    HarvestingMasks harvesting_masks = {
-        .tensix_harvesting_mask = 0x3, .eth_harvesting_mask = example_eth_harvesting_mask};
+    HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 0x3, .eth_harvesting_mask = example_eth_harvest_mask};
     // Blackhole tensix noc1 cores with first 2 harvested columns so we can just iterate
     // over the cores without the need to calculate the index.
     // clang-format off
@@ -643,7 +642,7 @@ TEST(SocDescriptor, AllSocDescriptors) {
 
         auto arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_yaml);
         HarvestingMasks harvesting_masks = {
-            .eth_harvesting_mask = (arch == tt::ARCH::BLACKHOLE) ? example_eth_harvesting_mask : 0};
+            .eth_harvesting_mask = (arch == tt::ARCH::BLACKHOLE) ? example_eth_harvest_mask : 0};
 
         SocDescriptor soc_desc(
             std::make_shared<SocArchDescriptor>(soc_desc_yaml),
@@ -667,13 +666,13 @@ TEST(SocDescriptor, SocDescriptorWormholeNoSecurityCores) {
 TEST(SocDescriptor, SocDescriptorBlackholeSecurity) {
     SocDescriptor soc_desc_yaml(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::SECURITY).size(), 1);
 
     SocDescriptor soc_desc_arch(
         std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::SECURITY).size(), 1);
 }
@@ -694,13 +693,13 @@ TEST(SocDescriptor, SocDescriptorWormholeNoL2CPUCores) {
 TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
     SocDescriptor soc_desc_yaml(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::L2CPU).size(), 4);
 
     SocDescriptor soc_desc_arch(
         std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::L2CPU).size(), 4);
 }
@@ -708,7 +707,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
 TEST(SocDescriptor, SerializeSimulatorBlackhole) {
     const SocDescriptor& soc_descriptor = SocDescriptor(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml")),
-        {.noc_translation_enabled = false, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = false, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     std::filesystem::path file_path = soc_descriptor.serialize_to_file();
     SocDescriptor soc(
@@ -747,13 +746,13 @@ TEST(SocDescriptor, SocDescriptorWormholeNoDispatchCores) {
 TEST(SocDescriptor, SocDescriptorBlackholeNoDispatchCores) {
     SocDescriptor soc_desc_yaml(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 
     SocDescriptor soc_desc_arch(
         std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
-        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvest_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::DISPATCH).size(), 0);
 }

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -31,7 +31,6 @@ using namespace tt;
 using namespace tt::umd;
 using namespace tt::umd::test::utils;
 
-constexpr ChipId CHIP_ID = 0;
 constexpr uint32_t NUM_EPOCHS = 10;
 
 // Measure the time it takes to map buffers of different sizes through IOMMU.

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -33,8 +33,6 @@ using namespace tt;
 using namespace tt::umd;
 using namespace tt::umd::test::utils;
 
-constexpr ChipId CHIP_ID = 0;
-
 TEST(MicrobenchmarkPCIeDMA, DRAM) {
     auto bench = ankerl::nanobench::Bench().title("DMA_DRAM").unit("byte");
     const uint64_t ADDRESS = 0x0;

--- a/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
+++ b/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
@@ -28,7 +28,6 @@ using namespace tt::umd::test::utils;
 
 namespace {
 
-constexpr ChipId CHIP_ID = 0;
 constexpr uint64_t ADDRESS = 0x0;
 constexpr size_t TRANSFER_SIZE = 4 * ONE_KIB;
 
@@ -43,8 +42,6 @@ protected:
 
     const char* sim_path_ = nullptr;
 };
-
-}  // namespace
 
 TEST_F(MicrobenchmarkSim, ClusterConstructor) {
     ClusterOptions options =
@@ -77,3 +74,5 @@ TEST_F(MicrobenchmarkSim, DeviceIO) {
     });
     test::utils::export_results(bench);
 }
+
+}  // namespace

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -23,8 +23,6 @@ using namespace tt;
 using namespace tt::umd;
 using namespace tt::umd::test::utils;
 
-constexpr ChipId CHIP_ID = 0;
-
 // Measure bandwidth of IO to DRAM core.
 TEST(MicrobenchmarkTLB, DRAM) {
     auto bench = ankerl::nanobench::Bench().title("TLB_DRAM").unit("byte");

--- a/tests/microbenchmark/common/microbenchmark_utils.hpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.hpp
@@ -9,6 +9,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "umd/device/types/cluster_descriptor_types.hpp"
+
 using namespace ankerl::nanobench;
 
 namespace tt::umd::test::utils {
@@ -18,6 +20,10 @@ inline const char* OUTPUT_ENV_VAR = "UMD_MICROBENCHMARK_RESULTS_PATH";
 inline constexpr size_t ONE_KIB = 1 << 10;
 inline constexpr size_t ONE_MIB = 1 << 20;
 inline constexpr size_t ONE_GIB = 1 << 30;
+
+// Every benchmark below runs against the first chip. Defined here rather than per
+// benchmark so the sources can share one translation unit under a unity build.
+inline constexpr ChipId CHIP_ID = 0;
 
 inline void export_results(const std::string& title, std::vector<Result> const& results) {
     const char* results_path = std::getenv(OUTPUT_ENV_VAR);

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -37,7 +37,7 @@
 
 using namespace tt::umd;
 
-constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
+constexpr std::uint32_t CLUSTER_WH_DRAM_BARRIER_BASE = 0;
 static const std::vector<tt_xy_pair> ETH_CORES_TRANSLATION_ON = {
     {{25, 16},
      {18, 16},
@@ -72,7 +72,7 @@ static const std::vector<uint32_t> REDUCED_BROADCAST_SIZES = {1, 128, 256, 16384
 static void set_barrier_params(Cluster& cluster) {
     // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
     cluster.set_barrier_address_params(
-        {tt::umd::wormhole::L1_BARRIER_BASE, tt::umd::wormhole::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
+        {tt::umd::wormhole::L1_BARRIER_BASE, tt::umd::wormhole::ERISC_BARRIER_BASE, CLUSTER_WH_DRAM_BARRIER_BASE});
 }
 
 // The tensix cores to read back after a broadcast on one chip. Reading back every targeted core


### PR DESCRIPTION
## Issue

Follow-up to #3321, which added `TT_UMD_ENABLE_UNITY_BUILD` but left it off. This makes the tests batching-safe and turns it on where it pays.

## Description

Batching turns what used to be per-file names into per-batch names, which needs two kinds of fix. Both are confined to tests — **libtt-umd needs no source changes at all.**

**Five colliding file-scope constants.** Worth recording for whoever hits this next: an anonymous namespace does *not* fix these, because every `namespace {}` block in a merged translation unit denotes the same namespace. `APB_OFFSET` was already inside one and collided anyway. `CHIP_ID` was defined identically in four microbenchmark sources, so it moves to the header they all already include; the other four are renamed on one side.

**Three gtest fixtures tripping gcc's `-Werror=subobject-linkage`.** Those files closed their anonymous namespace *before* the `TEST_F` blocks, so the generated `Fixture_Name_Test` classes had external linkage over an internal-linkage base. GCC applies that check to types arriving through an include, which is exactly what a unity TU does — so it is invisible in a normal build, and invisible to clang in either mode. Moving the closing brace past the tests is also the layout gtest documents. This is why the first CI run failed 3 of 11 entries, all gcc.

**Where it is turned on: `merge_group` only, because that is where builds are effectively cold.** `Build All` on the release-flags ubuntu-24.04 clang-20 entry:

| | Build All |
| --- | --- |
| merge queue today (sccache enabled, READ_ONLY off main) | 19m14s |
| no cache at all | 19m41s |
| push to main (sccache READ_WRITE) | 12m57s |

The merge queue reads main's cache read-only and gets almost nothing from it. Pushes to main write the cache and do get real value, so they stay per-file, as do the manylinux wheel jobs that package what we ship. The emulated riscv build is included since it is build-only and uses no cache at all.

**Measured effect**, cold dispatch of the full matrix, `Build All` ([baseline](https://github.com/tenstorrent/tt-umd/actions/runs/33445523123), [unity](https://github.com/tenstorrent/tt-umd/actions/runs/33448157918)):

| matrix entry | baseline | unity | |
| --- | --- | --- | --- |
| ubuntu-24.04 clang-20 (release flags) | 19m41s | 5m16s | 3.74x |
| ubuntu-24.04 gcc-11 | 22m00s | 6m33s | 3.36x |
| ubuntu-24.04-riscv gcc (emulated) | 7m57s | 2m48s | 2.84x |
| fedora-39 clang-17 (release flags) | 9m03s | 3m33s | 2.55x |
| ubuntu-24.04-arm clang-20 | 12m20s | 4m56s | 2.50x |
| ubuntu-22.04 clang-13 | 21m27s | 8m50s | 2.43x |
| ubuntu-22.04 clang-20 | 21m11s | 8m50s | 2.40x |
| ubuntu-24.04 clang-20 | 18m21s | 7m58s | 2.30x |
| fedora-39 clang-17 | 16m57s | 8m02s | 2.11x |
| ubuntu-22.04 gcc-11 | 18m42s | 8m59s | 2.08x |
| fedora-39 gcc-13 | 11m47s | 8m42s | 1.35x |

Whole-job totals went from 26-33 min to 8-15 min.

## List of the changes

- `CHIP_ID` moved to `microbenchmark_utils.hpp`, next to the existing `ONE_KIB`/`ONE_MIB`; the four per-file definitions deleted.
- Renamed one side of four colliding pairs: `example_eth_harvesting_mask` -> `example_eth_harvest_mask` (test_soc_descriptor.cpp), `HUGEPAGE_REGION_SIZE` -> `SIMULATION_HUGEPAGE_REGION_SIZE` (test_simulation_sysmem_manager.cpp), `APB_OFFSET` -> `BLACKHOLE_APB_OFFSET` (test_blackhole_arc_apb.cpp), `DRAM_BARRIER_BASE` -> `CLUSTER_WH_DRAM_BARRIER_BASE` (test_cluster_wh.cpp).
- Closing brace of the anonymous namespace moved past the tests in test_simulation_client.cpp, test_simulation_server_socket.cpp and benchmarks/simulator/test_simulator.cpp.
- `build-device.yml`: `TT_UMD_UNITY` is ON for `merge_group`, passed to `Build All`, `Rebuild package for python without wheel`, and the emulated riscv build. An `enable-unity-build` dispatch input exists only so that configuration can be reproduced or measured from a manual run.

## Testing

All 11 `build-device` entries pass on the cold dispatch linked above, across gcc and clang and on x86, arm and emulated riscv. The three package-install jobs (`Test deb`/`rpm package`) also pass, so packages built from unity TUs install and their example client compiles against the shipped `libtt-umd.so`.

`ninja -k 0` over the whole tree was used to confirm the gcc linkage errors were the only remaining error class rather than the first of several.

`baremetal_tests` from a unity build: 253/254 pass. The one failure, `SigBusMechanismTest.MultiProcessMultiThreadStress`, fails identically on a non-unity build of the same tree, so it is pre-existing and not caused by batching.

## API Changes

This PR has no API changes. It does change how the merge-queue builds are compiled — static-initialisation order within a batch, and inlining across what used to be separate translation units — which is the reason it is scoped to CI rather than turned on for releases.
