### PR TITLE
[Agents] AGENTS.md: fill in the Reviewing PRs workflow section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,5 +53,7 @@
 - Do not use dynamic logic or programmatic calculations to compute expected test outcomes. Hardcode all assertion values as literal constants. 
 
 ## Reviewing PRs workflow
+- If a PR stack is being reviewed, you can take a brief look at whole stack, but process PRs one by one. Provide comments that you think are relevant for one of the PRs, argue and discuss with the user, and upon confirming post the comments for that single PR.
+- Any suggested comments should be presented through a git unstaged text file for user to review.
 
 ## External knowledge


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Fills in the `## Reviewing PRs workflow` section: skim a stack for context but review it one PR at a
time, and route suggested comments through an unstaged text file so they are approved before they
land on someone else's PR.

### List of the changes
- Add the Reviewing PRs workflow rules under the existing header in `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
