### PR TITLE
Enable native macOS simulator builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,59 @@
+name: macOS simulator
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  simulator:
+    name: Apple Silicon simulator
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install host dependencies
+        run: brew install cmake ninja hwloc
+      - name: Configure UMD
+        run: >-
+          cmake -S . -B build/macos -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DTT_UMD_BUILD_SIMULATION=ON
+          -DTT_UMD_BUILD_TESTS=ON
+          -DTT_UMD_BUILD_TOOLS=OFF
+          -DTT_UMD_ENABLE_CLANG_TIDY=OFF
+      - name: Build native library and tests
+        run: cmake --build build/macos --target tt-umd api_tests baremetal_tests -j 3
+      - name: Checkout public simulator
+        uses: actions/checkout@v6
+        with:
+          repository: tenstorrent/ttsim
+          ref: 89bdc5eb726c4f1ebbe597e03b1b9cdf7622c779
+          path: ttsim
+      - name: Build native Blackhole simulator
+        working-directory: ttsim
+        run: python3 make.py src/_out/release_bh/libttsim.so -j 3
+      - name: Prepare simulator descriptor
+        run: >-
+          cp tests/soc_descs/blackhole_140_arch.yaml
+          ttsim/src/_out/release_bh/soc_descriptor.yaml
+      - name: Verify native binaries
+        run: |
+          file -L build/macos/lib/libtt-umd.dylib | grep 'Mach-O.*arm64'
+          file ttsim/src/_out/release_bh/libttsim.so | grep 'Mach-O.*arm64'
+      - name: Run simulator and platform tests
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/ttsim/src/_out/release_bh/libttsim.so
+        run: >-
+          ./build/macos/test/umd/api/api_tests
+          --gtest_filter='MacOSPlatform.*:SimulatorHost.*:*SimulationSysmemManager*'
+      - name: Run tests that need no card
+        run: ./build/macos/test/umd/baremetal/baremetal_tests

