### PR TITLE
[Agents] AGENTS.md: fill in the PR description section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@
 - If, when working on a PR change, there is some or several minor cleanup/rename to do in the same context, try to separate those in a different PR which would land right before or right after the current PR.
 
 ## PR description
+- PR Description should follow PR template defined in this repo.
+- Keep the description very brief and up to the point. For smaller PRs they can be one sentence. For larger ones keep them up to 15 lines.
+- In both description and list of changes, avoid mentioning many items (files or function names) if there's more than 3 or 4 to be named, rather use a description for that whole category.
+- If you need to explain the current state of code, those comments have no place in PR description, those should be commented directly in source files.
 
 ## Commenting
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Fills in the `## PR description` section: follow the repo template, stay brief, and summarise a
category of changes rather than enumerating every file and function touched.

Also draws the line between a PR description and a code comment. Anything explaining the current
state of the code belongs in the source, not in the description, where nobody reading the code
later will find it.

### List of the changes
- Add the PR description rules under the existing header in `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
