### PR TITLE
Remove usage of global ARC_MSG lock

### DIFF
--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -67,11 +67,23 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     // protocol faulted there before the assert could report it.
     device_id_ = device_protocol_->get_mmio_id();
 
-    // Wormhole serializes all ARC traffic on one system-wide mutex rather than a per-device one:
-    // several topology discovery instances can reach the same remote chip through different local
-    // chips, so a per-device lock would let concurrent messages interleave on that chip. This mirrors
-    // WormholeArcMessenger::send_message and the TODO recorded there.
+    // Wormhole serializes all ARC traffic on one system-wide mutex rather than a per-device one. The case that would
+    // break a per-device lock is two local chips reaching the same remote chip at once - concurrent messages could
+    // then interleave on that remote chip's ARC, since each would be holding a different device's lock. As the code
+    // is written that does not arise: a remote chip is only ever reached through its own local counterpart, so the
+    // local chip's lock does serialize everything that reaches it. UMD assumes that stays true.
+    // Keeping the lock system-wide therefore costs more than it buys, and it is the one ARC path that cannot move to
+    // a KMD resource lock, which exists per local device and has no system-wide form.
     LockManager::initialize_mutex(MutexType::ARC_MSG);
+
+    // The per device lock this path is moving to. For a remote device, device_id_ is the local chip used to reach the
+    // remote ARC, so REMOTE_ARC_MSG serializes all remote ARC traffic flowing through that same local chip.
+    // Both are claimed up front because acquire_mutex() throws unless the lock was initialized first, and which of the
+    // two is taken is decided per message.
+    LockManager::initialize_mutex(
+        remote_interface_ != nullptr ? MutexType::REMOTE_ARC_MSG : MutexType::ARC_MSG,
+        device_id_,
+        get_io_device_type());
 
     // The ARC core is at a fixed NOC0 coordinate on Wormhole, so both coordinates are known without
     // reading anything from the device.
@@ -289,9 +301,16 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
         arg1 = static_cast<uint16_t>(args[1]);
     }
 
-    // Serializes against other processes messaging any device's ARC; see the constructor for why the
-    // lock is system-wide on Wormhole.
-    auto lock = LockManager::acquire_mutex(MutexType::ARC_MSG);
+    // Serializes against everything else reaching this device's ARC, on the local chip the messages travel through.
+    auto lock = LockManager::acquire_mutex(
+        remote_interface_ != nullptr ? MutexType::REMOTE_ARC_MSG : MutexType::ARC_MSG,
+        device_id_,
+        get_io_device_type());
+
+    // TODO: This lock is deprecated, and will be removed once all clients update the code and start locking using the
+    // lock above. It prevents two clients running on different UMD versions from not synchronizing on the same lock.
+    // See the constructor for why it is system-wide, and why that is wider than what the code actually needs.
+    auto lock_global = LockManager::acquire_mutex(MutexType::ARC_MSG);
 
     uint32_t fw_arg = arg0 | (arg1 << 16);
     write_to_arc_apb(&fw_arg, wormhole::ARC_RESET_SCRATCH_RES0_OFFSET, sizeof(uint32_t), noc_id);

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -21,6 +21,8 @@
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
@@ -80,10 +82,15 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     // remote ARC, so REMOTE_ARC_MSG serializes all remote ARC traffic flowing through that same local chip.
     // Both are claimed up front because acquire_mutex() throws unless the lock was initialized first, and which of the
     // two is taken is decided per message.
+    // The type has to describe the same device as device_id_, which for a remote device is the local one the messages
+    // travel through. get_io_device_type() answers for this device instead, and calls anything that is not JTAG PCIe,
+    // which over a simulated gateway would name the lock after PCIe device -1.
     LockManager::initialize_mutex(
         remote_interface_ != nullptr ? MutexType::REMOTE_ARC_MSG : MutexType::ARC_MSG,
         device_id_,
-        get_io_device_type());
+        remote_interface_ != nullptr
+            ? remote_interface_->get_remote_communication()->get_local_device()->get_communication_device_type()
+            : get_io_device_type());
 
     // The ARC core is at a fixed NOC0 coordinate on Wormhole, so both coordinates are known without
     // reading anything from the device.
