### PR TITLE
[Base API] Add IoOrdering param and use Strict on LocalChip's fallback

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -297,6 +297,7 @@ public:
      * @param core_start Core to map, or upper-left corner of a multicast grid.
      * @param addr Address on the core(s) the window is anchored at.
      * @param host Host-side window properties (caching strategy and requested size).
+     * @param ordering Transaction ordering mode to apply to the mapping.
      * @param core_end Lower-right corner of a multicast grid, or nullopt for unicast.
      * @param flags Transaction attributes.
      * @param noc Routing selection, or nullopt to route over the NOC selected for this thread.
@@ -306,6 +307,7 @@ public:
         CoreCoord core_start,
         uint64_t addr,
         HostIoWindowConfig host = {},
+        IoOrdering ordering = IoOrdering::Strict,
         std::optional<CoreCoord> core_end = std::nullopt,
         WindowFlags flags = WindowFlags::None,
         std::optional<NocId> noc = std::nullopt);
@@ -416,6 +418,10 @@ public:
      * This API is used for writing to both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
+     * This is a bulk-transfer path with no ordering guarantee: writes from successive calls may
+     * complete in any order. If the order of two writes matters, separate them with a barrier or use
+     * an @ref IoWindow from @ref create_io_window, which takes an ordering mode.
+     *
      * @param mem_ptr Source data address.
      * @param size_in_bytes Source data size.
      * @param chip Chip to target.
@@ -428,6 +434,8 @@ public:
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
      * This API is used for reading from both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
+     *
+     * No ordering guarantee, same as @ref write_to_device, including against writes issued through it.
      *
      * @param mem_ptr Data pointer to read the data into.
      * @param chip Chip to target.

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -418,10 +418,12 @@ public:
      * This API is used for writing to both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
-     * Transfers use @ref IoOrdering::Strict, so the data has landed on the target before the call
-     * returns and successive calls are ordered with respect to each other. This costs write
-     * throughput; a caller that does not need the guarantee can take an @ref IoWindow from
-     * @ref create_io_window with a weaker ordering mode and drive it directly.
+     * Transfers use @ref IoOrdering::Strict, so successive calls are ordered with respect to each
+     * other. The call returns once the writes are issued, not once they are acknowledged by the
+     * target — the underlying MMIO stores are posted. This costs write throughput; a caller that
+     * does not need the ordering guarantee can take an @ref IoWindow from @ref create_io_window
+     * with a weaker ordering mode and drive it directly, using @ref IoWindow::configure to advance
+     * across chunks larger than the window.
      *
      * @param mem_ptr Source data address.
      * @param size_in_bytes Source data size.
@@ -436,8 +438,8 @@ public:
      * This API is used for reading from both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
-     * Uses @ref IoOrdering::Strict, same as @ref write_to_device, and is ordered against writes
-     * issued through it.
+     * Uses @ref IoOrdering::Strict, so successive calls through this function are ordered with
+     * respect to each other.
      *
      * @param mem_ptr Data pointer to read the data into.
      * @param chip Chip to target.

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -418,9 +418,10 @@ public:
      * This API is used for writing to both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
-     * This is a bulk-transfer path with no ordering guarantee: writes from successive calls may
-     * complete in any order. If the order of two writes matters, separate them with a barrier or use
-     * an @ref IoWindow from @ref create_io_window, which takes an ordering mode.
+     * Transfers use @ref IoOrdering::Strict, so the data has landed on the target before the call
+     * returns and successive calls are ordered with respect to each other. This costs write
+     * throughput; a caller that does not need the guarantee can take an @ref IoWindow from
+     * @ref create_io_window with a weaker ordering mode and drive it directly.
      *
      * @param mem_ptr Source data address.
      * @param size_in_bytes Source data size.
@@ -435,7 +436,8 @@ public:
      * This API is used for reading from both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
-     * No ordering guarantee, same as @ref write_to_device, including against writes issued through it.
+     * Uses @ref IoOrdering::Strict, same as @ref write_to_device, and is ordered against writes
+     * issued through it.
      *
      * @param mem_ptr Data pointer to read the data into.
      * @param chip Chip to target.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -498,9 +498,11 @@ public:
      * See @ref TargetIoWindowConfig.
      * @param host Host-side properties (caching strategy and requested size).
      * See @ref HostIoWindowConfig.
+     * @param ordering Transaction ordering mode to apply to the mapping.
      * @return An exclusively owned handle to the newly created @ref IoWindow.
      */
-    std::unique_ptr<IoWindow> create_io_window(TargetIoWindowConfig target, HostIoWindowConfig host);
+    std::unique_ptr<IoWindow> create_io_window(
+        TargetIoWindowConfig target, HostIoWindowConfig host, IoOrdering ordering = IoOrdering::Strict);
 
     /**
      * Export a NOC-addressable region as a dma-buf file descriptor for peer-to-peer PCIe DMA.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -498,11 +498,18 @@ public:
      * See @ref TargetIoWindowConfig.
      * @param host Host-side properties (caching strategy and requested size).
      * See @ref HostIoWindowConfig.
-     * @param ordering Transaction ordering mode to apply to the mapping.
      * @return An exclusively owned handle to the newly created @ref IoWindow.
      */
