### PR TITLE
[Agents] Add AGENTS.md and the CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+## General strict guidance - most attention
+- All activities that go out of the machine, such as PRs, commits addressing comments, proposed PR comments, issue creation and modification, have to be reviewed by the user. Leave drafts as text files in git unstaged index and give the control back to the user. 
+- Ask, don't assume. If something is unclear, ask before writing a single line. Never make silent assumptions about intent, architecture, or requirements. When running unattended, pick the most reasonable interpretation, proceed, and record the assumption rather than blocking.
+- Don't touch unrelated code but please do surface bad code or design smells you discover with the user so we can address them as a separate issue.
+- User is always open to ideas on better ways to do things. Please don't hesitate to suggest a better way, or one that has long lasting impact over a tactical change.
+- Where this file disagrees with personal or global agent instructions, this file wins for work in this repository.
+
+## Design
+
+## Development workflow
+
+## PR split
+
+## PR description
+
+## Commenting
+
+## Writing tests
+
+## Reviewing PRs workflow
+
+## External knowledge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Checks in the repo level agent instructions that have so far only lived in my local setup, so
every agent working in this repo picks up the same rules.

`AGENTS.md` is the single source of truth and `CLAUDE.md` is a symlink to it, so Claude Code and
any AGENTS.md aware agent read the same file without a second copy to keep in sync.

This PR lands the wiring and the first section only. The remaining section bodies follow one per
PR in this stack, so each set of rules can be reviewed on its own.

### List of the changes
- Add `AGENTS.md` with the "General strict guidance" section and empty headers for the sections
  the rest of the stack fills in.
- Add `CLAUDE.md` as a symlink to `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