--- a/README.md
+++ b/README.md
@@ -73,6 +73,44 @@ export CC=gcc
 export CXX=g++
 ```
 
+#### Native macOS simulator builds
+
+Apple Silicon Macs can build UMD and run the public [ttsim](https://github.com/tenstorrent/ttsim)
+simulator natively with Apple Clang. Install Xcode Command Line Tools and Homebrew dependencies:
+
+```bash
+brew install cmake ninja hwloc
+cmake -S . -B build/macos -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DTT_UMD_BUILD_SIMULATION=ON -DTT_UMD_BUILD_TESTS=ON \
+  -DTT_UMD_BUILD_TOOLS=OFF -DTT_UMD_ENABLE_CLANG_TIDY=OFF
+cmake --build build/macos --target tt-umd api_tests baremetal_tests -j 3
+```
+
+This produces a native `build/macos/lib/libtt-umd.dylib`. Warnings remain errors.
+Use a native simulator library too; a Linux ARM64 `.so` cannot be loaded by macOS.
+The public simulator can be built from source:
+
+```bash
+git clone https://github.com/tenstorrent/ttsim.git ttsim
+git -C ttsim checkout 89bdc5eb726c4f1ebbe597e03b1b9cdf7622c779
+(cd ttsim && python3 make.py src/_out/release_bh/libttsim.so -j 3)
+cp tests/soc_descs/blackhole_140_arch.yaml ttsim/src/_out/release_bh/soc_descriptor.yaml
+export TT_UMD_SIMULATOR="$PWD/ttsim/src/_out/release_bh/libttsim.so"
+./build/macos/test/umd/api/api_tests \
+  --gtest_filter='MacOSPlatform.*:SimulatorHost.*:*SimulationSysmemManager*'
+./build/macos/test/umd/baremetal/baremetal_tests
+```
+
+The simulator's `.so` filename is retained on macOS; `file` identifies its contents as Mach-O arm64.
+The Mac CI job builds this pinned public simulator and tests a mapped Tensix L1 write/read round-trip,
+host memory allocation, and the platform boundaries.
+
+This is simulator support. The Linux kernel driver is unavailable on macOS: `tt-kmd-lib` hardware
+calls return `-ENOTSUP`, and process-shared robust hardware locks throw an explicit error.
+Use `copy_sim_binary=false` for single-chip simulators. Legacy isolated simulator copies require
+Linux memfd; simulators with a shared-library multichip ABI retain their existing loading path.
+
 #### Disabling -Werror
 
 By default, all warnings are treated as errors. This is controlled via the standard CMake variable

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -9,8 +9,10 @@ if(TT_UMD_BUILD_SIMULATION)
         ${PROJECT_SOURCE_DIR}/device/simulation/simulation_server_protocol.fbs
     )
     set(FBS_DEPENDS "")
+    set(FBS_COMPILER flatc)
     if(TARGET flatc)
         set(FBS_DEPENDS flatc)
+        set(FBS_COMPILER $<TARGET_FILE:flatc>)
     endif()
     set(FBS_GENERATED_HEADERS "")
     foreach(FBS_FILE ${FBS_FILES})
@@ -20,7 +22,7 @@ if(TT_UMD_BUILD_SIMULATION)
             OUTPUT
                 ${FBS_GENERATED_HEADER}
             COMMAND
-                flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
+                ${FBS_COMPILER} --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
             DEPENDS
                 ${FBS_DEPENDS}
                 ${FBS_FILE}
@@ -131,7 +133,8 @@ target_sources(
         warm_reset_with_recovery.cpp
         types/xy_pair.cpp
         utils/lock_manager.cpp
-        utils/robust_mutex.cpp
+        $<$<PLATFORM_ID:Darwin>:utils/robust_mutex_unsupported.cpp>
+        $<$<NOT:$<PLATFORM_ID:Darwin>>:utils/robust_mutex.cpp>
         utils/kmd_mutex.cpp
         topology/topology_discovery.cpp
         topology/topology_discovery_blackhole.cpp
@@ -343,13 +346,21 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/common
 )
 
+# Resolve the header itself: Homebrew's include directory can contain unrelated
+# versions of dependencies (such as fmt) that shadow our pinned headers.
+find_path(HWLOC_INCLUDE_DIR hwloc.h REQUIRED)
+find_library(HWLOC_LIBRARY hwloc REQUIRED)
+get_filename_component(HWLOC_HEADER_REAL_PATH "${HWLOC_INCLUDE_DIR}/hwloc.h" REALPATH)
+get_filename_component(HWLOC_PRIVATE_INCLUDE_DIR "${HWLOC_HEADER_REAL_PATH}" DIRECTORY)
+target_include_directories(tt-umd SYSTEM PRIVATE "${HWLOC_PRIVATE_INCLUDE_DIR}")
+
 target_link_libraries(
     tt-umd
     PUBLIC
         fmt::fmt-header-only
     PRIVATE
-        hwloc
-        rt
+        ${HWLOC_LIBRARY}
+        $<$<PLATFORM_ID:Linux>:rt>
         spdlog::spdlog_header_only
         tt-logger::tt-logger
         yaml-cpp::yaml-cpp

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -7,9 +7,11 @@
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 
 #include <fmt/format.h>
+#if defined(__linux__)
 #include <linux/mman.h>  // for MAP_HUGE_1GB, MAP_HUGE_512MB, MAP_HUGE_2MB
-#include <sys/mman.h>    // for mmap, munmap
-#include <sys/stat.h>    // for fstat
+#endif
+#include <sys/mman.h>  // for mmap, munmap
+#include <sys/stat.h>  // for fstat
 #include <unistd.h>
 
 #include <cerrno>
@@ -33,6 +35,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils/mmap.hpp"
 
 namespace tt::umd {
 
@@ -42,11 +45,11 @@ namespace tt::umd {
 // 512MB (PMD/level-2 block) for the same total memory, reducing IOMMU mapping overhead.
 // 512MB is only meaningful on AArch64 with 64K base pages; it is not exposed on x86.
 static void *mmap_with_hugepage_fallback(size_t size) {
+    void *addr = MAP_FAILED;
+#if defined(__linux__)
     constexpr size_t kHugepage1GiB = 1ULL << 30;
     constexpr size_t kHugepage512MiB = 512ULL << 20;
     constexpr size_t kHugepage2MiB = 2ULL << 20;
-
-    void *addr = MAP_FAILED;
 
     // Only attempt 1GiB hugepages when the size is a multiple of 1GiB.
     if (size >= kHugepage1GiB && (size % kHugepage1GiB) == 0) {
@@ -54,7 +57,7 @@ static void *mmap_with_hugepage_fallback(size_t size) {
             nullptr,
             size,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | mmap_populate,
             -1,
             0);
         if (addr != MAP_FAILED) {
@@ -69,7 +72,7 @@ static void *mmap_with_hugepage_fallback(size_t size) {
             nullptr,
             size,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_512MB | MAP_POPULATE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_512MB | mmap_populate,
             -1,
             0);
         if (addr != MAP_FAILED) {
@@ -84,7 +87,7 @@ static void *mmap_with_hugepage_fallback(size_t size) {
             nullptr,
             size,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | mmap_populate,
             -1,
             0);
         if (addr != MAP_FAILED) {
@@ -93,7 +96,9 @@ static void *mmap_with_hugepage_fallback(size_t size) {
         }
     }
 
-    addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+#endif
+    addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | mmap_populate, -1, 0);
+#if defined(__linux__)
     if (addr != MAP_FAILED) {
         log_warning(
             LogUMD,
@@ -104,6 +109,7 @@ static void *mmap_with_hugepage_fallback(size_t size) {
             (size + kHugepage2MiB - 1) / kHugepage2MiB,
             (size + kHugepage512MiB - 1) / kHugepage512MiB);
     }
+#endif
     return addr;
 }
 
@@ -265,7 +271,7 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
         }
 
         std::byte *mapping = static_cast<std::byte *>(
-            mmap(nullptr, hugepage_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, hugepage_fd, 0));
+            mmap(nullptr, hugepage_size, PROT_READ | PROT_WRITE, MAP_SHARED | mmap_populate, hugepage_fd, 0));
 
         close(hugepage_fd);
 

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -21,6 +21,7 @@
 #include "tracy.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils/mmap.hpp"
 
 namespace tt {
 enum class ARCH;
@@ -68,7 +69,9 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     system_memory_ =
         static_cast<uint8_t*>(mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     UMD_ASSERT(system_memory_ != MAP_FAILED, error::RuntimeError, "system_memory mmap() failed");
+#if defined(__linux__)
     madvise(system_memory_, total_size, MADV_HUGEPAGE);
+#endif
     system_memory_size_ = total_size;
 
     // The mapped-buffer arena starts immediately after the hugepage region so
@@ -153,7 +156,7 @@ void* SimulationSysmemManager::get_mapped_host_ptr(uint64_t device_io_addr) {
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
     void* mapping =
-        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | mmap_populate, -1, 0);
     UMD_ASSERT(mapping != MAP_FAILED, error::RuntimeError, "Simulation sysmem buffer mmap() failed");
     // This mapping belongs to the buffer, so it is released along with the registry entry. mmap returns
     // a page-aligned address, so the pointer the deleter receives is the one to munmap.

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -41,6 +41,7 @@
 #include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
+#include "utils/mmap.hpp"
 
 namespace tt::umd {
 
@@ -930,7 +931,7 @@ bool PCIDevice::try_allocate_pcie_dma_buffer_iommu(const size_t dma_buf_size) {
     const size_t dma_buf_alloc_size = dma_buf_size + page_size;  // completion flag page
 
     void *dma_buf_mapping =
-        mmap(nullptr, dma_buf_alloc_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        mmap(nullptr, dma_buf_alloc_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | mmap_populate, -1, 0);
 
     try {
         uint64_t iova = map_for_dma(dma_buf_mapping, dma_buf_alloc_size);

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -21,6 +21,7 @@
 
 #include "simulation/simulation_server_transport.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils/local_socket.hpp"
 
 namespace tt::umd {
 
@@ -106,17 +107,8 @@ void SimulationServerSocket::serve(RequestHandler request_handler) {
 
 void SimulationServerSocket::do_accept() {
     auto sock = std::make_shared<stream_protocol::socket>(impl_->io);
-    impl_->acceptor.async_accept(*sock, [this, sock](const std::error_code& ec) {
-#ifdef __APPLE__
-        // asio sets SO_NOSIGPIPE after accept(). Darwin returns EINVAL if a
-        // queued peer already disconnected (e.g. a liveness probe), and asio
-        // closes that accepted socket. Keep accepting subsequent clients.
-        if (ec == asio::error::invalid_argument) {
-            do_accept();
-            return;
-        }
-#endif
-        // Other errors or io_context::stop() (teardown) end the loop.
+    async_accept_local(impl_->acceptor, *sock, [this, sock](const std::error_code& ec) {
+        // An accept error or io_context::stop() (teardown) ends the loop.
         if (ec) {
             return;
         }

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -107,7 +107,16 @@ void SimulationServerSocket::serve(RequestHandler request_handler) {
 void SimulationServerSocket::do_accept() {
     auto sock = std::make_shared<stream_protocol::socket>(impl_->io);
     impl_->acceptor.async_accept(*sock, [this, sock](const std::error_code& ec) {
-        // A non-aborted error or io_context::stop() (teardown) ends the loop.
+#ifdef __APPLE__
+        // asio sets SO_NOSIGPIPE after accept(). Darwin returns EINVAL if a
+        // queued peer already disconnected (e.g. a liveness probe), and asio
+        // closes that accepted socket. Keep accepting subsequent clients.
+        if (ec == asio::error::invalid_argument) {
+            do_accept();
+            return;
+        }
+#endif
+        // Other errors or io_context::stop() (teardown) end the loop.
         if (ec) {
             return;
         }

--- a/device/simulation/simulation_server_transport.cpp
+++ b/device/simulation/simulation_server_transport.cpp
@@ -5,9 +5,12 @@
 #include "simulation/simulation_server_transport.hpp"
 
 #include <fmt/format.h>
+#include <sys/socket.h>
 
 #include <array>
 #include <asio.hpp>
+#include <cerrno>
+#include <cstring>
 #include <system_error>
 
 #include "umd/device/utils/error.hpp"
@@ -27,8 +30,8 @@ constexpr size_t FRAME_HEADER_SIZE = sizeof(uint32_t);
 constexpr uint32_t MAX_FRAME_PAYLOAD_SIZE = 1u << 30;  // 1 GiB
 
 // asio::write/asio::read transfer exactly n bytes or set ec (short transfer on a closed peer, etc.);
-// convert any failure to a RuntimeError. asio sets MSG_NOSIGNAL on the send, so a closed peer is an
-// error here, never a SIGPIPE.
+// convert any failure to a RuntimeError. Linux uses MSG_NOSIGNAL and send_framed
+// enables SO_NOSIGPIPE on Darwin, so a closed peer is an error here, never a SIGPIPE.
 void write_exact(stream_protocol::socket& socket, const uint8_t* data, size_t n, const char* what) {
     std::error_code ec;
     asio::write(socket, asio::buffer(data, n), ec);
@@ -64,6 +67,16 @@ void read_exact(stream_protocol::socket& socket, uint8_t* data, size_t n, const 
 }  // namespace
 
 void send_framed(stream_protocol::socket& socket, const std::vector<uint8_t>& payload) {
+#ifdef SO_NOSIGPIPE
+    // Darwin has no MSG_NOSIGNAL. This also covers sockets adopted from
+    // socketpair(), which do not pass through asio's socket-creation path.
+    const int no_sigpipe = 1;
+    if (setsockopt(socket.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Failed to disable SIGPIPE on simulator socket: {}", std::strerror(errno)));
+    }
+#endif
     // Bounded so the length always fits the uint32_t prefix and matches what recv_framed() will
     // accept; anything larger is a programming error rather than a truncation.
     UMD_ASSERT(

--- a/device/simulation/simulation_server_transport.hpp
+++ b/device/simulation/simulation_server_transport.hpp
@@ -19,8 +19,8 @@ namespace tt::umd {
 // UMD client and a simulation host.
 //
 // I/O goes through asio::read/asio::write on the connected socket: they transfer exactly the
-// requested byte count (or fail), and on Linux asio sets MSG_NOSIGNAL, so writing to a closed peer
-// surfaces as a thrown error rather than raising SIGPIPE. The socket must be in blocking mode (its
+// requested byte count (or fail). Linux uses MSG_NOSIGNAL and Darwin uses SO_NOSIGPIPE, so writing to
+// a closed peer surfaces as a thrown error rather than raising SIGPIPE. The socket must be in blocking mode (its
 // owner clears any non-blocking flag asio leaves after connect/accept). Payloads are opaque here;
 // encoding/decoding is the protocol layer's job.
 //

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -8,7 +8,9 @@
 #include <fcntl.h>
 #include <fmt/format.h>
 #include <sys/mman.h>
+#if defined(__linux__)
 #include <sys/sendfile.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -247,10 +249,15 @@ void TTSimCommunicator::initialize() {
 
     // Legacy path: per-chip memfd + dlopen.
     if (copy_sim_binary_) {
+#if defined(__linux__)
         create_simulator_binary();
         copy_simulator_binary();
         secure_simulator_binary();
         load_simulator_library(fmt::format("/proc/self/fd/{}", copied_simulator_fd_));
+#else
+        UMD_THROW(
+            error::RuntimeError, "Isolated simulator library copies require Linux memfd; use copy_sim_binary=false.");
+#endif
     } else {
         load_simulator_library(simulator_directory_.string());
     }
@@ -503,6 +510,7 @@ void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     pfn_libttsim_set_pci_dma_mem_callbacks_(pci_dma_mem_rd_bytes_wrapper, pci_dma_mem_wr_bytes_wrapper);
 }
 
+#if defined(__linux__)
 void TTSimCommunicator::create_simulator_binary() {
     const std::string filename = simulator_directory_.stem().string();
     const std::string extension = simulator_directory_.extension().string();
@@ -561,6 +569,8 @@ void TTSimCommunicator::secure_simulator_binary() {
         UMD_THROW(error::RuntimeError, fmt::format("Failed to seal memfd: {}", strerror(errno)));
     }
 }
+
+#endif
 
 void TTSimCommunicator::load_simulator_library(const std::filesystem::path &path) {
     libttsim_handle_ = dlopen(path.c_str(), RTLD_LAZY);

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -5,6 +5,7 @@
 #include "umd/device/soc_descriptor.hpp"
 
 #include <fmt/format.h>
+#include <unistd.h>
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>

--- a/device/utils/local_socket.hpp
+++ b/device/utils/local_socket.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <asio.hpp>
+#include <functional>
+#include <system_error>
+#include <utility>
+#ifdef __APPLE__
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#endif
+
+namespace tt::umd {
+
+// The acceptor and socket must outlive the completion handler, as with
+// asio::async_accept. Only one accept may be outstanding on this acceptor.
+inline void async_accept_local(
+    asio::local::stream_protocol::acceptor& acceptor,
+    asio::local::stream_protocol::socket& socket,
+    std::function<void(std::error_code)> handler) {
+#ifdef __APPLE__
+    // Asio discards accepted Darwin sockets if SO_NOSIGPIPE fails with EINVAL.
+    // A sender that already closed can still have unread data (reset
+    // notifications), so retain that socket and its queued bytes instead.
+    std::error_code ec;
+    acceptor.native_non_blocking(true, ec);
+    if (ec) {
+        asio::post(acceptor.get_executor(), [handler = std::move(handler), ec] { handler(ec); });
+        return;
+    }
+    acceptor.async_wait(
+        asio::socket_base::wait_read, [&acceptor, &socket, handler = std::move(handler)](std::error_code ec) mutable {
+            if (ec) {
+                handler(ec);
+                return;
+            }
+            int fd;
+            do {
+                fd = ::accept(acceptor.native_handle(), nullptr, nullptr);
+            } while (fd < 0 && errno == EINTR);
+            if (fd < 0) {
+                ec = {errno, asio::error::get_system_category()};
+                if (ec == asio::error::would_block || ec == asio::error::try_again ||
+                    ec == asio::error::connection_aborted) {
+                    async_accept_local(acceptor, socket, std::move(handler));
+                    return;
+                }
+                handler(ec);
+                return;
+            }
+            const int no_sigpipe = 1;
+            if (::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0 && errno != EINVAL) {
+                ec = {errno, asio::error::get_system_category()};
+            } else {
+                socket.assign(asio::local::stream_protocol{}, fd, ec);
+            }
+            if (ec) {
+                ::close(fd);
+            }
+            handler(ec);
+        });
+#else
+    acceptor.async_accept(socket, std::move(handler));
+#endif
+}
+
+}  // namespace tt::umd

--- a/device/utils/mmap.hpp
+++ b/device/utils/mmap.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sys/mman.h>
+
+namespace tt::umd {
+
+// Prefaulting is an optimization; platforms without MAP_POPULATE fault pages in
+// on demand. Keep Linux's existing allocation behavior.
+#ifdef MAP_POPULATE
+inline constexpr int mmap_populate = MAP_POPULATE;
+#else
+inline constexpr int mmap_populate = 0;
+#endif
+
+}  // namespace tt::umd

--- a/device/utils/robust_mutex_unsupported.cpp
+++ b/device/utils/robust_mutex_unsupported.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <utility>
+
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
+
+namespace tt::umd {
+
+// macOS has no process-shared robust pthread mutexes. Simulator locks are
+// process-local; hardware locks must fail rather than lose owner-death recovery.
+RobustMutex::RobustMutex(std::string_view name) : mutex_name_(name) {}
+
+RobustMutex::~RobustMutex() noexcept = default;
+
+RobustMutex::RobustMutex(RobustMutex&& other) noexcept : mutex_name_(std::move(other.mutex_name_)) {}
+
+RobustMutex& RobustMutex::operator=(RobustMutex&& other) noexcept {
+    mutex_name_ = std::move(other.mutex_name_);
+    return *this;
+}
+
+void RobustMutex::initialize() {
+    UMD_THROW(error::RuntimeError, "Process-shared robust device locks are unavailable on macOS; use the simulator.");
+}
+
+void RobustMutex::lock() { initialize(); }
+
+void RobustMutex::unlock() { initialize(); }
+
+std::optional<std::pair<pid_t, pid_t>> RobustMutex::probe_lock(std::chrono::seconds) {
+    initialize();
+    return std::nullopt;
+}
+
+}  // namespace tt::umd

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -43,6 +43,7 @@
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
+#include "utils/local_socket.hpp"
 
 namespace tt::umd {
 
@@ -605,8 +606,8 @@ bool WarmResetCommunication::Monitor::start_monitoring(
 
         do_accept = [&]() {
             auto sock = std::make_shared<asio::local::stream_protocol::socket>(*io);
-            acceptor.async_accept(
-                *sock, [sock, &do_accept, &on_cleanup_request, &post_cleanup_request](std::error_code ec) {
+            async_accept_local(
+                acceptor, *sock, [sock, &do_accept, &on_cleanup_request, &post_cleanup_request](std::error_code ec) {
                     if (ec || !keep_monitoring) {
                         return;
                     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,12 +12,14 @@ target_link_libraries(
         tt-logger::tt-logger
         $<$<BOOL:${TT_UMD_BUILD_SIMULATION}>:nng>
 )
-target_include_directories(
-    test_common
-    INTERFACE
-        ${PROJECT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
+target_include_directories(test_common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    # On case-insensitive filesystems, -I at the repo root makes VERSION shadow
+    # libc++'s <version>. Repository-relative test headers use quoted includes.
+    target_compile_options(test_common INTERFACE "SHELL:-iquote \"${PROJECT_SOURCE_DIR}\"")
+else()
+    target_include_directories(test_common INTERFACE ${PROJECT_SOURCE_DIR})
+endif()
 # tt-umd's INCLUDE_DIRECTORIES carries its private third-party deps (e.g. asio), which are
 # system includes on the library itself. Re-expose them as SYSTEM so clang-tidy keeps skipping
 # third-party headers; without SYSTEM the copy lands as plain -I and trips warnings-as-errors.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(test_common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # On case-insensitive filesystems, -I at the repo root makes VERSION shadow
     # libc++'s <version>. Repository-relative test headers use quoted includes.
-    target_compile_options(test_common INTERFACE "SHELL:-iquote \"${PROJECT_SOURCE_DIR}\"")
+    target_compile_options(test_common INTERFACE "-iquote${PROJECT_SOURCE_DIR}")
 else()
     target_include_directories(test_common INTERFACE ${PROJECT_SOURCE_DIR})
 endif()

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -17,19 +17,29 @@ set(API_TESTS_SRCS
     test_jtag.cpp
     test_arc_telemetry.cpp
     test_firmware_info_provider.cpp
-    test_warm_reset.cpp
     test_tt_visible_devices.cpp
 )
 
 if(TT_UMD_BUILD_SIMULATION)
+    list(APPEND API_TESTS_SRCS test_simulator_host.cpp)
     list(APPEND API_TESTS_SRCS test_ttsim_device_io.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_connector.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_server_protocol.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_device_identity.cpp)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list(APPEND API_TESTS_SRCS test_macos_platform.cpp)
+else()
+    # Physical-device reset tests use the Linux eventfd synchronization helper.
+    list(APPEND API_TESTS_SRCS test_warm_reset.cpp)
+endif()
+
 add_executable(api_tests ${API_TESTS_SRCS})
 target_link_libraries(api_tests PRIVATE test_common)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    target_link_libraries(api_tests PRIVATE tt-kmd-lib::tt-kmd-lib)
+endif()
 set_target_properties(
     api_tests
     PROPERTIES

--- a/tests/api/test_macos_platform.cpp
+++ b/tests/api/test_macos_platform.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <utility>
+
+#include "tt-kmd-lib/tt_kmd_lib.h"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/tt_sim_communicator.hpp"
+#endif
+
+namespace tt::umd {
+
+using RuntimeException = error::UmdException<error::RuntimeError>;
+
+TEST(MacOSPlatform, HardwareAccessIsUnsupported) {
+    tt_device_t* device = nullptr;
+    EXPECT_EQ(tt_device_open("/dev/tenstorrent/0", &device, 0), -ENOTSUP);
+    EXPECT_EQ(device, nullptr);
+
+    uint32_t value = 0x12345678;
+    EXPECT_EQ(tt_noc_read32(nullptr, 1, 2, 0x10000, &value), -ENOTSUP);
+    EXPECT_EQ(value, 0x12345678);
+}
+
+TEST(MacOSPlatform, RobustLocksCannotSilentlyBecomeProcessLocal) {
+    RobustMutex lock("macos-platform-test");
+    EXPECT_THROW(lock.initialize(), RuntimeException);
+    EXPECT_THROW(lock.lock(), RuntimeException);
+    EXPECT_THROW(lock.unlock(), RuntimeException);
+    EXPECT_THROW(lock.probe_lock(std::chrono::seconds(0)), RuntimeException);
+
+    RobustMutex moved(std::move(lock));
+    EXPECT_THROW(moved.initialize(), RuntimeException);
+    RobustMutex assigned("macos-platform-test-assigned");
+    assigned = std::move(moved);
+    EXPECT_THROW(assigned.initialize(), RuntimeException);
+}
+
+#ifdef TT_UMD_BUILD_SIMULATION
+TEST(MacOSPlatform, LegacyIsolatedSimulatorCopyReportsUnsupported) {
+    // No library is needed: the unsupported copy mode must be rejected before
+    // opening a source file or issuing Linux memfd operations.
+    TTSimCommunicator communicator("unused-simulator.so", true);
+    EXPECT_THAT(
+        [&] { communicator.initialize(); },
+        ::testing::ThrowsMessage<RuntimeException>(::testing::HasSubstr("require Linux memfd")));
+}
+#endif
+
+}  // namespace tt::umd

--- a/tests/api/test_macos_platform.cpp
+++ b/tests/api/test_macos_platform.cpp
@@ -22,9 +22,11 @@ namespace tt::umd {
 using RuntimeException = error::UmdException<error::RuntimeError>;
 
 TEST(MacOSPlatform, HardwareAccessIsUnsupported) {
-    tt_device_t* device = nullptr;
+    // A non-null sentinel catches stale output handles on failure.
+    tt_device_t* device = reinterpret_cast<tt_device_t*>(uintptr_t{1});
     EXPECT_EQ(tt_device_open("/dev/tenstorrent/0", &device, 0), -ENOTSUP);
     EXPECT_EQ(device, nullptr);
+    EXPECT_EQ(tt_device_open("/dev/tenstorrent/0", nullptr, 0), -ENOTSUP);
 
     uint32_t value = 0x12345678;
     EXPECT_EQ(tt_noc_read32(nullptr, 1, 2, 0x10000, &value), -ENOTSUP);

--- a/tests/api/test_simulator_host.cpp
+++ b/tests/api/test_simulator_host.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+namespace tt::umd {
+
+TEST(SimulatorHost, MappedTensixL1RoundTrip) {
+    const char* simulator = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator == nullptr) {
+        GTEST_SKIP() << "Set TT_UMD_SIMULATOR to a native libttsim library.";
+    }
+    auto device = TTSimTTDevice::create(simulator);
+    const auto& soc = device->get_soc_descriptor();
+    const auto cores = soc.get_cores(CoreType::TENSIX);
+    ASSERT_FALSE(cores.empty());
+    const auto core = soc.translate_coord_to(cores.front(), CoordSystem::TRANSLATED).to_pair();
+
+    std::array<uint32_t, 256> expected{};
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        expected[i] = 0x12340000u + static_cast<uint32_t>(i);
+    }
+    std::array<uint32_t, 256> actual{};
+    constexpr uint64_t address = 0x10000;
+    // Use the normal TLB path: direct tile_rd/tile_wr are not implemented for
+    // Wormhole and Blackhole in the public simulator.
+    device->write_to_device(expected.data(), core, address, sizeof(expected));
+    device->read_from_device(actual.data(), core, address, sizeof(actual));
+    EXPECT_EQ(actual, expected);
+}
+
+}  // namespace tt::umd

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -35,6 +35,7 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/kmd_versions.hpp"
+#include "utils/mmap.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -156,7 +157,7 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
 
     const uint32_t one_mb = 1 << 20;
     void* mapping =
-        mmap(nullptr, 2 * one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        mmap(nullptr, 2 * one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | mmap_populate, -1, 0);
     // It's important that this offset is not a multiple of the page size.
     const size_t unaligned_offset = 100;
     void* mapping_buffer = static_cast<uint8_t*>(mapping) + unaligned_offset;  // Offset by 1MB
@@ -218,7 +219,8 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
     const size_t buf_size = 10;
 
     // Size is not multiple of page size.
-    void* mapping = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    void* mapping =
+        mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | mmap_populate, -1, 0);
 
     void* mapped_buffer = static_cast<uint8_t*>(mapping) + buf_size;  // Offset by 10 bytes
 
@@ -340,7 +342,8 @@ TEST(ApiSysmemManager, SysmemBufferHostCopyUnaligned) {
     const size_t buf_offset = 10;  // Deliberately not page aligned.
     const size_t buf_size = 128;
 
-    void* mapping = mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    void* mapping =
+        mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | mmap_populate, -1, 0);
     ASSERT_NE(mapping, MAP_FAILED);
 
     void* mapped_buffer = static_cast<uint8_t*>(mapping) + buf_offset;

--- a/tests/baremetal/test_notification_mechanism.cpp
+++ b/tests/baremetal/test_notification_mechanism.cpp
@@ -20,6 +20,7 @@
 
 #include "device/api/umd/device/warm_reset.hpp"
 #include "test_utils/pipe_communication.hpp"
+#include "utils/local_socket.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -93,6 +94,33 @@ protected:
 };
 
 class WarmResetTimingTest : public WarmResetNotificationTest, public testing::WithParamInterface<int> {};
+
+TEST_F(WarmResetNotificationTest, AcceptsNotificationFromAlreadyClosedSender) {
+    std::filesystem::create_directories(WarmResetCommunication::LISTENER_DIR);
+    asio::io_context io;
+    const asio::local::stream_protocol::endpoint endpoint(
+        std::string(WarmResetCommunication::LISTENER_DIR) + "/queued.sock");
+    asio::local::stream_protocol::acceptor acceptor(io, endpoint);
+    asio::local::stream_protocol::socket sender(io);
+    sender.connect(endpoint);
+    const auto expected = WarmResetCommunication::POST_RESET;
+    asio::write(sender, asio::buffer(&expected, sizeof(expected)));
+    // Force the sender to close before accept, without relying on scheduling.
+    sender.close();
+
+    asio::local::stream_protocol::socket receiver(io);
+    bool completed = false;
+    async_accept_local(acceptor, receiver, [&](std::error_code ec) {
+        completed = true;
+        ASSERT_FALSE(ec) << ec.message();
+        WarmResetCommunication::MessageType actual{};
+        asio::read(receiver, asio::buffer(&actual, sizeof(actual)), ec);
+        ASSERT_FALSE(ec) << ec.message();
+        EXPECT_EQ(actual, expected);
+    });
+    io.run();
+    EXPECT_TRUE(completed);
+}
 
 INSTANTIATE_TEST_SUITE_P(
     TimeoutScenarios,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -79,6 +79,12 @@ endif()
 # Flatbuffers
 ###################################################################################################################
 if(TT_UMD_BUILD_SIMULATION)
+    # Strict mode also adds -fno-rtti. On Darwin the resulting private copies of
+    # standard exception typeinfo break typed catches when linked into tt-umd.
+    set(UMD_FLATBUFFERS_STRICT_MODE ON)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        set(UMD_FLATBUFFERS_STRICT_MODE OFF)
+    endif()
     CPMAddPackage(
         NAME flatbuffers
         GITHUB_REPOSITORY google/flatbuffers
@@ -89,7 +95,7 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_BUILD_FLATC ON"
             "FLATBUFFERS_BUILD_TESTS OFF"
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
-            "FLATBUFFERS_STRICT_MODE ON"
+            "FLATBUFFERS_STRICT_MODE ${UMD_FLATBUFFERS_STRICT_MODE}"
     )
 
     if(NOT TARGET flatbuffers::flatbuffers)

--- a/tt-kmd-lib/CMakeLists.txt
+++ b/tt-kmd-lib/CMakeLists.txt
@@ -14,7 +14,11 @@ endif()
 add_library(tt-kmd-lib STATIC)
 add_library(tt-kmd-lib::tt-kmd-lib ALIAS tt-kmd-lib)
 
-target_sources(tt-kmd-lib PRIVATE src/tt_kmd_lib.c)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    target_sources(tt-kmd-lib PRIVATE src/tt_kmd_lib_unsupported.c)
+else()
+    target_sources(tt-kmd-lib PRIVATE src/tt_kmd_lib.c)
+endif()
 
 target_include_directories(
     tt-kmd-lib

--- a/tt-kmd-lib/src/tt_kmd_lib_unsupported.c
+++ b/tt-kmd-lib/src/tt_kmd_lib_unsupported.c
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+
+#include "tt-kmd-lib/tt_kmd_lib.h"
+
+// The kernel driver is Linux-only. Keep the C API linkable for simulator builds
+// without exposing Linux ioctl definitions or pretending hardware I/O succeeded.
+
+int tt_device_open(const char* chardev_path, tt_device_t** out_dev, int extra_flags) {
+    (void)chardev_path;
+    (void)out_dev;
+    (void)extra_flags;
+    return -ENOTSUP;
+}
+
+int tt_device_close(tt_device_t* dev) {
+    (void)dev;
+    return -ENOTSUP;
+}
+
+int tt_device_get_attrs(tt_device_t* dev, tt_device_attrs_t* out_attrs) {
+    (void)dev;
+    (void)out_attrs;
+    return -ENOTSUP;
+}
+
+int tt_device_get_attr(tt_device_t* dev, enum tt_device_attr attr, uint64_t* out_value) {
+    (void)dev;
+    (void)attr;
+    (void)out_value;
+    return -ENOTSUP;
+}
+
+int tt_driver_get_attr(tt_device_t* dev, enum tt_driver_attr attr, uint64_t* out_value) {
+    (void)dev;
+    (void)attr;
+    (void)out_value;
+    return -ENOTSUP;
+}
+
+int tt_device_query_bar_mappings(tt_device_t* dev, tt_bar_mappings_t* out_mappings) {
+    (void)dev;
+    (void)out_mappings;
+    return -ENOTSUP;
+}
+
+int tt_noc_read32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t* value) {
+    (void)dev;
+    (void)x;
+    (void)y;
+    (void)addr;
+    (void)value;
+    return -ENOTSUP;
+}
+
+int tt_noc_write32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t value) {
+    (void)dev;
+    (void)x;
+    (void)y;
+    (void)addr;
+    (void)value;
+    return -ENOTSUP;
+}
+
+int tt_noc_read(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, void* dst, size_t len) {
+    (void)dev;
+    (void)x;
+    (void)y;
+    (void)addr;
+    (void)dst;
+    (void)len;
+    return -ENOTSUP;
+}
+
+int tt_noc_write(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, const void* src, size_t len) {
+    (void)dev;
+    (void)x;
+    (void)y;
+    (void)addr;
+    (void)src;
+    (void)len;
+    return -ENOTSUP;
+}
+
+int tt_pin_pages(tt_device_t* dev, void* addr, size_t len, int flags, uint64_t* out_dma_addr, uint64_t* out_noc_addr) {
+    (void)dev;
+    (void)addr;
+    (void)len;
+    (void)flags;
+    (void)out_dma_addr;
+    (void)out_noc_addr;
+    return -ENOTSUP;
+}
+
+int tt_unpin_pages(tt_device_t* dev, void* addr, size_t len) {
+    (void)dev;
+    (void)addr;
+    (void)len;
+    return -ENOTSUP;
+}
+
+int tt_dma_map(tt_device_t* dev, void* addr, size_t len, int flags, tt_dma_t** out_dma) {
+    (void)dev;
+    (void)addr;
+    (void)len;
+    (void)flags;
+    (void)out_dma;
+    return -ENOTSUP;
+}
+
+int tt_dma_unmap(tt_device_t* dev, tt_dma_t* dma) {
+    (void)dev;
+    (void)dma;
+    return -ENOTSUP;
+}
+
+int tt_dma_get_dma_addr(tt_dma_t* dma, uint64_t* out_dma_addr) {
+    (void)dma;
+    (void)out_dma_addr;
+    return -ENOTSUP;
+}
+
+int tt_dma_get_noc_addr(tt_dma_t* dma, uint64_t* out_noc_addr) {
+    (void)dma;
+    (void)out_noc_addr;
+    return -ENOTSUP;
+}
+
+int tt_allocate_dma_buf(
+    tt_device_t* dev,
+    uint8_t buf_index,
+    size_t size,
+    int flags,
+    void** out_mapping,
+    uint64_t* out_dma_addr,
+    uint64_t* out_noc_addr) {
+    (void)dev;
+    (void)buf_index;
+    (void)size;
+    (void)flags;
+    (void)out_mapping;
+    (void)out_dma_addr;
+    (void)out_noc_addr;
+    return -ENOTSUP;
+}
+
+int tt_tlb_alloc(tt_device_t* dev, size_t size, enum tt_tlb_cache_mode cache, tt_tlb_t** out_tlb) {
+    (void)dev;
+    (void)size;
+    (void)cache;
+    (void)out_tlb;
+    return -ENOTSUP;
+}
+
+int tt_tlb_free(tt_device_t* dev, tt_tlb_t* tlb) {
+    (void)dev;
+    (void)tlb;
+    return -ENOTSUP;
+}
+
+int tt_tlb_get_mmio(tt_tlb_t* tlb, void** out_mmio) {
+    (void)tlb;
+    (void)out_mmio;
+    return -ENOTSUP;
+}
+
+int tt_tlb_get_id(tt_tlb_t* tlb, uint32_t* out_id) {
+    (void)tlb;
+    (void)out_id;
+    return -ENOTSUP;
+}
+
+int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config) {
+    (void)dev;
+    (void)tlb;
+    (void)config;
+    return -ENOTSUP;
+}
+
+int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr) {
+    (void)dev;
+    (void)tlb;
+    (void)x;
+    (void)y;
+    (void)addr;
+    return -ENOTSUP;
+}
+
+int tt_tlb_export_dmabuf(tt_device_t* dev, tt_tlb_t* tlb, uint64_t offset, uint64_t size, int* out_fd) {
+    (void)dev;
+    (void)tlb;
+    (void)offset;
+    (void)size;
+    (void)out_fd;
+    return -ENOTSUP;
+}
+
+int tt_device_set_power_state(tt_device_t* dev, uint16_t power_flags) {
+    (void)dev;
+    (void)power_flags;
+    return -ENOTSUP;
+}
+
+int tt_device_reset(tt_device_t* dev, uint32_t reset_flags) {
+    (void)dev;
+    (void)reset_flags;
+    return -ENOTSUP;
+}
+
+int tt_lock_acquire(tt_device_t* dev, uint8_t index, int* out_acquired) {
+    (void)dev;
+    (void)index;
+    (void)out_acquired;
+    return -ENOTSUP;
+}
+
+int tt_lock_release(tt_device_t* dev, uint8_t index, int* out_was_held) {
+    (void)dev;
+    (void)index;
+    (void)out_was_held;
+    return -ENOTSUP;
+}
+
+int tt_lock_test(tt_device_t* dev, uint8_t index, uint32_t* out_state) {
+    (void)dev;
+    (void)index;
+    (void)out_state;
+    return -ENOTSUP;
+}

--- a/tt-kmd-lib/src/tt_kmd_lib_unsupported.c
+++ b/tt-kmd-lib/src/tt_kmd_lib_unsupported.c
@@ -11,8 +11,10 @@
 
 int tt_device_open(const char* chardev_path, tt_device_t** out_dev, int extra_flags) {
     (void)chardev_path;
-    (void)out_dev;
     (void)extra_flags;
+    if (out_dev != NULL) {
+        *out_dev = NULL;
+    }
     return -ENOTSUP;
 }
 


### PR DESCRIPTION
### Issue

Related: https://github.com/tenstorrent/skills/pull/9

The native Apple Silicon Metalium recipe currently carries a UMD portability patch. This moves the UMD support into the current upstream source so consumers can eventually use a published revision directly.

### Description

Enable native macOS simulator builds with Apple Clang and a native public `ttsim` library. A Linux ARM64 build cannot run on macOS: the host library and simulator must be Mach-O binaries.

The supported path loads a simulator directly with `copy_sim_binary=false` (or uses the existing shared-library multichip ABI). Hardware entry points explicitly report unsupported operations. No kernel driver or physical-device support is implied.

### List of the changes

- Select a Darwin `tt-kmd-lib` implementation returning `-ENOTSUP`, and reject process-shared robust hardware locks. Leave Linux driver headers and implementation intact.
- Keep Linux huge-page, prefault, and memfd operations behind platform guards; use ordinary anonymous mappings on Darwin. Reject legacy isolated memfd simulator copies explicitly.
- Resolve Homebrew hwloc headers/libraries, link `rt` only on Linux, invoke the built `flatc` target, and avoid the repository's `VERSION` file shadowing libc++ `<version>` on case-insensitive filesystems.
- Keep RTTI enabled in FlatBuffers on Darwin. Its strict mode adds `-fno-rtti`, which introduced private standard-exception typeinfo into the UMD dylib and broke typed exception catches in the existing coordinate and socket tests.
- Suppress SIGPIPE for adopted Darwin sockets and preserve queued notifications from already-closed senders. A private local-socket accept helper retains those sockets when Darwin rejects `SO_NOSIGPIPE` with `EINVAL`; this prevents dropped reset notifications and stopped simulator accept loops. Linux retains Asio’s existing accept path.
- Add platform-boundary tests, a native simulator mapped Tensix L1 round-trip, an Apple Silicon CI workflow using a pinned public simulator, and reproducible README commands.

### Testing

On Apple Silicon, macOS 26.6.2, Apple Clang 21.0.0, Release, with warnings treated as errors:

- Built `tt-umd`, `api_tests`, and `baremetal_tests` with simulation enabled.
- Confirmed both UMD and the public Blackhole simulator are native Mach-O arm64 libraries. Public simulator revision: `89bdc5eb726c4f1ebbe597e03b1b9cdf7622c779`.
- All **256 baremetal tests passed** without a card.
- Simulator/platform/sysmem filter: **39 passed, 1 skipped**. The existing RSS-release test skips because `/proc/self/status` is unavailable on macOS. The native mapped L1 write/read test passed.
- All **23 socket regression tests passed 20 consecutive runs**, including a deterministic test that closes a notification sender before accept. The previously hanging deferred-serve case passes too.
- With simulation disabled, the same native targets build; **243 baremetal tests and both platform tests passed**.
- All applicable repository pre-commit hooks passed.

The [clean Apple Silicon CI run passed](https://github.com/tenstorrent/tt-umd/actions/runs/34324010001) on commit `f4572c2`, including the native UMD/public simulator build and both test groups. The broader Linux and physical-device CI matrix is still running. The [6u tooling job](https://github.com/tenstorrent/tt-umd/actions/runs/34324010734/job/102378219934) failed during device detection: PCIe ID 16 returned `0xffffffff`, and UMD reported that the board needs a reset. This is a hardware-runner failure to resolve before merging.

### API Changes

No public API signature changes. macOS hardware calls return `-ENOTSUP`; unsupported robust-lock and legacy memfd-copy paths throw explicit errors.

The skill's patch remains necessary for its older pinned Metalium/UMD pair until this support is merged and adopted by a compatible Metalium revision.
