### PR TITLE
Simulation: reset chip by chip instead of broadcasting the soft-reset register

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -836,9 +836,10 @@ void Cluster::assert_risc_reset() {
         return;
     }
 
-    // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
-    // loop all chips and issues the reset separately.
-    if (arch_name == tt::ARCH::QUASAR) {
+    // Quasar has no broadcast support, and a simulation chip cannot service the raw
+    // soft-reset register write the broadcast performs. Both reset chip by chip, which
+    // goes through the reset path each chip implements for itself.
+    if (arch_name == tt::ARCH::QUASAR || options_.chip_type == ChipType::SIMULATION) {
         for (const auto& chip : all_chip_ids_) {
             get_chip(chip)->assert_risc_reset(RiscType::ALL);
         }
@@ -857,9 +858,10 @@ void Cluster::deassert_risc_reset() {
         return;
     }
 
-    // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
-    // loop all chips and issues the reset separately.
-    if (arch_name == tt::ARCH::QUASAR) {
+    // Quasar has no broadcast support, and a simulation chip cannot service the raw
+    // soft-reset register write the broadcast performs. Both reset chip by chip, which
+    // goes through the reset path each chip implements for itself.
+    if (arch_name == tt::ARCH::QUASAR || options_.chip_type == ChipType::SIMULATION) {
         for (const auto& chip : all_chip_ids_) {
             get_chip(chip)->deassert_risc_reset(RiscType::ALL, false);
         }
@@ -1249,7 +1251,7 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
     broadcast_write_to_cluster(
         &reg_value,
         sizeof(uint32_t),
-        0xFFB121B0,
+        ArchitectureImplementation::create(arch_name)->get_tensix_soft_reset_addr(),
         chips_to_exclude,
         rows_to_exclude,
         columns_to_exclude,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd-internal/issues/33

### Description
Cluster::assert_risc_reset() and deassert_risc_reset() end in a broadcast write to
the tensix soft-reset register. SimulationChip::write_to_device_reg forwards to
write_to_device, so on a simulation chip that leaves as an ordinary NOC write, and
the RTL simulators only back L1. Versim rejects it with "Attempt to backdoor write
l1 past l1 size: addr = 0xffb121b0" and the reset does not happen. Cluster-wide
reset on a wormhole or blackhole simulator is therefore a silent no-op; it looks
fine only because callers also use the per-core API, which does reach the
ALL_TENSIX_RESET_* command.

The other two non-silicon cases were already handled a few lines above: SWEMULE
returns early for exactly this reason, and quasar loops chip by chip. Simulation
fell between them.

Separately, the broadcast hardcoded 0xFFB121B0 instead of asking the architecture.
That value is right for wormhole and blackhole but wrong for grendel (0x030179B0),
and grendel is not excluded by either caller.

### List of the changes
- Route ChipType::SIMULATION through the per-chip reset path, alongside quasar.
- Take the broadcast address from ArchitectureImplementation::get_tensix_soft_reset_addr().

### Testing
Built with -DTT_UMD_BUILD_ALL=ON. api_tests ApiClusterTest.OpenAllSiliconChips and
*TestDeviceIOFixture.SimpleIOAllTargets/TENSIX pass against the versim wormhole-b0
simulator, unchanged before and after.

Neither covers this path: nothing in the UMD test suite calls the cluster-wide
assert_risc_reset(), so the fix is not exercised by CI. The rejected write is
visible in versim logs from tt-metal runs, where tt_cluster.cpp calls it during
device init; confirming the fix end to end needs a tt-metal build against this UMD.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