@@ -305,7 +312,9 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
     auto lock = LockManager::acquire_mutex(
         remote_interface_ != nullptr ? MutexType::REMOTE_ARC_MSG : MutexType::ARC_MSG,
         device_id_,
-        get_io_device_type());
+        remote_interface_ != nullptr
+            ? remote_interface_->get_remote_communication()->get_local_device()->get_communication_device_type()
+            : get_io_device_type());
 
     // TODO: This lock is deprecated, and will be removed once all clients update the code and start locking using the
     // lock above. It prevents two clients running on different UMD versions from not synchronizing on the same lock.

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -69,19 +69,12 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     // protocol faulted there before the assert could report it.
     device_id_ = device_protocol_->get_mmio_id();
 
-    // Wormhole serializes all ARC traffic on one system-wide mutex rather than a per-device one. The case that would
-    // break a per-device lock is two local chips reaching the same remote chip at once - concurrent messages could
-    // then interleave on that remote chip's ARC, since each would be holding a different device's lock. As the code
-    // is written that does not arise: a remote chip is only ever reached through its own local counterpart, so the
-    // local chip's lock does serialize everything that reaches it. UMD assumes that stays true.
-    // Keeping the lock system-wide therefore costs more than it buys, and it is the one ARC path that cannot move to
-    // a KMD resource lock, which exists per local device and has no system-wide form.
-    LockManager::initialize_mutex(MutexType::ARC_MSG);
-
-    // The per device lock this path is moving to. For a remote device, device_id_ is the local chip used to reach the
-    // remote ARC, so REMOTE_ARC_MSG serializes all remote ARC traffic flowing through that same local chip.
-    // Both are claimed up front because acquire_mutex() throws unless the lock was initialized first, and which of the
-    // two is taken is decided per message.
+    // For a remote device, device_id_ is the local chip used to reach the remote ARC, so REMOTE_ARC_MSG serializes all
+    // remote ARC traffic flowing through that same local chip.
+    // Caveat: two local chips reaching the same remote chip are not serialized against each other. That does not arise
+    // as the code is written - a remote chip is only reached through its own local counterpart - and UMD assumes it
+    // stays that way. Serializing it properly would need a unique remote chip id rather than the local device.
+    // Claimed up front because acquire_mutex() throws unless the lock was initialized first.
     // The type has to describe the same device as device_id_, which for a remote device is the local one the messages
     // travel through. get_io_device_type() answers for this device instead, and calls anything that is not JTAG PCIe,
     // which over a simulated gateway would name the lock after PCIe device -1.
@@ -315,11 +308,6 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
         remote_interface_ != nullptr
             ? remote_interface_->get_remote_communication()->get_local_device()->get_communication_device_type()
             : get_io_device_type());
-
-    // TODO: This lock is deprecated, and will be removed once all clients update the code and start locking using the
-    // lock above. It prevents two clients running on different UMD versions from not synchronizing on the same lock.
-    // See the constructor for why it is system-wide, and why that is wider than what the code actually needs.
-    auto lock_global = LockManager::acquire_mutex(MutexType::ARC_MSG);
 
     uint32_t fw_arg = arg0 | (arg1 << 16);
     write_to_arc_apb(&fw_arg, wormhole::ARC_RESET_SCRATCH_RES0_OFFSET, sizeof(uint32_t), noc_id);


### PR DESCRIPTION
### Issue
On a path to #2745

### Description
A follow up of #3397, which is itself a redo of #3179 after #3322 dropped it.
NOTE: Not to be merged until the dependant PR hits all clients to ensure correctness.

With the per device lock back in place, the system wide one only exists so that a client on an older
UMD, which knows nothing about the per device lock, still serializes against one that does. Once every
client is updated it serializes nothing and only widens what a single ARC message blocks: today one
message to any chip locks out every other chip's ARC.

Nothing takes a system wide lock in UMD after this. ARC_MSG and CREATE_ETH_MAP stay in
SYSTEM_WIDE_MUTEX_TYPES, since lock_virus reports on them and the entry points remain.

### List of the changes
- Don't take the global ARC_MSG lock in WormholeDeviceFirmware

### Testing
Existing tests, multiprocess ones in particular, the same ones #3179 relied on.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
