### PR TITLE
[Agents] AGENTS.md: fill in the External knowledge section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,9 @@
 - Any suggested comments should be presented through a git unstaged text file for user to review.
 
 ## External knowledge
+Use the parent of this repo as the work folder where you can git clone relevant repositories, or look at already cloned ones.
+In the same local folder, there should be TT_SUMMARY.md which you can load and use to point you to the right repository when you're looking for some code.
+If that file doesn't exist, generate it before proceeding. Scan local repos in work folder, analyze them briefly and produce the summary.
+The resulting TT_SUMMARY.md should have very brief descriptions of what code it holds, so the agent debugging something can figure out where to look for relevant code.
+
+Glean MCP can offer access to internal company resources, including documents, private repos, internal tools, and already reported issues and bugs. Use it when it helps your investigation. If this MCP connection is not setup and you would use it as part of current query if it was available, alert the user what they're missing out on.


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/3294

### Description
Fills in the last empty section, `## External knowledge`: treat the parent of this repo as the work
folder holding the neighbouring Tenstorrent repos, and use the `TT_SUMMARY.md` index there to find
which one holds the code in question instead of searching blind.

Also points at Glean for internal docs and already reported issues, with the instruction to say so
when that connection is missing rather than silently investigating with less context.

This completes the stack started in #3423, so `AGENTS.md` now has no empty headers left.

### List of the changes
- Add the External knowledge rules under the existing header in `AGENTS.md`.

### Testing
N/A, documentation only.

### API Changes
This PR has no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/agents_9
