### PR TITLE
[Agents] AGENTS.md: fill in the Commenting section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,13 @@
 - If you need to explain the current state of code, those comments have no place in PR description, those should be commented directly in source files.
 
 ## Commenting
+- Comments are generally a good thing in code, try to comment on code if it leads to faster readability. Comment all non-trivial code concisely.
+- Comments follow same rule as code. You should not overkill with comments. Try to write concise comments providing a lot of info.
+- Code comments should explain the underlying reasoning or intent ("why"). Comments should not restate the implementation mechanics ("what" or "how"), code should be readable enough to do that.
+- Never write comments referencing past code states (e.g., "no longer uses X"). Historical changes belong in PR descriptions. Focus here is on explaining the current state of code the best way.
+- Add logs where it makes sense for tracking execution flow. log_info should be used for only if useful for an external user. log_warning should warn about unexpected states, but only if actionable. If you think log would be useful but is not useful for external user or not actionable, then add it as log_debug. If a log would be hit many times during execution such that it bogs down the console output, then use log_trace.
+- Interface headers must explain contract and purpose only. Never leak internal implementation details into header comments. It is fine to comment on guarantees that implementation provides or assumes.
+- Don't write same comments on multiple different items.
 
 ## Writing tests
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Fills in the `## Commenting` section: comment the why rather than the what, keep headers to contract
and purpose with no implementation detail leaking through, and never write comments that describe
what the code used to do.

Includes the log level convention, since picking a level is the same judgement call as deciding
whether a comment is worth writing: `log_info` only if an external user benefits, `log_warning` only
if actionable, `log_debug` otherwise, `log_trace` when it would flood the console.

### List of the changes
- Add the Commenting rules and the log level convention under the existing header in `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