+    std::unique_ptr<IoWindow> create_io_window(TargetIoWindowConfig target, HostIoWindowConfig host);
+
+    /**
+     * Same as the overload above, with the transaction ordering mode applied to the mapping made
+     * explicit instead of defaulting to @ref IoOrdering::Strict.
+     *
+     * @param ordering Transaction ordering mode to apply to the mapping.
+     */
     std::unique_ptr<IoWindow> create_io_window(
-        TargetIoWindowConfig target, HostIoWindowConfig host, IoOrdering ordering = IoOrdering::Strict);
+        TargetIoWindowConfig target, HostIoWindowConfig host, IoOrdering ordering);
 
     /**
      * Export a NOC-addressable region as a dma-buf file descriptor for peer-to-peer PCIe DMA.

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -261,9 +261,9 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
         tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
-        // Strict: the write is non-posted, so it has landed on the target once this call returns. Callers
-        // that pair a bulk write with a subsequent trigger rely on that completion, and this path
-        // reconfigures the window between transfers, so nothing else orders them.
+        // Strict orders this write against other Strict transfers, but the underlying MMIO stores
+        // are posted: the call returns once issued, not once landed. This path reconfigures the
+        // window between transfers, so nothing else orders them.
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         write_block_reconfigure(
             *get_cached_wc_tlb_window(),

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -261,6 +261,9 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
         tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
+        // Strict: the write is non-posted, so it has landed on the target once this call returns. Callers
+        // that pair a bulk write with a subsequent trigger rely on that completion, and this path
+        // reconfigures the window between transfers, so nothing else orders them.
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         write_block_reconfigure(
             *get_cached_wc_tlb_window(),
@@ -269,7 +272,7 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
             l1_dest,
             size,
             get_selected_noc_id(),
-            IoOrdering::Relaxed);
+            IoOrdering::Strict);
     }
 }
 
@@ -293,6 +296,7 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
         tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
     } else {
+        // Strict, matching write_to_device so both directions of the bulk path carry the same guarantee.
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         read_block_reconfigure(
             *get_cached_wc_tlb_window(),
@@ -301,7 +305,7 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
             l1_src,
             size,
             get_selected_noc_id(),
-            IoOrdering::Relaxed);
+            IoOrdering::Strict);
     }
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -918,6 +918,7 @@ std::unique_ptr<IoWindow> Cluster::create_io_window(
     CoreCoord core_start,
     uint64_t addr,
     HostIoWindowConfig host,
+    IoOrdering ordering,
     std::optional<CoreCoord> core_end,
     WindowFlags flags,
     std::optional<NocId> noc) {
@@ -927,7 +928,9 @@ std::unique_ptr<IoWindow> Cluster::create_io_window(
         return nullptr;
     }
     return tt_device->create_io_window(
-        make_io_window_target(get_chip(chip)->get_soc_descriptor(), core_start, addr, noc, core_end, flags), host);
+        make_io_window_target(get_chip(chip)->get_soc_descriptor(), core_start, addr, noc, core_end, flags),
+        host,
+        ordering);
 }
 
 TlbWindow* Cluster::get_static_tlb_window(const ChipId chip, const CoreCoord core) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -368,6 +368,10 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
     UMD_THROW(error::RuntimeError, "Failed to allocate TLB window.");
 }
 
+std::unique_ptr<IoWindow> TTDevice::create_io_window(TargetIoWindowConfig target, HostIoWindowConfig host) {
+    return create_io_window(target, host, IoOrdering::Strict);
+}
+
 // Non-virtual by design: the spec surface takes config structs and hands back an IoWindow, while the
 // virtual get_io_window() below it stays TLB-flavored (tlb_data, unique_ptr<TlbWindow>) as the seam
 // SimulationTTDevice overrides. That split is what lets the backends behind it change shape -- e.g.

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -373,7 +373,8 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
 // SimulationTTDevice overrides. That split is what lets the backends behind it change shape -- e.g.
 // the concrete windows implementing IoWindow directly, without TlbWindow as an intermediate base --
 // without touching this signature or any caller.
-std::unique_ptr<IoWindow> TTDevice::create_io_window(TargetIoWindowConfig target, HostIoWindowConfig host) {
+std::unique_ptr<IoWindow> TTDevice::create_io_window(
+    TargetIoWindowConfig target, HostIoWindowConfig host, IoOrdering ordering) {
     // A grid is only addressable in the translated space: without it the corners name NOC coordinates,
     // which harvesting shifts, so the rectangle they bound is not the one the caller asked for.
     UMD_ASSERT(
@@ -417,7 +418,7 @@ std::unique_ptr<IoWindow> TTDevice::create_io_window(TargetIoWindowConfig target
     }
 
     std::unique_ptr<TlbWindow> window = get_io_window({}, mapping, size);
-    window->configure(target);
+    window->configure(target, ordering);
     return window;
 }
 

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -624,7 +624,7 @@ TEST_F(TestTlb, CreateIoWindow) {
 
     EXPECT_GE(window->get_size(), requested_size);
     EXPECT_EQ(window->get_memory_caching_type(), HostMemoryCaching::WC);
-    // create_io_window() configures through the single-argument configure(), which applies Strict.
+    // Ordering defaults to Strict when the caller does not ask for one.
     EXPECT_EQ(window->get_io_ordering(), IoOrdering::Strict);
 
     const TargetIoWindowConfig readback = window->get_target_config();
@@ -638,13 +638,23 @@ TEST_F(TestTlb, CreateIoWindow) {
     // No architecture has a window this large, so the request cannot be served.
     EXPECT_ANY_THROW(tt_device->create_io_window(target, {.size = std::numeric_limits<size_t>::max()}));
 
+    // A caller that needs another ordering mode gets it applied to the mapping it is handed, rather
+    // than having to reconfigure the window itself once it has one.
+    for (const IoOrdering ordering : {IoOrdering::Relaxed, IoOrdering::Posted}) {
+        std::unique_ptr<IoWindow> ordered_window =
+            tt_device->create_io_window(target, {.size = requested_size}, ordering);
+        EXPECT_EQ(ordered_window->get_io_ordering(), ordering);
+        EXPECT_EQ(ordered_window->get_target_config().addr, l1_addr) << "Ordering should not disturb the target";
+    }
+
     // The same factory reached by chip and CoreCoord, which is how clients that hold neither a
     // TTDevice nor translated coordinates ask for a window.
     std::unique_ptr<IoWindow> chip_window =
-        cluster->create_io_window(chip, tensix_core, l1_addr, {.size = requested_size});
+        cluster->create_io_window(chip, tensix_core, l1_addr, {.size = requested_size}, IoOrdering::Relaxed);
     ASSERT_NE(chip_window, nullptr);
     EXPECT_EQ(chip_window->get_target_config().core_start, target.core_start);
     EXPECT_EQ(chip_window->get_target_config().addr, l1_addr);
+    EXPECT_EQ(chip_window->get_io_ordering(), IoOrdering::Relaxed);
 
     chip_window->write32(0, 0xa5a5a5a5);
     EXPECT_EQ(chip_window->read32(0), 0xa5a5a5a5u);
@@ -689,7 +699,13 @@ TEST_F(TestTlb, CreateMulticastIoWindow) {
     }
 
     std::unique_ptr<IoWindow> window = cluster->create_io_window(
-        chip, grid_start, l1_addr, {.size = sizeof(pattern)}, grid_end, WindowFlags::MulticastWrite);
+        chip,
+        grid_start,
+        l1_addr,
+        {.size = sizeof(pattern)},
+        IoOrdering::Strict,
+        grid_end,
+        WindowFlags::MulticastWrite);
     ASSERT_NE(window, nullptr);
 
     window->write32(0, pattern);


### PR DESCRIPTION
### Issue
#3377

### Description
Adds an ordering parameter to the IoWindow creation APIs ahead of TLBManager removal, and flips LocalChip's block-path fallback from Relaxed to Strict.

LocalChip::write_to_device/read_from_device fall back to a reconfigured window whenever the target isn't covered by a static TLB, and that fallback is Relaxed, under which writes can reorder or interleave with each other. Metal's static TLBs cover Tensix and ETH on Blackhole MMIO chips today, so those writes run Strict. Deleting them (the next PR in this stack, and metal's PR) would drop them to Relaxed, so this PR flips the fallback first and the ordering holds throughout the stack.

Callers that want Relaxed should take an IoWindow from create_io_window with IoOrdering::Relaxed requested explicitly.

Paired with the Strict variant of the metal migration PR, which needs no ordering fixes as a result: https://github.com/tenstorrent/tt-metal/pull/55531

Cost, measured on silicon: 11x to 16x on the bulk write path on wormhole_b0, 28x to 30x on blackhole. Reads are unaffected, so the read_from_device flip is symmetry only.

### List of the changes
 - Added IoOrdering ordering = IoOrdering::Strict to TTDevice::create_io_window and Cluster::create_io_window, plumbed through to TlbWindow::configure. Default preserves current behavior for all existing callers.
 - LocalChip::write_to_device/read_from_device's reconfigure fallback now requests IoOrdering::Strict instead of IoOrdering::Relaxed.
 - Documented the ordering Cluster::write_to_device/read_from_device now give, and pointed callers needing Relaxed at create_io_window.
 - Added Relaxed/Posted round-trip coverage in tests/unified/test_tlb.cpp.

### Testing
CI green, including a benchmark run on all three arches: https://github.com/tenstorrent/tt-umd/actions/runs/34597565499
Regression check against the n150 baseline passes; ClusterConstructor is unaffected. The microbenchmark TLB cases now measure the Strict path rather than the fastest bulk path and need rewriting onto an IoWindow with Relaxed requested explicitly, tracked separately.

### API Changes
This PR has API changes, widening base api spec with IoOrdering param defaulted to Strict.
