### PR TITLE
[Agents] AGENTS.md: fill in the Writing tests section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@
 - Don't write same comments on multiple different items.
 
 ## Writing tests
+- Tests follow same rule as code. Don't overkill with tests. Try to write concise tests which test the essence of components.
+- Tests are not there to fix the implementation details. Tests should not reimplement internal implementation details.
+- Tests are there to fix the API and its expected behavior. Tests should often look like good usage examples.
+- Do not use dynamic logic or programmatic calculations to compute expected test outcomes. Hardcode all assertion values as literal constants. 
 
 ## Reviewing PRs workflow
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Fills in the `## Writing tests` section: tests pin down the API and its expected behaviour, not the
internals, and they should read like good usage examples.

The one hard rule is that expected values are hardcoded literals. A test that recomputes its own
expectation passes whenever the implementation and the test drift together, which is exactly when
it should fail.

### List of the changes
- Add the Writing tests rules under the existing header in `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
